### PR TITLE
EPMRPP-37114 - REACT. There is no notification after adding a dashboard

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -285,6 +285,7 @@
   "DashboardPage.modal.modalCancelButtonText": "Адмяніць",
   "DashboardPage.noResults": "Нічога не знойдзена",
   "DashboardPage.title": "Усе панэлі кіравання",
+  "DashboardPage.addDashboardSuccess": "Панэль кіравання была дададзеная",
   "DashboardPageHeader.allDashboardsTitle": "All dashboards",
   "DashboardPageToolbar.searchPlaceholder": "Пошук па назве",
   "DashboardTable.dashboardName": "Назва панэлі кіравання",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -284,6 +284,7 @@
   "DashboardPage.modal.modalCancelButtonText": "Отменить",
   "DashboardPage.noResults": "Ничего не найдено",
   "DashboardPage.title": "Все панели управления",
+  "DashboardPage.addDashboardSuccess": "Панель управления была добавлена",
   "DashboardPageHeader.allDashboardsTitle": "All dashboards",
   "DashboardPageToolbar.searchPlaceholder": "Поиск по названию",
   "DashboardTable.dashboardName": "Название Панели управления",

--- a/app/src/components/main/notification/notificationList/notificationListItem/notificationItem.jsx
+++ b/app/src/components/main/notification/notificationList/notificationListItem/notificationItem.jsx
@@ -71,6 +71,10 @@ const messages = defineMessages({
     id: 'ConnectionSection.removeIntegrationSuccess',
     defaultMessage: 'Integration successfully deleted',
   },
+  addDashboardSuccess: {
+    id: 'DashboardPage.addDashboardSuccess',
+    defaultMessage: 'Dashboard has been added',
+  },
 });
 
 @injectIntl

--- a/app/src/controllers/dashboard/sagas.js
+++ b/app/src/controllers/dashboard/sagas.js
@@ -1,4 +1,6 @@
 import { all, call, put, select, takeEvery } from 'redux-saga/effects';
+import { showNotification } from 'controllers/notification';
+import { NOTIFICATION_TYPES } from 'controllers/notification/constants';
 import { redirect } from 'redux-first-router';
 import { URLS } from 'common/urls';
 import { fetchDataAction } from 'controllers/fetch';
@@ -62,6 +64,12 @@ function* addDashboard({ payload: dashboard }) {
   });
 
   yield put(addDashboardSuccessAction({ id, owner, ...dashboard }));
+  yield put(
+    showNotification({
+      messageId: 'addDashboardSuccess',
+      type: NOTIFICATION_TYPES.SUCCESS,
+    }),
+  );
   yield put(hideModalAction());
   yield put({
     type: PROJECT_DASHBOARD_ITEM_PAGE,


### PR DESCRIPTION
1) Go to RP -> Dashboard tab
2) Click 'Add New Dashboard' button
3) Fill in the fields in 'Add New Dashboard' modal window
4) Click 'Add' button

Actual result: no notification appears
Expected result: 'Dashboard has been added' notification appears at the bottom in green