### PR TITLE
Fix namespaced query parameters update

### DIFF
--- a/app/src/common/utils/routingUtils.js
+++ b/app/src/common/utils/routingUtils.js
@@ -1,4 +1,5 @@
 import { parse, stringify } from 'qs';
+import { isEmptyValue } from './isEmptyValue';
 
 const LEVEL_PARAMS_SUFFIX = 'Params';
 
@@ -23,3 +24,11 @@ export const copyQuery = (query = {}, namespacesToCopy = []) =>
     }
     return acc;
   }, {});
+
+export const mergeQuery = (oldQuery, paramsToMerge) => {
+  const newQuery = { ...oldQuery, ...paramsToMerge };
+  return Object.keys(newQuery).reduce(
+    (acc, key) => (isEmptyValue(newQuery[key]) ? acc : { ...acc, [key]: newQuery[key] }),
+    {},
+  );
+};

--- a/app/src/controllers/pages/actionCreators.js
+++ b/app/src/controllers/pages/actionCreators.js
@@ -1,16 +1,6 @@
 import { redirect } from 'redux-first-router';
 import isEqual from 'fast-deep-equal';
-
-const mergeQuery = (oldQuery, paramsToMerge) => {
-  const newQuery = { ...oldQuery, ...paramsToMerge };
-  return Object.keys(newQuery).reduce(
-    (acc, key) =>
-      newQuery[key] === undefined || newQuery[key] === null
-        ? acc
-        : { ...acc, [key]: newQuery[key] },
-    {},
-  );
-};
+import { mergeQuery } from 'common/utils/routingUtils';
 
 export const updatePagePropertiesAction = (properties) => (dispatch, getState) => {
   const {


### PR DESCRIPTION
### Case 1:
1. Go to suites level
2. Add any filter with
3. Input any value to that filter
4. Remove filter

**Expected result:**
Filter removed from query parameters.

**Actual result:**
Filter remains in query with an empty value.

### Case 2:
1. Go to the log level
2. Change log level
3. Check "Logs with Attachment" checkbox

**Expected result:**
Both parameters are presented in URL

**Actual result:**
Log level parameter is replaced with checkbox parameter