### PR TITLE
EPMRPP-35247: React: Long filter name is overlapped the delete icon mobile view

### DIFF
--- a/app/src/pages/inside/filtersPage/filterGrid/filterGrid.scss
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterGrid.scss
@@ -9,7 +9,7 @@
     }
   }
   @media (max-width: $SCREEN_XS_MAX) {
-    width: 100%;
+    width: calc(100% - 40px);
     padding: 25px 15px 15px 15px;
   }
 }


### PR DESCRIPTION
![localhost_3000_](https://user-images.githubusercontent.com/18571747/49737229-9928a980-fc8c-11e8-875c-073d288cbfcf.png)
