### PR TITLE
Logs grid. Set white-space css property to pre-wrap for log message

### DIFF
--- a/app/src/pages/inside/logsPage/logsGrid/logMessageBlock/logMessageBlock.scss
+++ b/app/src/pages/inside/logsPage/logsGrid/logMessageBlock/logMessageBlock.scss
@@ -4,9 +4,10 @@
   font-size: 11px;
   font-family: $FONT-MENLO;
   word-break: break-all;
+  white-space: pre-wrap;
+
   .log-message {
     display: inline;
-    white-space: pre-line;
     padding-bottom: 5px;
     line-height: 18px;
   }


### PR DESCRIPTION
Fix for [this](https://github.com/reportportal/reportportal/issues/150) issue.