### PR TITLE
Test CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ lint: checkstyle
 fmt:
 	gofmt -l -w -s ${GOFILES_NOVENDOR}
 #	gofumpt -l -w -s ${GOFILES_NOVENDOR}
+#	gofumports -l -w ${GOFILES_NOVENDOR}
 
 # Builds server
 build-server: checkstyle test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GO = go
 BINARY_DIR=bin
 RELEASE_DIR=release
 
-BUILD_DEPS:= github.com/avarabyeu/releaser mvdan.cc/gofumpt/gofumports
+BUILD_DEPS:= github.com/avarabyeu/releaser mvdan.cc/gofumpt
 GODIRS_NOVENDOR = $(shell go list ./... | grep -v /vendor/)
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 PACKAGE_COMMONS=github.com/reportportal/commons-go/v5
@@ -42,7 +42,6 @@ lint: checkstyle
 fmt:
 	gofmt -l -w -s ${GOFILES_NOVENDOR}
 #	gofumpt -l -w -s ${GOFILES_NOVENDOR}
-#	gofumports -l -w ${GOFILES_NOVENDOR}
 
 # Builds server
 build-server: checkstyle test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GO = go
 BINARY_DIR=bin
 RELEASE_DIR=release
 
-BUILD_DEPS:= github.com/avarabyeu/releaser mvdan.cc/gofumpt
+BUILD_DEPS:= github.com/avarabyeu/releaser mvdan.cc/gofumpt@v0.1.1
 GODIRS_NOVENDOR = $(shell go list ./... | grep -v /vendor/)
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 PACKAGE_COMMONS=github.com/reportportal/commons-go/v5

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # UI service for Report Portal 
 [![Build Status](https://semaphoreci.com/api/v1/lexecon/rp_service-ui/branches/develop/badge.svg)](http://reportportal.io/service-ui/index.html)
 
-1. Install nodejs (minimum required version 10, preferred 12)
+1. Install nodejs (minimum required version 10)
 
 2. Open console from the project root
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # UI service for Report Portal 
 [![Build Status](https://semaphoreci.com/api/v1/lexecon/rp_service-ui/branches/develop/badge.svg)](http://reportportal.io/service-ui/index.html)
 
-1. Install nodejs (minimum required version 10)
+1. Install nodejs (minimum required version 10, preferred 12)
 
 2. Open console from the project root
 


### PR DESCRIPTION
gofumports was completely removed from gofumpt version 0.2.0 ([release notes](https://github.com/mvdan/gofumpt/releases)).
@avarabyeu could you please help with this? Should we migrate this style utilities to the new version?
I'll merge this quick fix to repair jenkins build, but it is still potentially unreliable.