### PR TITLE
EPMRPP-38837 - React. "Passing rate per Launch" widget bar goes out of borders when changing its size

### DIFF
--- a/app/src/components/widgets/charts/passingRatePerLaunch/passingRatePerLaunch.jsx
+++ b/app/src/components/widgets/charts/passingRatePerLaunch/passingRatePerLaunch.jsx
@@ -224,7 +224,7 @@ export class PassingRatePerLaunch extends Component {
     return widget.widgetType === PASSING_RATE_PER_LAUNCH;
   }
 
-  resizeChart() {
+  resizeChart = () => {
     const newHeight = this.props.container.offsetHeight;
     const newWidth = this.props.container.offsetWidth;
     if (this.height !== newHeight) {
@@ -237,7 +237,7 @@ export class PassingRatePerLaunch extends Component {
       this.width = newWidth;
     }
     this.resizeHelper();
-  }
+  };
 
   resizeHelper() {
     const nodeElement = this.node;


### PR DESCRIPTION
**Preconditions:**
Passing rate per Launch widget is created

**Steps**:
1) Login to RP -> go to Dashboard page
2) Change the size of Passing rate per Launch widget using arrows in the lower right corner

**Expected result:**
the widget should adjust to resize