### PR TITLE
Increase number of chars in description of a launch to 4096

### DIFF
--- a/app/src/common/utils/validation/validate.js
+++ b/app/src/common/utils/validation/validate.js
@@ -39,7 +39,7 @@ export const userName = composeValidators([
 ]);
 export const filterName = composeValidators([isNotEmpty, lengthRange(3, 128)]);
 export const launchName = composeValidators([isNotEmpty, maxLength(256)]);
-export const launchDescription = maxLength(1024);
+export const launchDescription = maxLength(4096);
 export const dashboardName = composeValidators([isNotEmpty, lengthRange(3, 128)]);
 export const createDashboardNameUniqueValidator = (dashboardItems, dashboardItem) => (name) =>
   !dashboardItems.some((dashboard) => dashboard.name === name && dashboard.id !== dashboardItem.id);


### PR DESCRIPTION
We use the launch description to allow our users to have that information presented within the launch description such as links, artifacts, OKR Results. 
But the limit of 1024 chars trims most of the links and data from there.

Example: 
![Screen Shot 2022-05-26 at 20 03 10](https://user-images.githubusercontent.com/70978871/170538243-a08deb2c-54bf-4e75-a563-848700a1ea6e.png)


