### PR TITLE
Improve email validation to handle domains with more than one dot.

### DIFF
--- a/src/main/resources/public/js/src/core/app-config.js
+++ b/src/main/resources/public/js/src/core/app-config.js
@@ -161,7 +161,7 @@ define(function (require) {
             },
 
             patterns: {
-                email: /^[a-z0-9._-]+@[a-z0-9_-]+?\.[a-z0-9]{2,}$/i,
+                email: /^[a-z0-9._%+-]+@([a-z0-9_-]+\.)+[a-z0-9]{2,}$/i,
                 emailInternal: '^((?!(@epam.com)).)*$',
                 emailWrong: /wrong email/i,
                 login: /^[0-9a-zA-Z-_.]{1,128}$/,


### PR DESCRIPTION
This is really simple change. Rather silly limitation.

See also reportportal/service-ui#815