### PR TITLE
EPMRPP-41362 Fix Launch statistics chart data calculating

### DIFF
--- a/app/src/components/widgets/singleLevelWidgets/charts/launchStatisticsChart/launchStatisticsChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/launchStatisticsChart/launchStatisticsChart.jsx
@@ -341,9 +341,9 @@ export class LaunchStatisticsChart extends Component {
       delete currentItemData.values;
       itemData.push(currentItemData);
       contentFields.forEach((contentFieldKey) => {
-        const value = item.values[contentFieldKey] || 0;
-        if (value) {
-          chartData[contentFieldKey].push(!Number(value) && isTimeLine ? null : Number(value));
+        const value = Number(item.values[contentFieldKey]) || 0;
+        if (value || !isTimeLine) {
+          chartData[contentFieldKey].push(value);
         }
       });
     });


### PR DESCRIPTION
Fix for displaying empty data for `Launch statistics chart` (see the screenshot below).

![image](https://user-images.githubusercontent.com/31861805/65962334-195d0d00-e461-11e9-9476-6106378b8adf.png)
