### PR TITLE
EPMRPP-35176 This a fix for hardcoded 7s in duration field.

### DIFF
--- a/app/src/pages/inside/common/infoLine/infoLine.jsx
+++ b/app/src/pages/inside/common/infoLine/infoLine.jsx
@@ -6,6 +6,7 @@ import styles from './infoLine.scss';
 import { BarChart } from './barChart';
 import { Duration } from './duration';
 import { DefectTypeBlock } from './defectTypeBlock';
+import { getDuration } from '../../../../common/utils/timeDateUtils';
 
 const cx = classNames.bind(styles);
 const messages = defineMessages({
@@ -35,7 +36,7 @@ export class InfoLine extends Component {
     const skipped = executions.skipped / executions.total * 100;
     const endTime = this.props.data.end_time;
     const startTime = this.props.data.start_time;
-    const duration = (endTime - startTime) / 1000;
+    const duration = getDuration(startTime, endTime);
     return (
       <div className={cx('info-line')}>
         <div className={cx('bar-chart-holder')}>
@@ -50,8 +51,7 @@ export class InfoLine extends Component {
         <div className={cx('duration')}>
           <FormattedMessage id="InfoLine.duration" defaultMessage="Duration" />
           <div className={cx('duration-value')}>
-            {/* TODO change on duration calculation */}
-            <Duration duration={`${duration}s`} />
+            <Duration duration={duration} />
           </div>
         </div>
         <div className={cx('defect-types')}>

--- a/app/src/pages/inside/common/infoLine/infoLine.jsx
+++ b/app/src/pages/inside/common/infoLine/infoLine.jsx
@@ -33,6 +33,9 @@ export class InfoLine extends Component {
     const passed = executions.passed / executions.total * 100;
     const failed = executions.failed / executions.total * 100;
     const skipped = executions.skipped / executions.total * 100;
+    const endTime = this.props.data.end_time;
+    const startTime = this.props.data.start_time;
+    const duration = (endTime - startTime) / 1000;
     return (
       <div className={cx('info-line')}>
         <div className={cx('bar-chart-holder')}>
@@ -48,7 +51,7 @@ export class InfoLine extends Component {
           <FormattedMessage id="InfoLine.duration" defaultMessage="Duration" />
           <div className={cx('duration-value')}>
             {/* TODO change on duration calculation */}
-            <Duration duration={'7s'} />
+            <Duration duration={`${duration}s`} />
           </div>
         </div>
         <div className={cx('defect-types')}>

--- a/app/src/pages/inside/common/infoLine/infoLine.jsx
+++ b/app/src/pages/inside/common/infoLine/infoLine.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { getDuration } from 'common/utils/timeDateUtils';
 import { injectIntl, intlShape, defineMessages, FormattedMessage } from 'react-intl';
 import styles from './infoLine.scss';
 import { BarChart } from './barChart';
 import { Duration } from './duration';
 import { DefectTypeBlock } from './defectTypeBlock';
-import { getDuration } from '../../../../common/utils/timeDateUtils';
 
 const cx = classNames.bind(styles);
 const messages = defineMessages({


### PR DESCRIPTION
This a fix for hardcoded 7s in duration field.
Maybe it would be handy to solve a default case if props has no/undefined for start_time/end_time. Any suggestion is welcomed.

https://jiraeu.epam.com/browse/EPMRPP-35176

