### PR TITLE
Fix unnecessary renders on blur and clicking outside of some popups

### DIFF
--- a/app/src/components/inputs/inputConditional/inputConditional.jsx
+++ b/app/src/components/inputs/inputConditional/inputConditional.jsx
@@ -88,7 +88,7 @@ export class InputConditional extends Component {
     return getInputConditions(conditions);
   };
   handleClickOutside = (e) => {
-    if (!this.conditionsBlock.contains(e.target)) {
+    if (!this.conditionsBlock.contains(e.target) && this.state.opened) {
       this.setState({ opened: false });
     }
   };

--- a/app/src/components/inputs/inputConditionalTags/inputConditionalTags.jsx
+++ b/app/src/components/inputs/inputConditionalTags/inputConditionalTags.jsx
@@ -78,7 +78,7 @@ export class InputConditionalTags extends Component {
     return getInputConditions(conditions);
   };
   handleClickOutside = (e) => {
-    if (!this.conditionsBlock.contains(e.target)) {
+    if (!this.conditionsBlock.contains(e.target) && this.state.opened) {
       this.setState({ opened: false });
     }
   };

--- a/app/src/components/inputs/inputDropdown/inputDropdown.jsx
+++ b/app/src/components/inputs/inputDropdown/inputDropdown.jsx
@@ -96,7 +96,7 @@ export class InputDropdown extends Component {
   };
 
   handleClickOutside = (e) => {
-    if (!this.node.contains(e.target)) {
+    if (!this.node.contains(e.target) && this.state.opened) {
       this.setState({ opened: false });
       this.props.onBlur();
     }

--- a/app/src/components/inputs/inputDropdownSorting/inputDropdownSorting.jsx
+++ b/app/src/components/inputs/inputDropdownSorting/inputDropdownSorting.jsx
@@ -84,7 +84,7 @@ export class InputDropdownSorting extends Component {
   };
 
   handleClickOutside = (e) => {
-    if (!this.node.contains(e.target)) {
+    if (!this.node.contains(e.target) && this.state.opened) {
       this.setState({ opened: false });
       this.props.onBlur();
     }

--- a/app/src/components/inputs/inputTimeDateRange/inputTimeDateRange.jsx
+++ b/app/src/components/inputs/inputTimeDateRange/inputTimeDateRange.jsx
@@ -119,7 +119,7 @@ export class InputTimeDateRange extends Component {
   }
 
   handleClickOutside = (e) => {
-    if (!this.node.contains(e.target)) {
+    if (!this.node.contains(e.target) && this.state.opened) {
       this.setState({ opened: false });
       this.props.onBlur();
     }

--- a/app/src/components/main/colorPicker/colorPicker.jsx
+++ b/app/src/components/main/colorPicker/colorPicker.jsx
@@ -54,7 +54,8 @@ class ColorPickerComponent extends Component {
       this.pickerNode &&
       !this.pickerNode.contains(e.target) &&
       this.controlNode &&
-      !this.controlNode.contains(e.target)
+      !this.controlNode.contains(e.target) &&
+      this.state.opened
     ) {
       this.setState({ opened: false });
     }

--- a/app/src/pages/inside/common/defectTypeSelector/defectTypeSelector.jsx
+++ b/app/src/pages/inside/common/defectTypeSelector/defectTypeSelector.jsx
@@ -69,7 +69,7 @@ export class DefectTypeSelector extends Component {
   };
 
   handleClickOutside = (e) => {
-    if (!this.node.contains(e.target)) {
+    if (!this.node.contains(e.target) && this.state.opened) {
       this.setState({ opened: false });
       this.props.onBlur();
     }

--- a/app/src/pages/inside/common/launchFiltersToolbar/allLatestDropdown/allLatestDropdown.jsx
+++ b/app/src/pages/inside/common/launchFiltersToolbar/allLatestDropdown/allLatestDropdown.jsx
@@ -81,7 +81,7 @@ export class AllLatestDropdown extends Component {
   };
 
   handleClickOutside = (e) => {
-    if (!this.nodeRef.current.contains(e.target)) {
+    if (!this.nodeRef.current.contains(e.target) && this.state.expanded) {
       this.setState({ expanded: false });
     }
   };


### PR DESCRIPTION
Case 1:
- open widget wizard modal
- select "LaunchStatistics" widget
- go to second step
- click on empty place in the modal

**ER**: nothing happens
**AR**: preview rerenders on every click

Case 2:
- open any page with any of changed components present (for example: launches page with selected filter)
- open react devtools
- open preferences and select "Highlight Updates"
- click on empty place on a page

**ER**: nothing happens
**AR**: some of components are marked with blue rectengles which indicates rerenders