### PR TITLE
EPMRPP-31255. Now clicking on failed statistics (launches grid and launch table widget) show interrupted and failed selection of items.

### DIFF
--- a/src/main/resources/public/js/src/launches/common/LaunchSuiteItemView.js
+++ b/src/main/resources/public/js/src/launches/common/LaunchSuiteItemView.js
@@ -163,7 +163,7 @@ define(function (require) {
                 deps: ['url', 'has_childs'],
                 get: function (url, hasChilds) {
                     if (hasChilds) {
-                        return this.allCasesUrl('failed');
+                        return this.allCasesUrl('failedPlusInterrupted');
                     }
                     return undefined;
                 }
@@ -193,6 +193,9 @@ define(function (require) {
             switch (type) {
             case 'total':
                 statusFilter = '&filter.in.status=PASSED,FAILED,SKIPPED,INTERRUPTED&filter.in.type=STEP';
+                break;
+            case 'failedPlusInterrupted':
+                statusFilter = '&filter.in.status=FAILED,INTERRUPTED&filter.in.type=STEP';
                 break;
             case 'passed':
             case 'failed':

--- a/src/main/resources/public/js/src/newWidgets/widgets/launchesTable/LaunchesTableView.js
+++ b/src/main/resources/public/js/src/newWidgets/widgets/launchesTable/LaunchesTableView.js
@@ -116,6 +116,9 @@ define(function (require) {
             case 'total':
                 statusFilter = '&filter.in.status=PASSED,FAILED,SKIPPED,INTERRUPTED&filter.in.type=STEP';
                 break;
+            case 'failedPlusInterrupted':
+                statusFilter = '&filter.in.status=FAILED,INTERRUPTED&filter.in.type=STEP';
+                break;
             case 'passed':
             case 'failed':
             case 'skipped':

--- a/src/main/resources/public/templates/widgets/tpl-widget-filters-table-item.html
+++ b/src/main/resources/public/templates/widgets/tpl-widget-filters-table-item.html
@@ -115,7 +115,7 @@
                 <div class="filter-tb-td">
                     <% if(failed && failed !== '0'){ %>
                     <a class="cases-view rp-blue-link-undrl"
-                       href="<%= data.allCasesUrl('failed') %>"><%= failed %></a>
+                       href="<%= data.allCasesUrl('failedPlusInterrupted') %>"><%= failed %></a>
                     <p class="visible-xs cell-name"><%= data.text.launchesHeaders.failed%></p>
                     <% } else { %>
                     <span class="text-muted visible-xs-inline">0</span>


### PR DESCRIPTION
launch table widget) show interrupted and failed selection of items.