### PR TITLE
EPMRPP-34392: fix toolbar on top when at least one launch is selected

### DIFF
--- a/app/src/layouts/common/layout/constants.js
+++ b/app/src/layouts/common/layout/constants.js
@@ -1,0 +1,1 @@
+export const SCROLLING_CONTENT_ELEM_ID = 'scrollingContent';

--- a/app/src/layouts/common/layout/layout.jsx
+++ b/app/src/layouts/common/layout/layout.jsx
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { Footer } from '../footer';
+import { SCROLLING_CONTENT_ELEM_ID } from './constants';
 import styles from './layout.scss';
 
 const cx = classNames.bind(styles);
@@ -76,7 +77,10 @@ export class Layout extends Component {
             />
           </div>
           <div className={cx('content')}>
-            <ScrollWrapper withBackToTop>
+            <ScrollWrapper
+              renderView={(props) => <div id={SCROLLING_CONTENT_ELEM_ID} {...props} />}
+              withBackToTop
+            >
               <div className={cx('scrolling-content')}>
                 <div className={cx('header-container')}>
                   <Header

--- a/app/src/pages/inside/common/launchSuiteGrid/launchSuiteGrid.jsx
+++ b/app/src/pages/inside/common/launchSuiteGrid/launchSuiteGrid.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react';
+import React, { PureComponent } from 'react';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
@@ -213,6 +213,8 @@ export class LaunchSuiteGrid extends PureComponent {
     onFilterClick: PropTypes.func,
     events: PropTypes.object,
     onAnalysis: PropTypes.func,
+    getGridRef: PropTypes.func.isRequired,
+    style: PropTypes.object,
   };
   static defaultProps = {
     data: [],
@@ -231,6 +233,7 @@ export class LaunchSuiteGrid extends PureComponent {
     onFilterClick: () => {},
     events: {},
     onAnalysis: () => {},
+    style: {},
   };
   getColumns() {
     const hamburgerColumn = {
@@ -435,9 +438,11 @@ export class LaunchSuiteGrid extends PureComponent {
       onAllItemsSelect,
       loading,
       onFilterClick,
+      getGridRef,
+      style,
     } = this.props;
     return (
-      <Fragment>
+      <div ref={getGridRef} style={style}>
         <Grid
           columns={this.COLUMNS}
           data={data}
@@ -453,7 +458,7 @@ export class LaunchSuiteGrid extends PureComponent {
         />
         {!data.length &&
           !loading && <NoItemMessage message={formatMessage(COMMON_LOCALE_KEYS.NO_RESULTS)} />}
-      </Fragment>
+      </div>
     );
   }
 }

--- a/app/src/pages/inside/launchesPage/LaunchToolbar/launchToolbar.jsx
+++ b/app/src/pages/inside/launchesPage/LaunchToolbar/launchToolbar.jsx
@@ -20,8 +20,15 @@ export const LaunchToolbar = ({
   debugMode,
   onRefresh,
   onDelete,
+  getToolbarRef,
+  sticky,
+  style,
 }) => (
-  <div className={cx('launch-toolbar')}>
+  <div
+    className={cx('launch-toolbar', { 'sticky-toolbar': sticky })}
+    ref={getToolbarRef}
+    style={style}
+  >
     {!!selectedLaunches.length && (
       <SelectedItems
         selectedItems={selectedLaunches}
@@ -61,6 +68,9 @@ LaunchToolbar.propTypes = {
   onImportLaunch: PropTypes.func,
   debugMode: PropTypes.bool,
   onRefresh: PropTypes.func,
+  getToolbarRef: PropTypes.func.isRequired,
+  sticky: PropTypes.bool,
+  style: PropTypes.object,
 };
 LaunchToolbar.defaultProps = {
   selectedLaunches: [],
@@ -76,4 +86,6 @@ LaunchToolbar.defaultProps = {
   onImportLaunch: () => {},
   debugMode: false,
   onRefresh: () => {},
+  sticky: false,
+  style: {},
 };

--- a/app/src/pages/inside/launchesPage/LaunchToolbar/launchToolbar.scss
+++ b/app/src/pages/inside/launchesPage/LaunchToolbar/launchToolbar.scss
@@ -2,3 +2,9 @@
   background-color: $COLOR--white-two;
   border-bottom: 1px solid $COLOR--gray-91;
 }
+
+.sticky-toolbar {
+  position: fixed;
+  top: 0;
+  z-index: 2;
+}


### PR DESCRIPTION
As we use `react-custom-scrollbars` we can't catch `scroll` event on window, we need to listen to `scroll` event on element with scrollbars. So that is why I add specific `id` on Layout component.

![image](https://user-images.githubusercontent.com/3634380/57377670-b023e700-71ab-11e9-8222-e077da45b42e.png)
