### PR TITLE
EPMRPP-38839: reopened - incorrect hyphenation of launch name

### DIFF
--- a/app/src/pages/inside/common/itemInfo/itemInfo.scss
+++ b/app/src/pages/inside/common/itemInfo/itemInfo.scss
@@ -31,7 +31,11 @@
   }
 }
 .name {
-  overflow-wrap: break-word;
+  word-break: break-all;
+
+  @supports (word-break: break-word) {
+    word-break: break-word;
+  }
 }
 .edit-number-box {
   white-space: nowrap;


### PR DESCRIPTION
Last fix with `overflow-wrap` didn't work appropriately.