### PR TITLE
Fix login username and password double encoded

### DIFF
--- a/src/main/resources/public/js/src/core/core-service.js
+++ b/src/main/resources/public/js/src/core/core-service.js
@@ -39,6 +39,8 @@ define([
         return call('DELETE', urls.userLogout());
     };
     var userLogin = function (data) {
+        data['username'] = decodeURIComponent(data.username);
+        data['password'] = decodeURIComponent(data.password);
         return call('POST', urls.userLogin(), data, true, false, 'application/x-www-form-urlencoded; charset=UTF-8');
     };
 


### PR DESCRIPTION
With data as object and add contentType, the password was double
encoded and login will fail with special charcater like '@'.

To fix the username and password value, decode it before pass to
ajax.

Signed-off-by: Wayne Sun <gsun@redhat.com>