### PR TITLE
EPMRPP-36908: fix - React: Markdown options are not applied

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 			},
             "font-src": {"'self'", "fonts.googleapis.com", "fonts.gstatic.com"},
             "media-src": {"'self'", "*.saucelabs.com"},
-			"img-src":    {"'self'", "data:", "www.google-analytics.com", "stats.g.doubleclick.net", "*.epam.com", "*.uservoice.com", "*.saucelabs.com"},
+			"img-src": {"*", "'self'", "data:"},
 			"object-src": {"'self'"},
 		}
 


### PR DESCRIPTION
Fixes `Refused to load the image '<URL>' because it violates the following Content Security Policy directive: "img-src 'self' data: <URL> stats.g.doubleclick.net *.epam.com *.uservoice.com"
` console message and its consequences.


