### PR TITLE
EPMRPP-34192: add redirect to launches page when click on filter name

### DIFF
--- a/app/src/pages/inside/filtersPage/filterGrid/filterGrid.jsx
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterGrid.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames/bind';
 import { injectIntl, intlShape, defineMessages, FormattedMessage } from 'react-intl';
 import { ALIGN_CENTER, Grid } from 'components/main/grid';
 import { FILTERS_PAGE_EVENTS } from 'components/main/analytics/events';
+import { PROJECT_LAUNCHES_PAGE } from 'controllers/pages';
 import { canDeleteFilter } from 'common/utils/permissions';
 import { FilterName } from './filterName';
 import { FilterOptions } from './filterOptions';
@@ -31,6 +32,11 @@ const NameColumn = ({ className, value, customProps }) => (
       onClickName={customProps.onClickName}
       onEdit={customProps.onEdit}
       userId={customProps.userId}
+      nameLink={{
+        type: PROJECT_LAUNCHES_PAGE,
+        payload: { projectId: customProps.activeProject, filterId: value.id },
+      }}
+      isLink
       noShareIcons
     />
   </div>
@@ -150,6 +156,7 @@ export class FilterGrid extends Component {
       trackEvent: PropTypes.func,
       getTrackingData: PropTypes.func,
     }).isRequired,
+    activeProject: PropTypes.string,
   };
 
   static defaultProps = {
@@ -163,6 +170,7 @@ export class FilterGrid extends Component {
     onDelete: () => {},
     accountRole: '',
     loading: false,
+    activeProject: null,
   };
 
   getColumns = () => [
@@ -174,12 +182,18 @@ export class FilterGrid extends Component {
       component: NameColumn,
       customProps: {
         userFilters: this.props.userFilters,
-        onClickName: () => {}, // TODO
+        onClickName: (filter) => {
+          const isActiveFilter = this.props.userFilters.find((item) => item.id === filter.id);
+          if (!isActiveFilter) {
+            this.props.showFilterOnLaunchesAction(filter);
+          }
+        },
         onEdit: (filter) => {
           this.props.onEdit(filter);
           this.props.tracking.trackEvent(FILTERS_PAGE_EVENTS.CLICK_EDIT_ICON);
         },
         userId: this.props.userId,
+        activeProject: this.props.activeProject,
       },
     },
     {

--- a/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.jsx
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.jsx
@@ -3,6 +3,7 @@ import { injectIntl, defineMessages, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Parser from 'html-react-parser';
+import Link from 'redux-first-router-link';
 
 import ShareIcon from 'common/img/share-icon-inline.svg';
 import PencilIcon from 'common/img/pencil-icon-inline.svg';
@@ -32,7 +33,9 @@ export class FilterName extends Component {
     showDesc: PropTypes.bool,
     editable: PropTypes.bool,
     isBold: PropTypes.bool,
+    isLink: PropTypes.bool,
     noShareIcons: PropTypes.bool,
+    nameLink: PropTypes.object,
   };
 
   static defaultProps = {
@@ -46,7 +49,9 @@ export class FilterName extends Component {
     showDesc: true,
     editable: true,
     isBold: false,
+    isLink: false,
     noShareIcons: false,
+    nameLink: null,
   };
 
   getHighlightName = () => {
@@ -78,21 +83,35 @@ export class FilterName extends Component {
       showDesc,
       editable,
       isBold,
+      isLink,
       noShareIcons,
+      nameLink,
     } = this.props;
+
+    const NameLink = ({ link, children }) =>
+      link ? (
+        <Link className={cx('name-link')} to={link}>
+          {children}
+        </Link>
+      ) : (
+        children
+      );
 
     return (
       <Fragment>
         <span className={cx('name-wrapper')}>
-          <span
-            className={cx('name', {
-              bold: isBold,
-              link: userFilters.find((item) => item.id === filter.id),
-            })}
-            onClick={onClickName}
-          >
-            {Parser(this.getHighlightName(filter.name))}
-          </span>
+          <NameLink link={nameLink}>
+            <span
+              className={cx('name', {
+                bold: isBold,
+                link: isLink || userFilters.find((item) => item.id === filter.id),
+              })}
+              onClick={() => onClickName(filter)}
+            >
+              {Parser(this.getHighlightName(filter.name))}
+            </span>
+          </NameLink>
+
           {filter.share &&
             !noShareIcons && (
               <span className={cx('share-icon')} title={intl.formatMessage(messages.shareFilter)}>

--- a/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.scss
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.scss
@@ -60,3 +60,7 @@
   vertical-align: top;
   fill: $COLOR--gray-60;
 }
+
+.name-link {
+  text-decoration: none;
+}

--- a/app/src/pages/inside/filtersPage/filtersPage.jsx
+++ b/app/src/pages/inside/filtersPage/filtersPage.jsx
@@ -181,6 +181,7 @@ export class FiltersPage extends Component {
       onChangePageSize,
       filters,
       loading,
+      activeProject,
       ...rest
     } = this.props;
     return (
@@ -198,6 +199,7 @@ export class FiltersPage extends Component {
             onDelete={this.confirmDelete}
             filters={filters}
             loading={loading}
+            activeProject={activeProject}
             {...rest}
           />
           {!filters.length && !loading && !this.props.filter && <NoFiltersBlock />}


### PR DESCRIPTION
Solution:
1. Add `NavLink` to redirect to Launches page when the user click on the filter name
2. Call `showFilterOnLaunchesAction` when the user click on the filter name to display filter on Launches page in case DISPLAY ON LAUNCHES was set to `off`
