### PR TITLE
EPMRPP-38750 - React: Statuses of retried elements are overlapped on step view

### DIFF
--- a/app/src/pages/inside/stepPage/retries/retriesList/retry/retry.jsx
+++ b/app/src/pages/inside/stepPage/retries/retriesList/retry/retry.jsx
@@ -25,7 +25,7 @@ export const Retry = injectIntl(({ intl, retry, selected, index, onClick }) => (
       />
     </div>
     <div className={cx('column', 'status')}>{formatStatus(intl.formatMessage, retry.status)}</div>
-    <div className={cx('column', 'date')}>{dateFormat(retry.endTime)}</div>
+    <div className={cx('column', 'date')}>{dateFormat(retry.startTime)}</div>
   </div>
 ));
 Retry.propTypes = {

--- a/app/src/pages/inside/stepPage/retries/retriesList/retry/retry.scss
+++ b/app/src/pages/inside/stepPage/retries/retriesList/retry/retry.scss
@@ -61,7 +61,7 @@
 }
 
 .status {
-  width: 60px;
+  width: 85px;
   color: $COLOR--charcoal-grey;
   font-family: $FONT-SEMIBOLD;
   font-size: 13px;


### PR DESCRIPTION
Create launch (Suite>Test>Step(with retry))
Go to Step view
Click on the link with count of retried elements 
Check displayed statuses of retried elements 
Expected result: Statuses are not overlapped, start time is displayed for each item

Actual result: Statuses are overlapped, items with status "in progress" has no start time