### PR TITLE
EPMRPP-37311 REACT. Widget type names are hyphenated on 'Add new widg…

### DIFF
--- a/app/src/pages/inside/dashboardItemPage/modals/widgetWizardModal/widgetWizardContent/wizardControlsSection/wizardFirstStepForm/widgetTypeSelector/widgetTypeItem/widgetTypeItem.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/widgetWizardModal/widgetWizardContent/wizardControlsSection/wizardFirstStepForm/widgetTypeSelector/widgetTypeItem/widgetTypeItem.jsx
@@ -14,9 +14,9 @@ export const WidgetTypeItem = ({ widget, activeWidgetId, onChange }) => (
       onChange={onChange}
       circleAtTop
     >
-      <span className={cx('widget-type-item-name', { active: widget.id === activeWidgetId })}>
+      <div className={cx('widget-type-item-name', { active: widget.id === activeWidgetId })}>
         {widget.title}
-      </span>
+      </div>
     </InputRadio>
   </div>
 );


### PR DESCRIPTION
…et' modal for Firefox and Edge. Changed span to div.