### PR TITLE
EPMRPP-67496: fix attribute refine removed when click stat info line …

### DIFF
--- a/app/src/controllers/testItem/selectors.js
+++ b/app/src/controllers/testItem/selectors.js
@@ -363,13 +363,16 @@ export const defectLinkSelector = createSelector(
       'filter.in.issueType': getDefectsString(ownProps.defects),
       'filter.has.attributeKey': ownProps.attributeKey,
       'filter.has.attributeValue': ownProps.attributeValue,
-      'filter.has.compositeAttribute': ownProps.compositeAttribute,
       'filter.has.levelAttribute': ownProps.levelAttribute,
       providerType,
       [providerTypeModifierId]: ownProps[providerTypeModifierId],
       launchesLimit,
       isLatest,
     };
+
+    if (ownProps.compositeAttributes) {
+      params['filter.has.compositeAttribute'] = ownProps.compositeAttributes;
+    }
 
     if (ownProps.filterType) {
       params['filter.in.type'] = ownProps.filterTypes


### PR DESCRIPTION
…(#2871)

* EPMRPP-67496: fix attribute refine removed when click stat info line

* EPMRPP-67496: code review fixes - 1

Co-authored-by: Aleksandr Zyabrev <aleksandr_zyabrev@epam.com>