### PR TITLE
EPMRPP-31901. Fixed redirection after creating a new project.

### DIFF
--- a/src/main/resources/public/js/src/modals/modalAddProject.js
+++ b/src/main/resources/public/js/src/modals/modalAddProject.js
@@ -108,8 +108,8 @@ define(function (require) {
                 .done(function () {
                     config.userModel.get('projects')[name] = { projectRole: 'MEMBER', entryType: 'INTERNAL' };
                     Util.ajaxSuccessMessenger('projectCreated', name);
-                    config.router.navigate(self.getProjectUrl(name, 'settings'), { trigger: true });
                     self.successClose();
+                    config.router.navigate(self.getProjectUrl(name, 'settings'), { trigger: true });
                 })
                 .fail(function (error) {
                     self.hideLoading();


### PR DESCRIPTION
Because of backbone extension in updateBackbone.js file, now we need first of all close modals before routing. Otherwise routing will be skipped. (See Backbone.Router.prototype.route in updateBackbone.js)