### PR TITLE
EPMRPP-37586 OX axis visibility fix in launchesDuration chart

### DIFF
--- a/app/src/components/widgets/charts/launchesDurationChart/launchesDurationChart.scss
+++ b/app/src/components/widgets/charts/launchesDurationChart/launchesDurationChart.scss
@@ -7,7 +7,7 @@
         .c3-axis-y-label {
           font-size: 12px;
         }
-        path {
+        &.c3-axis-y path.domain {
           display: inline;
           stroke: $COLOR--gray-80;
         }

--- a/app/src/components/widgets/charts/launchesDurationChart/launchesDurationChart.scss
+++ b/app/src/components/widgets/charts/launchesDurationChart/launchesDurationChart.scss
@@ -7,6 +7,10 @@
         .c3-axis-y-label {
           font-size: 12px;
         }
+        path {
+          display: inline;
+          stroke: $COLOR--gray-80;
+        }
       }
     }
 


### PR DESCRIPTION
EPMRPP-37586 -  React: No OX axis is shown on the widget

![ox](https://user-images.githubusercontent.com/45286789/51115732-66348100-1809-11e9-8e59-5ddcf3537ada.png)
