### PR TITLE
EPMRPP-38393: Fix incorrect launch filter query

### DIFF
--- a/app/src/pages/inside/common/launchFiltersContainer/launchFiltersContainer.jsx
+++ b/app/src/pages/inside/common/launchFiltersContainer/launchFiltersContainer.jsx
@@ -93,7 +93,7 @@ export class LaunchFiltersContainer extends Component {
     const currentFilter = this.createFilterQuery(this.getConditions());
 
     if (!isEqual(currentFilter, newFilter)) {
-      this.fetchLaunches({ [PAGE_KEY]: 1, newFilter });
+      this.fetchLaunches({ [PAGE_KEY]: 1, ...newFilter });
     }
 
     const conditionsWithFilteringField = addFilteringFieldToConditions(conditions);


### PR DESCRIPTION
Case:
1. Open launches page
2. Click "Add filter"
3. Change "name" field
4. Check request

**Expected result**
Request contains: `filter.cnt.name=demo`

**Actial result**
Request contains: `newFilter={"filter.cnt.name":"demo"}`