### PR TITLE
EPMRPP 79767 || reduce selectors for new routing

### DIFF
--- a/app/src/components/containers/attributeListContainer/attributeListContainer.jsx
+++ b/app/src/components/containers/attributeListContainer/attributeListContainer.jsx
@@ -17,10 +17,10 @@
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { EditableAttributeList } from 'componentLibrary/attributeList/editableAttributeList';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 
 export const AttributeListContainer = ({ value, keyURLCreator, valueURLCreator, ...rest }) => {
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(activeProjectKeySelector);
   const getURIKey = keyURLCreator(projectKey);
   const getURIValue = (key) => valueURLCreator(projectKey, key);
   return (

--- a/app/src/components/integrations/elements/bts/btsPropertiesForIssueForm/btsPropertiesForIssueForm.jsx
+++ b/app/src/components/integrations/elements/bts/btsPropertiesForIssueForm/btsPropertiesForIssueForm.jsx
@@ -22,7 +22,7 @@ import track from 'react-tracking';
 import classNames from 'classnames/bind';
 import { fetch } from 'common/utils';
 import { SpinningPreloader } from 'components/preloaders/spinningPreloader';
-import { projectIdSelector } from 'controllers/pages';
+import { urlProjectKeySelector } from 'controllers/pages';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import {
   COMMAND_GET_ISSUE_TYPES,
@@ -39,7 +39,6 @@ import {
 } from 'components/fields/dynamicFieldsSection/utils';
 import { PLUGINS_PAGE_EVENTS, SETTINGS_PAGE_EVENTS } from 'components/main/analytics/events';
 import { getDefaultOptionValueKey } from 'pages/inside/stepPage/modals/postIssueModal/utils';
-import { projectKeySelector } from 'controllers/project';
 import { IntegrationFormField } from '../../integrationFormField';
 import { ISSUE_TYPE_FIELD_KEY } from '../constants';
 import styles from './btsPropertiesForIssueForm.scss';
@@ -67,8 +66,7 @@ const messages = defineMessages({
 
 @connect(
   (state) => ({
-    projectName: projectIdSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: urlProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/components/widgets/multiLevelWidgets/cumulativeTrendChart/cumulativeTrendChart.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/cumulativeTrendChart/cumulativeTrendChart.jsx
@@ -29,11 +29,7 @@ import {
   TEST_ITEMS_TYPE_LIST,
   PROVIDER_TYPE_WIDGET,
 } from 'controllers/testItem';
-import {
-  defectTypesSelector,
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-} from 'controllers/project';
+import { defectTypesSelector, projectOrganizationSlugSelector } from 'controllers/project';
 import { SCREEN_XS_MAX } from 'common/constants/screenSizeVariables';
 import { PASSED, FAILED, SKIPPED, INTERRUPTED } from 'common/constants/testStatuses';
 import { formatAttribute } from 'common/utils/attributeUtils';
@@ -41,6 +37,7 @@ import { BEFORE_AFTER_METHOD_TYPES_SEQUENCE } from 'common/constants/methodTypes
 import { STATE_READY, DEFECTS, TOTAL_KEY } from 'components/widgets/common/constants';
 import SearchIcon from 'common/img/search-icon-inline.svg';
 import FiltersIcon from 'common/img/filters-icon-inline.svg';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getChartData } from './chartjsConfig';
 import { CumulativeChartLegend } from './legend/cumulativeChartLegend';
 import { ActionsPopup } from './actionsPopup';
@@ -60,7 +57,7 @@ const PRINTED_LEGEND_HEIGHT = 80;
 @connect(
   (state) => ({
     organizationSlug: projectOrganizationSlugSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     defectTypes: defectTypesSelector(state),
     getDefectLink: defectLinkSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),

--- a/app/src/components/widgets/multiLevelWidgets/mostPopularPatterns/mostPopularPatterns.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/mostPopularPatterns/mostPopularPatterns.jsx
@@ -25,7 +25,8 @@ import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { InputDropdown } from 'components/inputs/inputDropdown';
 import { NoDataAvailable } from 'components/widgets';
 import { getDefaultTestItemLinkParams } from 'components/widgets/common/utils';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { PatternGrid } from './patternGrid';
 import styles from './mostPopularPatterns.scss';
 
@@ -34,7 +35,7 @@ const cx = classNames.bind(styles);
 @connect(
   (state) => ({
     organizationSlug: projectOrganizationSlugSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     navigate: (linkAction) => linkAction,

--- a/app/src/components/widgets/singleLevelWidgets/charts/failedCasesTrendChart/failedCasesTrendChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/failedCasesTrendChart/failedCasesTrendChart.jsx
@@ -27,7 +27,8 @@ import {
   getChartDefaultProps,
   getDefaultTestItemLinkParams,
 } from 'components/widgets/common/utils';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig } from './config/getConfig';
 import styles from './failedCasesTrendChart.scss';
 
@@ -36,7 +37,7 @@ const cx = classNames.bind(styles);
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),
   }),

--- a/app/src/components/widgets/singleLevelWidgets/charts/investigatedTrendChart/investigatedTrendChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/investigatedTrendChart/investigatedTrendChart.jsx
@@ -36,11 +36,8 @@ import {
 import * as STATUSES from 'common/constants/testStatuses';
 import { ALL } from 'common/constants/reservedFilterIds';
 import { ChartContainer } from 'components/widgets/common/c3chart';
-import {
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-  defectTypesSelector,
-} from 'controllers/project';
+import { projectOrganizationSlugSelector, defectTypesSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig as getStatusPageModeConfig } from '../common/statusPageChartConfig';
 import { selectConfigFunction } from './config';
 import styles from './investigatedTrendChart.scss';
@@ -50,7 +47,7 @@ const cx = classNames.bind(styles);
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     defectTypes: defectTypesSelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getDefectLink: defectLinkSelector(state),

--- a/app/src/components/widgets/singleLevelWidgets/charts/launchExecutionAndIssueStatistics/common/donutChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/launchExecutionAndIssueStatistics/common/donutChart.jsx
@@ -22,11 +22,7 @@ import classNames from 'classnames/bind';
 import { connect } from 'react-redux';
 import { ALL } from 'common/constants/reservedFilterIds';
 import { TEST_ITEMS_TYPE_LIST } from 'controllers/testItem';
-import {
-  userFiltersSelector,
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-} from 'controllers/project';
+import { userFiltersSelector, projectOrganizationSlugSelector } from 'controllers/project';
 import { TEST_ITEM_PAGE } from 'controllers/pages';
 import {
   getItemNameConfig,
@@ -34,6 +30,7 @@ import {
   getDefaultTestItemLinkParams,
 } from 'components/widgets/common/utils';
 import { ChartContainer } from 'components/widgets/common/c3chart';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig } from './config/getConfig';
 import { isSmallDonutChartView } from './config/utils';
 import styles from './donutChart.scss';
@@ -42,7 +39,7 @@ const cx = classNames.bind(styles);
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     launchFilters: userFiltersSelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
   }),

--- a/app/src/components/widgets/singleLevelWidgets/charts/launchStatisticsChart/launchStatisticsChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/launchStatisticsChart/launchStatisticsChart.jsx
@@ -23,7 +23,6 @@ import * as d3 from 'd3-selection';
 import {
   defectTypesSelector,
   orderedContentFieldsSelector,
-  projectKeySelector,
   projectOrganizationSlugSelector,
 } from 'controllers/project';
 import {
@@ -45,6 +44,7 @@ import {
 import { createTooltipRenderer } from 'components/widgets/common/tooltip';
 import { CHART_OFFSET } from 'components/widgets/common/constants';
 import { getMillisecondsWoTimezone } from 'common/utils/timeDateUtils';
+import { activeProjectKeySelector } from 'controllers/user';
 import { IssueTypeStatTooltip } from '../common/issueTypeStatTooltip';
 import { isSingleColumnChart, calculateTooltipParams } from './config/utils';
 import { getConfig } from './config/getConfig';
@@ -56,7 +56,7 @@ const cx = classNames.bind(styles);
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     defectTypes: defectTypesSelector(state),
     orderedContentFields: orderedContentFieldsSelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),

--- a/app/src/components/widgets/singleLevelWidgets/charts/launchesComparisonChart/launchesComparisonChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/launchesComparisonChart/launchesComparisonChart.jsx
@@ -21,11 +21,7 @@ import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import * as d3 from 'd3-selection';
 import { ALL } from 'common/constants/reservedFilterIds';
-import {
-  defectTypesSelector,
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-} from 'controllers/project';
+import { defectTypesSelector, projectOrganizationSlugSelector } from 'controllers/project';
 import { defectLinkSelector, statisticsLinkSelector } from 'controllers/testItem';
 import {
   getDefaultTestItemLinkParams,
@@ -34,6 +30,7 @@ import {
   getChartDefaultProps,
 } from 'components/widgets/common/utils';
 import { ChartContainer } from 'components/widgets/common/c3chart';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig } from './config/getConfig';
 import styles from './launchesComparisonChart.scss';
 
@@ -42,7 +39,7 @@ const cx = classNames.bind(styles);
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     defectTypes: defectTypesSelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getDefectLink: defectLinkSelector(state),

--- a/app/src/components/widgets/singleLevelWidgets/charts/launchesDurationChart/launchesDurationChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/launchesDurationChart/launchesDurationChart.jsx
@@ -25,7 +25,8 @@ import {
   getDefaultTestItemLinkParams,
 } from 'components/widgets/common/utils';
 import { ALL } from 'common/constants/reservedFilterIds';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig } from './config/getConfig';
 import styles from './launchesDurationChart.scss';
 
@@ -34,7 +35,7 @@ const cx = classNames.bind(styles);
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
   }),
   {

--- a/app/src/components/widgets/singleLevelWidgets/charts/nonPassedTestCasesTrendChart/nonPassedTestCasesTrendChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/nonPassedTestCasesTrendChart/nonPassedTestCasesTrendChart.jsx
@@ -26,7 +26,8 @@ import {
 import { connect } from 'react-redux';
 import { statisticsLinkSelector } from 'controllers/testItem';
 import { FAILED, SKIPPED, INTERRUPTED } from 'common/constants/testStatuses';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig } from './config/getConfig';
 import styles from './nonPassedTestCasesTrendChart.scss';
 
@@ -37,7 +38,7 @@ const FAILED_SKIPPED_STATISTICS_KEY = 'statistics$executions$failedSkippedTotal'
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),
   }),

--- a/app/src/components/widgets/singleLevelWidgets/charts/overallStatistics/overallStatisticsPanel/overallStatisticsPanel.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/overallStatistics/overallStatisticsPanel/overallStatisticsPanel.jsx
@@ -17,17 +17,14 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames/bind';
-import {
-  orderedDefectFieldsSelector,
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-} from 'controllers/project';
+import { orderedDefectFieldsSelector, projectOrganizationSlugSelector } from 'controllers/project';
 import {
   defectLinkSelector,
   statisticsLinkSelector,
   TEST_ITEMS_TYPE_LIST,
 } from 'controllers/testItem';
 import { getDefaultTestItemLinkParams } from 'components/widgets/common/utils';
+import { activeProjectKeySelector } from 'controllers/user';
 import { TotalStatistics } from './totalStatistics';
 import { OverallDefects } from './overallDefects';
 import styles from './overallStatisticsPanel.scss';
@@ -37,7 +34,7 @@ const cx = classNames.bind(styles);
 @connect(
   (state) => ({
     orderedContentFields: orderedDefectFieldsSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getDefectLink: defectLinkSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),

--- a/app/src/components/widgets/singleLevelWidgets/charts/passingRatePerLaunch/passingRatePerLaunch.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/passingRatePerLaunch/passingRatePerLaunch.jsx
@@ -23,7 +23,8 @@ import { ALL } from 'common/constants/reservedFilterIds';
 import { getDefaultTestItemLinkParams } from 'components/widgets/common/utils';
 import { statisticsLinkSelector } from 'controllers/testItem';
 import { STATS_PASSED } from 'common/constants/statistics';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { PassingRateChart } from '../common/passingRateChart';
 
 const getFilterName = ({ contentParameters, content: { result = {} } = {} } = {}) =>
@@ -31,7 +32,7 @@ const getFilterName = ({ contentParameters, content: { result = {} } = {} } = {}
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),
   }),

--- a/app/src/components/widgets/singleLevelWidgets/charts/passingRateSummary/passingRateSummary.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/passingRateSummary/passingRateSummary.jsx
@@ -22,12 +22,13 @@ import { PASSED, FAILED, INTERRUPTED, SKIPPED } from 'common/constants/testStatu
 import { statisticsLinkSelector, TEST_ITEMS_TYPE_LIST } from 'controllers/testItem';
 import { getDefaultTestItemLinkParams } from 'components/widgets/common/utils';
 import { messages } from 'components/widgets/common/messages';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { PassingRateChart } from '../common/passingRateChart';
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),
   }),

--- a/app/src/components/widgets/singleLevelWidgets/charts/testCasesGrowthTrendChart/testCasesGrowthTrendChart.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/charts/testCasesGrowthTrendChart/testCasesGrowthTrendChart.jsx
@@ -31,7 +31,8 @@ import {
   getChartDefaultProps,
   getDefaultTestItemLinkParams,
 } from 'components/widgets/common/utils';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getConfig } from './config/getConfig';
 import styles from './testCasesGrowthTrendChart.scss';
 
@@ -39,7 +40,7 @@ const cx = classNames.bind(styles);
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
     getStatisticsLink: statisticsLinkSelector(state),
   }),

--- a/app/src/components/widgets/singleLevelWidgets/mostTimeConsumingTestCases/mostTimeConsumingTestCases.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/mostTimeConsumingTestCases/mostTimeConsumingTestCases.jsx
@@ -22,7 +22,8 @@ import { injectIntl, defineMessages } from 'react-intl';
 import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
 import { ALL } from 'common/constants/reservedFilterIds';
 import { TEST_ITEM_PAGE, PROJECT_LOG_PAGE } from 'controllers/pages/constants';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { MostTimeConsumingTestCasesChart } from './mostTimeConsumingTestCasesChart';
 import { MostTimeConsumingTestCasesTable } from './mostTimeConsumingTestCasesTable';
 import styles from './mostTimeConsumingTestCases.scss';
@@ -39,7 +40,7 @@ const localMessages = defineMessages({
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
   }),
   {

--- a/app/src/components/widgets/singleLevelWidgets/tables/launchesTable/launchesTable.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/tables/launchesTable/launchesTable.jsx
@@ -51,7 +51,8 @@ import { formatStatus } from 'common/utils/localizationUtils';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { getItemNameConfig } from 'components/widgets/common/utils';
 import { formatAttribute } from 'common/utils';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { defaultDefectsMessages, defaultStatisticsMessages } from '../components/messages';
 import { getStatisticsStatuses, groupFieldsWithDefectTypes } from '../components/utils';
 import {
@@ -258,7 +259,7 @@ const getColumn = (name, customProps, fieldKeys) => ({
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
   }),
   {

--- a/app/src/components/widgets/singleLevelWidgets/tables/productStatus/productStatus.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/tables/productStatus/productStatus.jsx
@@ -28,7 +28,8 @@ import { changeActiveFilterAction } from 'controllers/filter';
 import { ALL } from 'common/constants/reservedFilterIds';
 import { Grid } from 'components/main/grid';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { STATS_SI, STATS_PB, STATS_TI, STATS_ND, STATS_AB } from '../components/constants';
 import {
   NAME,
@@ -71,7 +72,7 @@ const columnComponentsMap = {
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
   }),
   {

--- a/app/src/components/widgets/singleLevelWidgets/tables/projectActivity/projectActivity.jsx
+++ b/app/src/components/widgets/singleLevelWidgets/tables/projectActivity/projectActivity.jsx
@@ -45,8 +45,9 @@ import {
   MATCHED_PATTERN,
 } from 'common/constants/actionTypes';
 import { AbsRelTime } from 'components/main/absRelTime';
-import { externalSystemSelector, projectKeySelector } from 'controllers/project';
+import { externalSystemSelector } from 'controllers/project';
 import { UserAvatar } from 'pages/inside/common/userAvatar';
+import { urlProjectKeySelector } from 'controllers/pages';
 import { DefaultProjectSettings } from './activities/defaultProjectSettings';
 import { AnalysisProperties } from './activities/analysisProperties';
 import { AnalysisConfigurations } from './activities/analysisConfigurations';
@@ -166,7 +167,7 @@ const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 
 // TODO: rewrite it when integrations will be added
 @connect((state) => ({
   hasBts: externalSystemSelector(state).length > 0,
-  projectKey: projectKeySelector(state),
+  projectKey: urlProjectKeySelector(state),
   lang: langSelector(state),
 }))
 @injectIntl

--- a/app/src/controllers/dashboard/sagas.js
+++ b/app/src/controllers/dashboard/sagas.js
@@ -34,7 +34,7 @@ import {
 import { provideEcGA } from 'components/main/analytics/utils';
 import { formatEcDashboardData } from 'components/main/analytics/events/common/widgetPages/utils';
 import { analyticsEnabledSelector } from 'controllers/appInfo';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
 
 import {
   ADD_DASHBOARD,
@@ -111,7 +111,7 @@ function* fetchDashboard() {
 }
 
 function* addDashboard({ payload: dashboard }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const owner = yield select(userIdSelector);
   const organizationSlug = yield select(projectOrganizationSlugSelector);
   const { id } = yield call(fetch, URLS.dashboards(projectKey), {
@@ -138,7 +138,7 @@ function* addDashboard({ payload: dashboard }) {
 }
 
 function* updateDashboard({ payload: dashboard }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const { name, description, id } = dashboard;
 
   yield call(fetch, URLS.dashboard(projectKey, id), {
@@ -149,7 +149,7 @@ function* updateDashboard({ payload: dashboard }) {
 }
 
 function* updateDashboardWidgets({ payload: dashboard }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
 
   yield call(fetch, URLS.dashboard(projectKey, dashboard.id), {
     method: 'put',
@@ -163,7 +163,7 @@ function* updateDashboardWidgets({ payload: dashboard }) {
 
 function* removeDashboard({ payload: id }) {
   try {
-    const projectKey = yield select(projectKeySelector);
+    const projectKey = yield select(activeProjectKeySelector);
     yield call(fetch, URLS.dashboard(projectKey, id), {
       method: 'delete',
     });
@@ -185,7 +185,7 @@ function* redirectAfterDelete({ payload: dashboardId }) {
   if (activePage === PROJECT_DASHBOARD_ITEM_PAGE) {
     const activeDashboardId = yield select(activeDashboardIdSelector);
     if (activeDashboardId === dashboardId) {
-      const projectKey = yield select(projectKeySelector);
+      const projectKey = yield select(activeProjectKeySelector);
       yield put(hideModalAction());
       yield put(
         redirect({

--- a/app/src/controllers/filter/sagas.js
+++ b/app/src/controllers/filter/sagas.js
@@ -23,14 +23,13 @@ import {
   FETCH_ERROR,
 } from 'controllers/fetch';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { URLS } from 'common/urls';
 import {
   userFiltersSelector,
   updateProjectFilterPreferencesAction,
   fetchProjectPreferencesAction,
   FETCH_PROJECT_PREFERENCES_SUCCESS,
-  projectKeySelector,
   projectOrganizationSlugSelector,
 } from 'controllers/project';
 import { launchDistinctSelector } from 'controllers/launch';
@@ -62,7 +61,7 @@ import {
 } from './actionCreators';
 
 function* fetchFilters() {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const query = yield select(querySelector);
   yield put(
     fetchDataAction(NAMESPACE)(URLS.filters(projectKey), {
@@ -72,7 +71,7 @@ function* fetchFilters() {
 }
 
 function* fetchFiltersConcat({ payload: { params, concat } }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const query = yield select(querySelector);
   yield put(
     concatFetchDataAction(NAMESPACE, concat)(URLS.filters(projectKey), {
@@ -82,7 +81,7 @@ function* fetchFiltersConcat({ payload: { params, concat } }) {
 }
 
 function* updateLaunchesFilter({ payload: filter }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const shallowFilter = {
     ...filter,
     conditions: filter.conditions.filter((item) => item.value.trim()),
@@ -104,7 +103,7 @@ function* updateLaunchesFilter({ payload: filter }) {
 
 function* changeActiveFilter({ payload: filterId }) {
   const organizationSlug = yield select(projectOrganizationSlugSelector);
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
 
   yield put({
     type: PROJECT_LAUNCHES_PAGE,
@@ -143,7 +142,7 @@ function* createFilter({ payload: filter = {} }) {
 }
 
 function* saveNewFilter({ payload: filter }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const shallowFilter = {
     ...filter,
     conditions: filter.conditions.filter((item) => item.value.trim()),
@@ -219,7 +218,7 @@ function* fetchFiltersPage({ payload: refreshProjectSettings }) {
   yield call(fetchFilters);
   const waitEffects = [take(createFetchPredicate(NAMESPACE))];
   if (refreshProjectSettings) {
-    const projectKey = yield select(projectKeySelector);
+    const projectKey = yield select(activeProjectKeySelector);
     yield put(fetchProjectPreferencesAction(projectKey));
     waitEffects.push(take(FETCH_PROJECT_PREFERENCES_SUCCESS));
   }

--- a/app/src/controllers/itemsHistory/sagas.js
+++ b/app/src/controllers/itemsHistory/sagas.js
@@ -34,7 +34,6 @@ import {
   pagePropertiesSelector,
 } from 'controllers/pages';
 import { isOldHistorySelector } from 'controllers/appInfo';
-import { projectKeySelector } from 'controllers/project';
 import { activeProjectKeySelector } from 'controllers/user';
 import {
   fetchItemsHistoryAction,
@@ -147,7 +146,7 @@ function* refreshHistory({ payload }) {
 }
 
 function* fetchFilterHistory({ payload: { filter, loadMore } }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const itemsHistory = yield select(historySelector);
   const isOldHistory = yield select(isOldHistorySelector);
   const historyGroupingFieldKey = isOldHistory

--- a/app/src/controllers/log/attachments/sagas.js
+++ b/app/src/controllers/log/attachments/sagas.js
@@ -30,7 +30,6 @@ import { DETAILED_LOG_VIEW } from 'controllers/log/constants';
 import { downloadFile } from 'common/utils/downloadFile';
 import { JSON as JSON_TYPE } from 'common/constants/fileTypes';
 import { PAGE_KEY, SIZE_KEY } from 'controllers/pagination';
-import { projectKeySelector } from 'controllers/project';
 import { activeProjectKeySelector } from 'controllers/user';
 import {
   ATTACHMENT_CODE_MODAL_ID,
@@ -53,7 +52,7 @@ import {
 } from './utils';
 
 function* getAttachmentURL() {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const isLaunchLog = yield select(isLaunchLogSelector);
   const activeRetryId = yield select(activeRetryIdSelector);
   if (isLaunchLog) {
@@ -141,13 +140,13 @@ function* openAttachmentInModal({ payload: { id, contentType } }) {
 }
 
 function* downloadAttachment({ payload: { id, contentType } }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
 
   downloadFile(URLS.getFileById(projectKey, id), createAttachmentName(id, contentType));
 }
 
 function* openAttachmentInBrowser({ payload: id }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const data = yield call(fetch, URLS.getFileById(projectKey, id), { responseType: 'blob' });
 
   if (window.navigator && window.navigator.msSaveOrOpenBlob) {

--- a/app/src/controllers/log/attachments/selectors.js
+++ b/app/src/controllers/log/attachments/selectors.js
@@ -16,7 +16,7 @@
 
 import { createSelector } from 'reselect';
 import { attachmentsSelector } from 'controllers/log/selectors';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { createAttachment } from './utils';
 
 export const logsWithAttachmentsSelector = (state) =>
@@ -30,7 +30,7 @@ export const activeAttachmentIdSelector = (state) => attachmentsSelector(state).
 
 export const attachmentItemsSelector = createSelector(
   logsWithAttachmentsSelector,
-  projectKeySelector,
+  activeProjectKeySelector,
   (logItems, projectKey) =>
     logItems
       .filter((item) => !!item.binaryContent)

--- a/app/src/controllers/log/sagaUtils.js
+++ b/app/src/controllers/log/sagaUtils.js
@@ -15,14 +15,13 @@
  */
 
 import { select } from 'redux-saga/effects';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { activeRetryIdSelector, querySelector } from 'controllers/log/selectors';
 import { LOG_LEVEL_FILTER_KEY, NAMESPACE } from 'controllers/log/constants';
 import { getLogLevel } from 'controllers/log/storageUtils';
-import { projectKeySelector } from 'controllers/project';
 
 export function* collectLogPayload() {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const userId = yield select(userIdSelector);
   const query = yield select(querySelector, NAMESPACE);
   const filterLevel = query[LOG_LEVEL_FILTER_KEY] || getLogLevel(userId).id;

--- a/app/src/controllers/log/sauceLabs/sagas.js
+++ b/app/src/controllers/log/sauceLabs/sagas.js
@@ -19,7 +19,7 @@ import { URLS } from 'common/urls';
 import { SAUCE_LABS } from 'common/constants/pluginNames';
 import { availableIntegrationsByPluginNameSelector } from 'controllers/plugins';
 import { fetchDataAction, createFetchPredicate } from 'controllers/fetch';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import {
   EXECUTE_SAUCE_LABS_COMMAND_ACTION,
   BULK_EXECUTE_SAUCE_LABS_COMMAND_ACTION,
@@ -28,7 +28,7 @@ import {
 import { updateLoadingAction } from './actionCreators';
 
 function* executeSauceLabsCommand({ payload: { command, integrationId, data = {} } }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
 
   yield put(
     fetchDataAction(SAUCE_LABS_COMMANDS_NAMESPACES_MAP[command])(

--- a/app/src/controllers/plugins/sagas.js
+++ b/app/src/controllers/plugins/sagas.js
@@ -26,7 +26,7 @@ import { hideModalAction } from 'controllers/modal';
 import { showScreenLockAction, hideScreenLockAction } from 'controllers/screenLock';
 import { fetch, omit } from 'common/utils';
 import { userIdSelector } from 'controllers/user';
-import { projectKeySelector } from 'controllers/project';
+import { urlProjectKeySelector } from 'controllers/pages';
 import {
   NAMESPACE,
   FETCH_PLUGINS,
@@ -60,7 +60,7 @@ import { fetchUiExtensions, fetchExtensionsMetadata } from './uiExtensions';
 function* addIntegration({ payload: { data, isGlobal, pluginName, callback }, meta }) {
   yield put(showScreenLockAction());
   try {
-    const projectKey = yield select(projectKeySelector);
+    const projectKey = yield select(urlProjectKeySelector);
     const integrationUrl = isGlobal
       ? URLS.newGlobalIntegration(pluginName)
       : URLS.newProjectIntegration(projectKey, pluginName);
@@ -105,7 +105,7 @@ function* watchAddIntegration() {
 function* updateIntegration({ payload: { data, isGlobal, pluginName, id, callback }, meta }) {
   yield put(showScreenLockAction());
   try {
-    const projectKey = yield select(projectKeySelector);
+    const projectKey = yield select(urlProjectKeySelector);
     const integrationUrl = isGlobal
       ? URLS.globalIntegration(id)
       : URLS.projectIntegration(projectKey, id);
@@ -145,7 +145,7 @@ function* watchUpdateIntegration() {
 function* removeIntegration({ payload: { id, isGlobal, callback } }) {
   yield put(showScreenLockAction());
   try {
-    const projectKey = yield select(projectKeySelector);
+    const projectKey = yield select(urlProjectKeySelector);
     const url = isGlobal ? URLS.globalIntegration(id) : URLS.projectIntegration(projectKey, id);
 
     yield call(fetch, url, {
@@ -177,7 +177,7 @@ function* watchRemoveIntegration() {
 function* removeIntegrationsByType({ payload: instanceType }) {
   yield put(showScreenLockAction());
   try {
-    const projectKey = yield select(projectKeySelector);
+    const projectKey = yield select(urlProjectKeySelector);
     yield call(fetch, URLS.removeProjectIntegrationByType(projectKey, instanceType), {
       method: 'delete',
     });

--- a/app/src/controllers/project/index.js
+++ b/app/src/controllers/project/index.js
@@ -73,7 +73,6 @@ export {
   projectNotificationsLoadingSelector,
   projectNotificationsStateSelector,
   projectOrganizationSlugSelector,
-  projectKeySelector,
 } from './selectors';
 export { normalizeAttributesWithPrefix } from './utils';
 export { projectSagas } from './sagas';

--- a/app/src/controllers/project/sagas.js
+++ b/app/src/controllers/project/sagas.js
@@ -76,11 +76,7 @@ import {
   updateProjectNotificationSuccessAction,
   setProjectNotificationsLoadingAction,
 } from './actionCreators';
-import {
-  projectNotificationsConfigurationSelector,
-  patternsSelector,
-  projectKeySelector,
-} from './selectors';
+import { projectNotificationsConfigurationSelector, patternsSelector } from './selectors';
 
 function* updateDefectSubType({ payload: subTypes }) {
   try {
@@ -488,7 +484,7 @@ function* watchShowFilterOnLaunches() {
 
 function* updateProjectFilterPreferences({ payload = {} }) {
   const { filterId, method } = payload;
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(urlProjectKeySelector);
   const userId = yield select(userIdSelector);
   yield call(fetch, URLS.projectPreferences(projectKey, userId, filterId), { method });
 }

--- a/app/src/controllers/project/selectors.js
+++ b/app/src/controllers/project/selectors.js
@@ -51,8 +51,6 @@ export const projectAttributesSelector = (state) => projectConfigSelector(state)
 export const projectOrganizationSlugSelector = (state) =>
   projectInfoSelector(state).organizationSlug || '';
 
-export const projectKeySelector = (state) => projectInfoSelector(state).projectKey || '';
-
 export const autoAnalysisEnabledSelector = (state) =>
   projectAttributesSelector(state)[AA_ATTRIBUTE_ENABLED_KEY];
 

--- a/app/src/controllers/test/sagas.js
+++ b/app/src/controllers/test/sagas.js
@@ -18,11 +18,11 @@ import { takeEvery, all, put, select } from 'redux-saga/effects';
 import { fetchDataAction } from 'controllers/fetch';
 import { launchIdSelector, suiteIdSelector } from 'controllers/pages';
 import { URLS } from 'common/urls';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { FETCH_TESTS, NAMESPACE } from './constants';
 
 function* getTests({ payload }) {
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const launchId = yield select(launchIdSelector);
   const suiteId = yield select(suiteIdSelector);
   yield put(

--- a/app/src/controllers/testItem/sagas.js
+++ b/app/src/controllers/testItem/sagas.js
@@ -21,7 +21,7 @@ import {
   bulkFetchDataAction,
   createFetchPredicate,
 } from 'controllers/fetch';
-import { showFilterOnLaunchesAction, projectKeySelector } from 'controllers/project';
+import { showFilterOnLaunchesAction } from 'controllers/project';
 import { activeFilterSelector } from 'controllers/filter';
 import { put, select, all, takeEvery, take, call } from 'redux-saga/effects';
 import {
@@ -131,7 +131,7 @@ export function* fetchParentItems() {
 
 export function* fetchParentLaunch({ payload = {} } = {}) {
   const {
-    projectKey = yield select(projectKeySelector),
+    projectKey = yield select(activeProjectKeySelector),
     launchId = yield select(launchIdSelector),
   } = payload;
 
@@ -178,7 +178,7 @@ function* fetchTestItems({ payload = {} }) {
   if (itemIds.length > 1) {
     parentId = itemIds[itemIds.length - 1];
   }
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const namespace = yield select(namespaceSelector, offset);
   const query = yield select(queryParametersSelector, namespace);
   const pageQuery = yield select(pagePropertiesSelector);
@@ -292,7 +292,7 @@ export function* fetchTestItemsFromLogPage({ payload = {} }) {
   const stepParams = yield call(calculateStepPagination, { next, offset });
   yield call(fetchTestItems, { payload: { offset, params: stepParams } });
   const testItems = yield select(itemsSelector);
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const testItem = next ? testItems[0] : testItems[testItems.length - 1];
   const { launchId, path } = testItem;
   const testItemIds = [launchId, ...path.split('.')].join('/');
@@ -322,7 +322,7 @@ function* watchTestItemsFromLogPage() {
 
 function* deleteTestItems({ payload: { items, callback } }) {
   const ids = items.map((item) => item.id).join(',');
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   yield put(showScreenLockAction());
   try {
     yield call(fetch, URLS.testItems(projectKey, ids), {

--- a/app/src/controllers/testItem/selectors.js
+++ b/app/src/controllers/testItem/selectors.js
@@ -51,11 +51,8 @@ import { omit } from 'common/utils';
 import { PAGE_KEY, SIZE_KEY } from 'controllers/pagination';
 import { SORTING_KEY } from 'controllers/sorting';
 import { clusterItemsSelector } from 'controllers/uniqueErrors/clusterItems/selectors';
-import {
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-  defectTypesSelector,
-} from 'controllers/project';
+import { projectOrganizationSlugSelector, defectTypesSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import {
   DEFAULT_SORTING,
   TEST_ITEMS_TYPE_LIST,
@@ -161,7 +158,7 @@ const itemTitleFormatter = (item) => {
 };
 
 export const breadcrumbsSelector = createSelector(
-  projectKeySelector,
+  activeProjectKeySelector,
   activeFilterSelector,
   parentItemsSelector,
   testItemIdsArraySelector,
@@ -425,7 +422,7 @@ export const defectLinkSelector = createSelector(
 );
 
 export const testCaseNameLinkSelector = (state) => (ownProps) => {
-  const projectKey = projectKeySelector(state);
+  const projectKey = activeProjectKeySelector(state);
   const organizationSlug = projectOrganizationSlugSelector(state);
   const payload = {
     projectKey,
@@ -539,7 +536,7 @@ export const uniqueErrorsLinkSelector = createSelector(
 );
 
 export const getLogItemLinkSelector = createSelector(
-  projectKeySelector,
+  activeProjectKeySelector,
   projectOrganizationSlugSelector,
   (projectKey, organizationSlug) => (testItem) => {
     const payload = {

--- a/app/src/controllers/uniqueErrors/clusterItems/sagas.js
+++ b/app/src/controllers/uniqueErrors/clusterItems/sagas.js
@@ -26,7 +26,7 @@ import {
 import { showDefaultErrorNotification } from 'controllers/notification';
 import { SORTING_KEY } from 'controllers/sorting';
 import { launchIdSelector } from 'controllers/pages';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import {
   fetchClusterItemsStartAction,
   fetchClusterItemsSuccessAction,
@@ -38,7 +38,7 @@ import { LOAD_MORE_CLUSTER_ITEMS, PAGE_SIZE, REQUEST_CLUSTER_ITEMS } from './con
 function* fetchClusterItems({ payload = {} }) {
   const { id } = payload;
   const { page } = yield select(clusterItemsSelector, id);
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const launchId = yield select(launchIdSelector);
   let pageNumber = 1;
   if (!isEmptyObject(page)) {

--- a/app/src/controllers/uniqueErrors/sagas.js
+++ b/app/src/controllers/uniqueErrors/sagas.js
@@ -36,7 +36,7 @@ import { NAMESPACE as PLUGINS_NAMESPACE } from 'controllers/plugins/constants';
 import { pluginsSelector } from 'controllers/plugins';
 
 import { COMMAND_GET_CLUSTERS } from 'controllers/plugins/uiExtensions/constants';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import {
   CLEAR_CLUSTER_ITEMS,
   clusterItemsSagas,
@@ -68,7 +68,7 @@ function* fetchClusters(payload = {}) {
   const { refresh = false } = payload;
   const launchId = yield select(launchIdSelector);
   const parentLaunch = yield select(launchSelector);
-  const projectKey = yield select(projectKeySelector);
+  const projectKey = yield select(activeProjectKeySelector);
   const isPathNameChanged = yield select(pathnameChangedSelector);
   const selectedItems = yield select(selectedClusterItemsSelector);
 

--- a/app/src/controllers/user/selectors.js
+++ b/app/src/controllers/user/selectors.js
@@ -32,7 +32,7 @@ export const startTimeFormatSelector = (state) =>
 export const photoTimeStampSelector = (state) => settingsSelector(state).photoTimeStamp || null;
 export const assignedProjectsSelector = (state) => userInfoSelector(state).assignedProjects || {};
 export const userAccountRoleSelector = (state) => userInfoSelector(state).userRole || '';
-export const activeProjectKeySelector = (state) => userSelector(state).activeProjectKey;
+export const activeProjectKeySelector = (state) => userSelector(state).activeProjectKey || '';
 export const activeProjectRoleSelector = (state) => {
   const activeProjectKey = activeProjectKeySelector(state);
   const assignedProject = assignedProjectsSelector(state)[activeProjectKey];

--- a/app/src/layouts/appLayout/appHeader/appHeader.jsx
+++ b/app/src/layouts/appLayout/appHeader/appHeader.jsx
@@ -43,7 +43,6 @@ export class AppHeader extends Component {
   };
 
   static defaultProps = {
-    assignedProjects: {},
     sideMenuOpened: false,
     toggleSideMenu: () => {},
   };

--- a/app/src/layouts/appLayout/appSidebar/appSidebar.jsx
+++ b/app/src/layouts/appLayout/appSidebar/appSidebar.jsx
@@ -22,6 +22,7 @@ import {
   activeProjectSelector,
   activeProjectRoleSelector,
   userAccountRoleSelector,
+  activeProjectKeySelector,
 } from 'controllers/user';
 import { SIDEBAR_EVENTS } from 'components/main/analytics/events';
 import { FormattedMessage } from 'react-intl';
@@ -40,7 +41,7 @@ import {
 import { uiExtensionSidebarComponentsSelector } from 'controllers/plugins';
 import { Sidebar } from 'layouts/common/sidebar';
 import FiltersIcon from 'common/img/filters-icon-inline.svg';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
 import DashboardIcon from './img/dashboard-icon-inline.svg';
 import LaunchesIcon from './img/launches-icon-inline.svg';
 import DebugIcon from './img/debug-icon-inline.svg';
@@ -56,7 +57,7 @@ import { ProjectSelector } from '../../common/projectSelector';
   accountRole: userAccountRoleSelector(state),
   extensionComponents: uiExtensionSidebarComponentsSelector(state),
   organizationSlug: projectOrganizationSlugSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @track()
 export class AppSidebar extends Component {

--- a/app/src/pages/admin/allUsersPage/allUsersGrid/nameColumn/nameColumn.jsx
+++ b/app/src/pages/admin/allUsersPage/allUsersGrid/nameColumn/nameColumn.jsx
@@ -22,14 +22,13 @@ import track from 'react-tracking';
 import classNames from 'classnames/bind';
 import { fetch } from 'common/utils';
 import { ADMINISTRATOR, USER } from 'common/constants/accountRoles';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { URLS } from 'common/urls';
 import { fetchAllUsersAction } from 'controllers/administrate/allUsers';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { showModalAction } from 'controllers/modal';
 import { UserAvatar } from 'pages/inside/common/userAvatar';
 import { ADMIN_ALL_USERS_PAGE_EVENTS } from 'components/main/analytics/events';
-import { projectKeySelector } from 'controllers/project';
 import styles from './nameColumn.scss';
 
 const cx = classNames.bind(styles);
@@ -47,7 +46,7 @@ const messages = defineMessages({
 @connect(
   (state) => ({
     currentUser: userIdSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showModal: showModalAction,

--- a/app/src/pages/admin/projectEventsPage/eventsEntities.jsx
+++ b/app/src/pages/admin/projectEventsPage/eventsEntities.jsx
@@ -97,7 +97,7 @@ import {
   actionMessages,
   objectTypesMessages,
 } from 'common/constants/localization/eventsLocalization';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 
 const messages = defineMessages({
   timeCol: { id: 'EventsGrid.timeCol', defaultMessage: 'Time' },
@@ -115,7 +115,7 @@ const messages = defineMessages({
 });
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {},
 )

--- a/app/src/pages/admin/projectEventsPage/projectEventsPage.jsx
+++ b/app/src/pages/admin/projectEventsPage/projectEventsPage.jsx
@@ -27,12 +27,12 @@ import {
 } from 'controllers/administrate/events';
 import { ENTITY_CREATION_DATE } from 'components/filterEntities/constants';
 import { SORTING_DESC, withSortingURL } from 'controllers/sorting';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { EventsGrid } from './eventsGrid';
 import { EventsToolbar } from './eventsToolbar';
 
 @connect((state) => ({
-  url: URLS.events(projectKeySelector),
+  url: URLS.events(activeProjectKeySelector),
   events: eventsSelector(state),
   loading: loadingSelector(state),
 }))

--- a/app/src/pages/common/membersPage/membersGrid/personalInfo/personalInfo.jsx
+++ b/app/src/pages/common/membersPage/membersGrid/personalInfo/personalInfo.jsx
@@ -22,14 +22,14 @@ import { FormattedMessage } from 'react-intl';
 import { ADMINISTRATOR } from 'common/constants/accountRoles';
 import { userIdSelector } from 'controllers/user';
 import { UserAvatar } from 'pages/inside/common/userAvatar';
-import { projectKeySelector } from 'controllers/project';
+import { urlProjectKeySelector } from 'controllers/pages';
 import styles from './personalInfo.scss';
 
 const cx = classNames.bind(styles);
 
 @connect((state) => ({
   currentUser: userIdSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: urlProjectKeySelector(state),
 }))
 export class PersonalInfo extends Component {
   static propTypes = {

--- a/app/src/pages/common/membersPage/membersGrid/unassignButton/unassignButton.jsx
+++ b/app/src/pages/common/membersPage/membersGrid/unassignButton/unassignButton.jsx
@@ -25,7 +25,7 @@ import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { canAssignUnassignInternalUser } from 'common/utils/permissions';
-import { projectIdSelector } from 'controllers/pages';
+import { projectIdSelector, urlProjectKeySelector } from 'controllers/pages';
 import {
   activeProjectRoleSelector,
   userAccountRoleSelector,
@@ -35,7 +35,6 @@ import {
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { MEMBERS_PAGE_EVENTS } from 'components/main/analytics/events';
 import UnassignIcon from 'common/img/unassign-inline.svg';
-import { projectKeySelector } from 'controllers/project';
 
 const messages = defineMessages({
   anassignUser: {
@@ -91,7 +90,7 @@ const messages = defineMessages({
     entryType:
       assignedProjectsSelector(state)[projectIdSelector(state)] &&
       assignedProjectsSelector(state)[projectIdSelector(state)].entryType,
-    projectKey: projectKeySelector(state),
+    projectKey: urlProjectKeySelector(state),
   }),
   { showNotification, showModalAction },
 )

--- a/app/src/pages/common/settingsPage/autoAnalysisTab/autoAnalysisTab.jsx
+++ b/app/src/pages/common/settingsPage/autoAnalysisTab/autoAnalysisTab.jsx
@@ -22,6 +22,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { activeProjectRoleSelector, userAccountRoleSelector } from 'controllers/user';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { canUpdateSettings } from 'common/utils/permissions';
+import { urlProjectKeySelector } from 'controllers/pages';
 import { showModalAction } from 'controllers/modal';
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
@@ -31,7 +32,6 @@ import {
   normalizeAttributesWithPrefix,
   analyzerAttributesSelector,
   ANALYZER_ATTRIBUTE_PREFIX,
-  projectKeySelector,
 } from 'controllers/project';
 import { analyzerExtensionsSelector } from 'controllers/appInfo/selectors';
 import { AnalysisForm } from './analysisForm/analysisForm';
@@ -78,7 +78,7 @@ const messages = defineMessages({
     userRole: activeProjectRoleSelector(state),
     analyzerConfiguration: analyzerAttributesSelector(state),
     analyzerExtensions: analyzerExtensionsSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: urlProjectKeySelector(state),
   }),
   {
     fetchConfigurationAttributesAction,

--- a/app/src/pages/common/settingsPage/autoAnalysisTab/modals/generateIndexModal/generateIndexModal.jsx
+++ b/app/src/pages/common/settingsPage/autoAnalysisTab/modals/generateIndexModal/generateIndexModal.jsx
@@ -22,13 +22,14 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
-import { fetchProjectAction, projectKeySelector } from 'controllers/project';
+import { fetchProjectAction } from 'controllers/project';
 import {
   showNotification,
   showDefaultErrorNotification,
   NOTIFICATION_TYPES,
 } from 'controllers/notification';
 import { withModal, ModalLayout } from 'components/main/modal';
+import { urlProjectKeySelector } from 'controllers/pages';
 import styles from './generateIndexModal.scss';
 
 const cx = classNames.bind(styles);
@@ -62,7 +63,7 @@ const messages = defineMessages({
 @withModal('generateIndexModal')
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: urlProjectKeySelector(state),
   }),
   {
     fetchProjectAction,

--- a/app/src/pages/common/settingsPage/autoAnalysisTab/modals/removeIndexModal/removeIndexModal.jsx
+++ b/app/src/pages/common/settingsPage/autoAnalysisTab/modals/removeIndexModal/removeIndexModal.jsx
@@ -28,7 +28,7 @@ import {
   NOTIFICATION_TYPES,
 } from 'controllers/notification';
 import { withModal, ModalLayout } from 'components/main/modal';
-import { projectKeySelector } from 'controllers/project';
+import { urlProjectKeySelector } from 'controllers/pages';
 import styles from './removeIndexModal.scss';
 
 const cx = classNames.bind(styles);
@@ -54,7 +54,7 @@ const messages = defineMessages({
 @withModal('removeIndexModal')
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: urlProjectKeySelector(state),
   }),
   { showNotification, showDefaultErrorNotification },
 )

--- a/app/src/pages/inside/common/dashboardPageHeader/dashboardPageHeader.jsx
+++ b/app/src/pages/inside/common/dashboardPageHeader/dashboardPageHeader.jsx
@@ -27,7 +27,8 @@ import {
 import { dashboardItemsSelector, dashboardItemPropTypes } from 'controllers/dashboard';
 import { InputDropdown } from 'components/inputs/inputDropdown';
 import { NavLink } from 'components/main/navLink';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { AddDashboardButton } from './addDashboardButton';
 import styles from './dashboardPageHeader.scss';
 
@@ -45,7 +46,7 @@ const DASHBOARD_PAGE_ITEM_VALUE = 'All';
   organizationSlug: projectOrganizationSlugSelector(state),
   dashboards: dashboardItemsSelector(state),
   activeItemId: activeDashboardIdSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @injectIntl
 export class DashboardPageHeader extends Component {

--- a/app/src/pages/inside/common/filterEntitiesGroups/launchLevelEntities.jsx
+++ b/app/src/pages/inside/common/filterEntitiesGroups/launchLevelEntities.jsx
@@ -50,8 +50,9 @@ import {
   CONDITION_EQ,
   ENTITY_ATTRIBUTE,
 } from 'components/filterEntities/constants';
-import { defectTypesSelector, projectKeySelector } from 'controllers/project';
+import { defectTypesSelector } from 'controllers/project';
 import { LAUNCHES_PAGE_EVENTS } from 'components/main/analytics/events';
+import { activeProjectKeySelector } from 'controllers/user';
 
 const messages = defineMessages({
   NameTitle: {
@@ -161,7 +162,7 @@ const DEFECT_ENTITY_ID_BASE = 'statistics$defects$';
 @injectIntl
 @connect((state) => ({
   defectTypes: defectTypesSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class LaunchLevelEntities extends Component {
   static propTypes = {

--- a/app/src/pages/inside/common/filterEntitiesGroups/stepLevelEntities.jsx
+++ b/app/src/pages/inside/common/filterEntitiesGroups/stepLevelEntities.jsx
@@ -66,7 +66,7 @@ import {
   ENTITY_ATTRIBUTE,
   ENTITY_NEW_FAILURE,
 } from 'components/filterEntities/constants';
-import { defectTypesSelector, patternsSelector, projectKeySelector } from 'controllers/project';
+import { defectTypesSelector, patternsSelector } from 'controllers/project';
 import { launchIdSelector } from 'controllers/pages';
 import {
   getQueryNamespace,
@@ -79,6 +79,7 @@ import { pageEventsMap } from 'components/main/analytics';
 import { connectRouter } from 'common/utils';
 import { createNamespacedQuery } from 'common/utils/routingUtils';
 import { PROVIDER_TYPE_BASELINE } from 'controllers/testItem/constants';
+import { activeProjectKeySelector } from 'controllers/user';
 
 const messages = defineMessages({
   NameTitle: {
@@ -314,7 +315,7 @@ const descriptionStepLevelEntity = bindMessageToValidator(
   patterns: patternsSelector(state),
   level: levelSelector(state),
   query: queryParametersSelector(state, namespaceSelector(state)),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class StepLevelEntities extends Component {
   static propTypes = {

--- a/app/src/pages/inside/common/filterEntitiesGroups/suiteLevelEntities.jsx
+++ b/app/src/pages/inside/common/filterEntitiesGroups/suiteLevelEntities.jsx
@@ -45,10 +45,11 @@ import {
   CONDITION_EQ,
   ENTITY_ATTRIBUTE,
 } from 'components/filterEntities/constants';
-import { defectTypesSelector, projectKeySelector } from 'controllers/project';
+import { defectTypesSelector } from 'controllers/project';
 import { launchIdSelector } from 'controllers/pages';
 import { pageEventsMap } from 'components/main/analytics';
 import { levelSelector } from 'controllers/testItem';
+import { activeProjectKeySelector } from 'controllers/user';
 
 const messages = defineMessages({
   NameTitle: {
@@ -148,7 +149,7 @@ const DEFECT_ENTITY_ID_BASE = 'statistics$defects$';
   defectTypes: defectTypesSelector(state),
   launchId: launchIdSelector(state),
   level: levelSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class SuiteLevelEntities extends Component {
   static propTypes = {

--- a/app/src/pages/inside/common/launchSuiteGrid/hamburger/hamburger.jsx
+++ b/app/src/pages/inside/common/launchSuiteGrid/hamburger/hamburger.jsx
@@ -33,8 +33,9 @@ import {
   activeProjectRoleSelector,
   userIdSelector,
   userAccountRoleSelector,
+  activeProjectKeySelector,
 } from 'controllers/user';
-import { enabledPattersSelector, projectKeySelector } from 'controllers/project';
+import { enabledPattersSelector } from 'controllers/project';
 import { analyzerExtensionsSelector } from 'controllers/appInfo';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { ANALYZER_TYPES } from 'common/constants/analyzerTypes';
@@ -95,7 +96,7 @@ const messages = defineMessages({
     projectRole: activeProjectRoleSelector(state),
     userId: userIdSelector(state),
     accountRole: userAccountRoleSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     enabledPatterns: enabledPattersSelector(state),
     analyzerExtensions: analyzerExtensionsSelector(state),
   }),

--- a/app/src/pages/inside/common/modals/editItemModal/editItemModal.jsx
+++ b/app/src/pages/inside/common/modals/editItemModal/editItemModal.jsx
@@ -31,6 +31,7 @@ import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { LAUNCH_ITEM_TYPES } from 'common/constants/launchItemTypes';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import {
+  activeProjectKeySelector,
   activeProjectRoleSelector,
   userAccountRoleSelector,
   userIdSelector,
@@ -46,7 +47,6 @@ import { canEditLaunch } from 'common/utils/permissions';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { TestParameters } from 'pages/inside/common/testParameters';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
-import { projectKeySelector } from 'controllers/project';
 import styles from './editItemModal.scss';
 
 const cx = classNames.bind(styles);
@@ -126,7 +126,7 @@ const messages = defineMessages({
     userAccountRole: userAccountRoleSelector(state),
     userProjectRole: activeProjectRoleSelector(state),
     userId: userIdSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/common/modals/editItemsModal/editItemsModal.jsx
+++ b/app/src/pages/inside/common/modals/editItemsModal/editItemsModal.jsx
@@ -38,7 +38,7 @@ import { AttributeListField } from 'components/main/attributeList';
 import { InputDropdown } from 'components/inputs/inputDropdown';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import track from 'react-tracking';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './editItemsModal.scss';
 
 const cx = classNames.bind(styles);
@@ -135,7 +135,7 @@ const makeDescriptionOptions = (formatMessage) => [
 @formValues('descriptionAction', 'uniqueAttributes')
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/common/statusDropdown/statusDropdown.jsx
+++ b/app/src/pages/inside/common/statusDropdown/statusDropdown.jsx
@@ -26,7 +26,7 @@ import { InputDropdown } from 'components/inputs/inputDropdown';
 import { formatStatus } from 'common/utils/localizationUtils';
 import { PASSED, FAILED, SKIPPED, IN_PROGRESS } from 'common/constants/testStatuses';
 import { TestItemStatus } from 'pages/inside/common/testItemStatus';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { ATTRIBUTE_KEY_MANUALLY } from './constants';
 import styles from './statusDropdown.scss';
 
@@ -45,7 +45,7 @@ const messages = defineMessages({
 
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showMessage: showNotification,

--- a/app/src/pages/inside/dashboardItemPage/dashboardItemPage.jsx
+++ b/app/src/pages/inside/dashboardItemPage/dashboardItemPage.jsx
@@ -39,7 +39,11 @@ import {
   deleteDashboardAction,
   updateDashboardAction,
 } from 'controllers/dashboard';
-import { userInfoSelector, activeProjectRoleSelector } from 'controllers/user';
+import {
+  userInfoSelector,
+  activeProjectRoleSelector,
+  activeProjectKeySelector,
+} from 'controllers/user';
 import {
   PROJECT_DASHBOARD_PAGE,
   PROJECT_DASHBOARD_PRINT_PAGE,
@@ -55,7 +59,7 @@ import { DASHBOARD_PAGE_EVENTS } from 'components/main/analytics/events';
 import { DashboardPageHeader } from 'pages/inside/common/dashboardPageHeader';
 import AddWidgetIcon from 'common/img/add-widget-inline.svg';
 import ExportIcon from 'common/img/export-inline.svg';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
 import { getUpdatedWidgetsList } from './modals/common/utils';
 import EditIcon from './img/edit-inline.svg';
 import CancelIcon from './img/cancel-inline.svg';
@@ -119,7 +123,7 @@ const messages = defineMessages({
     projectRole: activeProjectRoleSelector(state),
     activeDashboardId: activeDashboardIdSelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showModalAction,

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckControls.jsx
@@ -31,7 +31,7 @@ import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { DEFAULT_LAUNCHES_LIMIT } from 'controllers/testItem';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getWidgetModeOptions } from './utils/getWidgetModeOptions';
 import {
   FiltersControl,
@@ -83,7 +83,7 @@ const attributeKeyValidator = (formatMessage) => (attributes) =>
   ]);
 
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @injectIntl
 export class ComponentHealthCheckControls extends Component {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckTableViewControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckTableViewControls.jsx
@@ -33,7 +33,7 @@ import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { DEFAULT_LAUNCHES_LIMIT } from 'controllers/testItem';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getWidgetModeOptions } from './utils/getWidgetModeOptions';
 import {
   FiltersControl,
@@ -98,7 +98,7 @@ const attributeKeyValidator = (formatMessage) => (attributes) =>
   ]);
 
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @injectIntl
 export class ComponentHealthCheckTableViewControls extends Component {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/filtersControl/filtersControl.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/filtersControl/filtersControl.jsx
@@ -21,7 +21,7 @@ import { injectIntl, defineMessages } from 'react-intl';
 import { change } from 'redux-form';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import AddFilterIcon from 'common/img/add-filter-inline.svg';
 import { fetch, debounce } from 'common/utils';
@@ -36,7 +36,6 @@ import {
 import { PAGE_KEY, SIZE_KEY } from 'controllers/pagination';
 import { GhostButton } from 'components/buttons/ghostButton';
 import { SearchableFilterList } from 'pages/inside/common/searchableFilterList';
-import { projectKeySelector } from 'controllers/project';
 import { WIDGET_WIZARD_FORM } from '../../../constants';
 import { LockedActiveFilter } from './lockedActiveFilter';
 import { FilterEdit } from './filterEdit';
@@ -93,7 +92,7 @@ const messages = defineMessages({
     filters: filtersSelector(state),
     pagination: filtersPaginationSelector(state),
     loading: loadingSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     changeWizardForm: (field, value) => change(WIDGET_WIZARD_FORM, field, value, null),

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/cumulativeTrendControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/cumulativeTrendControls.jsx
@@ -30,7 +30,7 @@ import { URLS } from 'common/urls';
 import { STATS_FAILED, STATS_PASSED, STATS_SKIPPED } from 'common/constants/statistics';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { DEFAULT_LAUNCHES_LIMIT } from 'controllers/testItem';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import {
   FiltersControl,
   InputControl,
@@ -94,7 +94,7 @@ const attributeKeyValidator = (formatMessage) => (attributes) =>
   ]);
 
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @injectIntl
 export class CumulativeTrendControls extends Component {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/flakyTestCasesTableControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/flakyTestCasesTableControls.jsx
@@ -21,7 +21,7 @@ import { FieldProvider } from 'components/fields/fieldProvider';
 import { injectIntl, defineMessages } from 'react-intl';
 import { URLS } from 'common/urls';
 import { validate, bindMessageToValidator, commonValidators } from 'common/utils/validation';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { ITEMS_INPUT_WIDTH } from './constants';
 import { InputControl, TagsControl, CheckboxControl } from './controls';
 
@@ -58,7 +58,7 @@ const itemsValidator = (message) =>
 
 @injectIntl
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class FlakyTestCasesTableControls extends Component {
   static propTypes = {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/mostFailedTestCasesTableControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/mostFailedTestCasesTableControls.jsx
@@ -21,7 +21,7 @@ import { FieldProvider } from 'components/fields/fieldProvider';
 import { injectIntl, defineMessages } from 'react-intl';
 import { URLS } from 'common/urls';
 import { validate, bindMessageToValidator } from 'common/utils/validation';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getWidgetCriteriaOptions } from './utils/getWidgetCriteriaOptions';
 import {
   SKIPPED_FAILED_LAUNCHES_OPTIONS,
@@ -68,7 +68,7 @@ const validators = {
 
 @injectIntl
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class MostFailedTestCasesTableControls extends Component {
   static propTypes = {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/mostPopularPatternsControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/mostPopularPatternsControls.jsx
@@ -25,7 +25,7 @@ import { ModalField } from 'components/main/modal';
 import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
 import { bindMessageToValidator, commonValidators, validate } from 'common/utils/validation';
 import { FIELD_LABEL_WIDTH } from 'pages/inside/dashboardItemPage/modals/common/widgetControls/controls/constants';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { FiltersControl, InputControl, TogglerControl } from './controls';
 import { getWidgetModeOptions } from './utils/getWidgetModeOptions';
 import { ITEMS_INPUT_WIDTH } from './constants';
@@ -61,7 +61,7 @@ const attributeKeyValidator = (message) => bindMessageToValidator(validate.attri
 
 @injectIntl
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class MostPopularPatternsControls extends Component {
   static propTypes = {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/mostTimeConsumingTestCasesControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/mostTimeConsumingTestCasesControls.jsx
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
 import { URLS } from 'common/urls';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getWidgetCriteriaOptions } from './utils/getWidgetCriteriaOptions';
 import { PASSED_FAILED_LAUNCHES_OPTIONS } from './constants';
 import { DropdownControl, TogglerControl, TagsControl, CheckboxControl } from './controls';
@@ -66,7 +66,7 @@ const validators = {
 
 @injectIntl
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class MostTimeConsumingTestCasesControls extends Component {
   static propTypes = {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/passingRatePerLaunchControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/passingRatePerLaunchControls.jsx
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { URLS } from 'common/urls';
 import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getWidgetModeOptions } from './utils/getWidgetModeOptions';
 import { TogglerControl, TagsControl } from './controls';
 
@@ -47,7 +47,7 @@ const validators = {
 
 @injectIntl
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class PassingRatePerLaunchControls extends Component {
   static propTypes = {

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/productStatusControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/productStatusControls.jsx
@@ -18,7 +18,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, defineMessages } from 'react-intl';
 import { connect } from 'react-redux';
-import { defectTypesSelector, projectKeySelector } from 'controllers/project';
+import { defectTypesSelector } from 'controllers/project';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { URLS } from 'common/urls';
 import {
@@ -34,6 +34,7 @@ import {
 } from 'common/constants/statistics';
 import { ENTITY_START_TIME, ENTITY_STATUS } from 'components/filterEntities/constants';
 import { CHART_MODES, MODES_VALUES } from 'common/constants/chartModes';
+import { activeProjectKeySelector } from 'controllers/user';
 import { getWidgetCriteriaOptions } from './utils/getWidgetCriteriaOptions';
 import { getWidgetModeOptions } from './utils/getWidgetModeOptions';
 import { GROUPED_DEFECT_TYPES_OPTIONS } from './constants';
@@ -103,8 +104,8 @@ const validators = {
 @injectIntl
 @connect((state) => ({
   defectTypes: defectTypesSelector(state),
-  filtersSearchUrl: URLS.filtersSearch(projectKeySelector(state)),
-  projectKey: projectKeySelector(state),
+  filtersSearchUrl: URLS.filtersSearch(activeProjectKeySelector(state)),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class ProductStatusControls extends Component {
   static propTypes = {

--- a/app/src/pages/inside/dashboardItemPage/modals/editWidgetModal/editWidgetModal.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/editWidgetModal/editWidgetModal.jsx
@@ -24,14 +24,13 @@ import { injectIntl, defineMessages } from 'react-intl';
 import { destroy, getFormValues, isDirty, isValid } from 'redux-form';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
-import { activeProjectSelector } from 'controllers/user';
+import { activeProjectKeySelector } from 'controllers/user';
 import { withModal, ModalLayout } from 'components/main/modal';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { showScreenLockAction, hideScreenLockAction } from 'controllers/screenLock';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { getWidgets } from 'pages/inside/dashboardItemPage/modals/common/widgets';
 import { getWidgetModeValuesString } from 'components/main/analytics/events/common/widgetPages/utils';
-import { projectKeySelector } from 'controllers/project';
 import { EditWidgetControlsSectionForm } from './editWidgetControlsSectionForm';
 import { EditWidgetInfoSection } from './editWidgetInfoSection';
 import { WIDGET_WIZARD_FORM } from '../common/constants';
@@ -55,11 +54,10 @@ const messages = defineMessages({
 @withModal('editWidgetModal')
 @connect(
   (state) => ({
-    projectId: activeProjectSelector(state),
     widgetSettings: getFormValues(WIDGET_WIZARD_FORM)(state),
     dirty: isDirty(WIDGET_WIZARD_FORM)(state),
     valid: isValid(WIDGET_WIZARD_FORM)(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showScreenLockAction,
@@ -85,7 +83,6 @@ export class EditWidgetModal extends Component {
       widget: PropTypes.object,
       eventsInfo: PropTypes.object,
     }),
-    projectId: PropTypes.string,
     tracking: PropTypes.shape({
       trackEvent: PropTypes.func,
       getTrackingData: PropTypes.func,
@@ -99,7 +96,6 @@ export class EditWidgetModal extends Component {
       widget: {},
     },
     widgetSettings: {},
-    projectId: '',
   };
 
   constructor(props) {
@@ -222,7 +218,6 @@ export class EditWidgetModal extends Component {
     const {
       intl: { formatMessage },
       data: { widget, eventsInfo },
-      projectId,
       widgetSettings,
       valid,
     } = this.props;
@@ -254,7 +249,6 @@ export class EditWidgetModal extends Component {
       >
         <div className={cx('edit-widget-modal-content')}>
           <EditWidgetInfoSection
-            projectId={projectId}
             widgetSettings={prepareWidgetDataForSubmit(this.preprocessOutputData(widgetSettings))}
             activeWidget={this.widgetInfo}
           />

--- a/app/src/pages/inside/dashboardItemPage/modals/widgetWizardModal/widgetWizardContent/widgetWizardContent.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/widgetWizardModal/widgetWizardContent/widgetWizardContent.jsx
@@ -31,7 +31,7 @@ import { getWidgets } from 'pages/inside/dashboardItemPage/modals/common/widgets
 import { provideEcGA } from 'components/main/analytics';
 import { activeDashboardIdSelector, pageSelector } from 'controllers/pages';
 import { getWidgetModeValuesString } from 'components/main/analytics/events/common/widgetPages/utils';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { WIDGET_WIZARD_FORM } from '../../common/constants';
 import { prepareWidgetDataForSubmit, getDefaultWidgetConfig } from '../../common/utils';
 import { WizardInfoSection } from './wizardInfoSection';
@@ -46,7 +46,7 @@ const cx = classNames.bind(styles);
     activeDashboardId: activeDashboardIdSelector(state),
     currentPage: pageSelector(state),
     isAnalyticsEnabled: analyticsEnabledSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     submitWidgetWizardForm: () => submit(WIDGET_WIZARD_FORM),

--- a/app/src/pages/inside/dashboardItemPage/widgetsGrid/widget/widget.jsx
+++ b/app/src/pages/inside/dashboardItemPage/widgetsGrid/widget/widget.jsx
@@ -34,7 +34,7 @@ import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { CHARTS, MULTI_LEVEL_WIDGETS_MAP, NoDataAvailable } from 'components/widgets';
 import { provideEcGA } from 'components/main/analytics';
 import { activeDashboardIdSelector } from 'controllers/pages';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { isWidgetDataAvailable } from '../../modals/common/utils';
 import { WidgetHeader } from './widgetHeader';
 import styles from './widget.scss';
@@ -61,7 +61,7 @@ const SILENT_UPDATE_TIMEOUT_FULLSCREEN = 30000;
   (state) => ({
     activeDashboardId: activeDashboardIdSelector(state),
     isAnalyticsEnabled: analyticsEnabledSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showModalAction,

--- a/app/src/pages/inside/dashboardPage/dashboardList/dashboardGrid/dashboardGridItem/dashboardGridItem.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardList/dashboardGrid/dashboardGridItem/dashboardGridItem.jsx
@@ -22,10 +22,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { canEditDashboard, canDeleteDashboard } from 'common/utils/permissions';
 import { PROJECT_DASHBOARD_ITEM_PAGE } from 'controllers/pages';
-import { activeProjectRoleSelector } from 'controllers/user';
+import { activeProjectKeySelector, activeProjectRoleSelector } from 'controllers/user';
 import { Icon } from 'components/main/icon';
 import { NavLink } from 'components/main/navLink';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
 import styles from './dashboardGridItem.scss';
 
 const cx = classNames.bind(styles);
@@ -34,7 +34,7 @@ const cx = classNames.bind(styles);
 @connect((state) => ({
   projectRole: activeProjectRoleSelector(state),
   organizationSlug: projectOrganizationSlugSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @track()
 export class DashboardGridItem extends Component {

--- a/app/src/pages/inside/dashboardPage/dashboardList/dashboardTable/dashboardTable.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardList/dashboardTable/dashboardTable.jsx
@@ -18,11 +18,15 @@ import React, { Component, Fragment } from 'react';
 import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { activeProjectSelector, activeProjectRoleSelector } from 'controllers/user';
+import {
+  activeProjectSelector,
+  activeProjectRoleSelector,
+  activeProjectKeySelector,
+} from 'controllers/user';
 import { injectIntl, defineMessages } from 'react-intl';
 import { Grid, ALIGN_CENTER } from 'components/main/grid';
 import { EmptyDashboards } from 'pages/inside/dashboardPage/dashboardList/EmptyDashboards';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
 import {
   NameColumn,
   DescriptionColumn,
@@ -61,7 +65,7 @@ const messages = defineMessages({
   projectId: activeProjectSelector(state),
   projectRole: activeProjectRoleSelector(state),
   organizationSlug: projectOrganizationSlugSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class DashboardTable extends Component {
   static propTypes = {

--- a/app/src/pages/inside/filtersPage/filterEditModal/filterEditModal.jsx
+++ b/app/src/pages/inside/filtersPage/filterEditModal/filterEditModal.jsx
@@ -28,7 +28,7 @@ import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { MarkdownEditor } from 'components/main/markdown';
 import { commonValidators, validateAsync } from 'common/utils/validation';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 
 const messages = defineMessages({
   name: {
@@ -59,7 +59,7 @@ const validateFilterNameUniqueness = (projectKey, id, name) =>
 @withModal('filterEditModal')
 @injectIntl
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @reduxForm({
   form: 'filterEditForm',

--- a/app/src/pages/inside/filtersPage/filtersPage.jsx
+++ b/app/src/pages/inside/filtersPage/filtersPage.jsx
@@ -35,6 +35,7 @@ import {
   userIdSelector,
   activeProjectRoleSelector,
   userAccountRoleSelector,
+  activeProjectKeySelector,
 } from 'controllers/user';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { withPagination, DEFAULT_PAGINATION, SIZE_KEY, PAGE_KEY } from 'controllers/pagination';
@@ -45,7 +46,6 @@ import {
   userFiltersSelector,
   showFilterOnLaunchesAction,
   hideFilterOnLaunchesAction,
-  projectKeySelector,
   projectOrganizationSlugSelector,
 } from 'controllers/project';
 import { FILTERS_PAGE, FILTERS_PAGE_EVENTS } from 'components/main/analytics/events';
@@ -76,14 +76,14 @@ const messages = defineMessages({
 @connect(
   (state) => ({
     userId: userIdSelector(state),
-    url: URLS.filters(projectKeySelector(state)),
+    url: URLS.filters(activeProjectKeySelector(state)),
     userFilters: userFiltersSelector(state),
     projectRole: activeProjectRoleSelector(state),
     accountRole: userAccountRoleSelector(state),
     filters: filtersSelector(state),
     loading: pageLoadingSelector(state),
     organizationSlug: projectOrganizationSlugSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showModalAction,

--- a/app/src/pages/inside/filtersPage/noFiltersBlock/noFiltersBlock.jsx
+++ b/app/src/pages/inside/filtersPage/noFiltersBlock/noFiltersBlock.jsx
@@ -26,14 +26,14 @@ import { PROJECT_LAUNCHES_PAGE } from 'controllers/pages';
 import AddFilterIcon from 'common/img/add-filter-inline.svg';
 import { GhostButton } from 'components/buttons/ghostButton';
 import { ALL } from 'common/constants/reservedFilterIds';
-
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './noFiltersBlock.scss';
 
 const cx = classNames.bind(styles);
 
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
   organizationSlug: projectOrganizationSlugSelector(state),
 }))
 @track()

--- a/app/src/pages/inside/launchesPage/launchesPage.jsx
+++ b/app/src/pages/inside/launchesPage/launchesPage.jsx
@@ -34,9 +34,9 @@ import { IN_PROGRESS } from 'common/constants/testStatuses';
 import { levelSelector } from 'controllers/testItem';
 import { PaginationToolbar } from 'components/main/paginationToolbar';
 import { MODAL_TYPE_IMPORT_LAUNCH } from 'pages/common/modals/importModal/constants';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { isDemoInstanceSelector } from 'controllers/appInfo';
-import { projectConfigSelector, projectKeySelector } from 'controllers/project';
+import { projectConfigSelector } from 'controllers/project';
 import { withPagination, DEFAULT_PAGINATION, SIZE_KEY, PAGE_KEY } from 'controllers/pagination';
 import { showModalAction } from 'controllers/modal';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
@@ -164,7 +164,7 @@ const messages = defineMessages({
   (state) => ({
     debugMode: debugModeSelector(state),
     userId: userIdSelector(state),
-    url: URLS.launches(projectKeySelector(state)),
+    url: URLS.launches(activeProjectKeySelector(state)),
     selectedLaunches: selectedLaunchesSelector(state),
     validationErrors: validationErrorsSelector(state),
     launches: launchesSelector(state),
@@ -174,7 +174,7 @@ const messages = defineMessages({
     projectSetting: projectConfigSelector(state),
     highlightItemId: prevTestItemSelector(state),
     isDemoInstance: isDemoInstanceSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showModalAction,

--- a/app/src/pages/inside/launchesPage/modals/launchCompareModal/launchCompareModal.jsx
+++ b/app/src/pages/inside/launchesPage/modals/launchCompareModal/launchCompareModal.jsx
@@ -34,8 +34,9 @@ import {
 import { withModal, ModalLayout } from 'components/main/modal';
 import { SpinningPreloader } from 'components/preloaders/spinningPreloader';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
-import { defectColorsSelector, projectKeySelector } from 'controllers/project';
+import { defectColorsSelector } from 'controllers/project';
 import { LaunchesComparisonChart } from 'components/widgets/singleLevelWidgets/charts';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './launchCompareModal.scss';
 
 const cx = classNames.bind(styles);
@@ -63,7 +64,7 @@ const contentParameters = {
 @injectIntl
 @connect((state) => ({
   defectColors: defectColorsSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class LaunchCompareModal extends Component {
   static propTypes = {

--- a/app/src/pages/inside/launchesPage/modals/launchFinishForceModal/launchFinishForceModal.jsx
+++ b/app/src/pages/inside/launchesPage/modals/launchFinishForceModal/launchFinishForceModal.jsx
@@ -23,11 +23,10 @@ import { injectIntl, defineMessages } from 'react-intl';
 import { withModal, ModalLayout } from 'components/main/modal';
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { STOPPED } from 'common/constants/launchStatuses';
-import { projectKeySelector } from 'controllers/project';
 import styles from './launchFinishForceModal.scss';
 
 const cx = classNames.bind(styles);
@@ -69,7 +68,7 @@ const messages = defineMessages({
 @connect(
   (state) => ({
     userId: userIdSelector(state),
-    url: URLS.launchStop(projectKeySelector(state)),
+    url: URLS.launchStop(activeProjectKeySelector(state)),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/launchesPage/modals/launchMergeModal/launchMergeModal.jsx
+++ b/app/src/pages/inside/launchesPage/modals/launchMergeModal/launchMergeModal.jsx
@@ -36,11 +36,10 @@ import { Input } from 'components/inputs/input';
 import { InputTextArea } from 'components/inputs/inputTextArea';
 import { InputRadio } from 'components/inputs/inputRadio';
 import { InputCheckbox } from 'components/inputs/inputCheckbox';
-import { userInfoSelector } from 'controllers/user';
+import { activeProjectKeySelector, userInfoSelector } from 'controllers/user';
 import { LAUNCHES_MODAL_EVENTS } from 'components/main/analytics/events';
 import { compareAttributes } from 'common/utils/attributeUtils';
 import { AttributeListField } from 'components/main/attributeList';
-import { projectKeySelector } from 'controllers/project';
 import { MergeTypeScheme } from './mergeTypeScheme';
 import { StartEndTime } from './startEndTime';
 import styles from './launchMergeModal.scss';
@@ -126,7 +125,7 @@ const formSyncErrorsSelector = getFormSyncErrors(MERGE_FORM);
     user: userInfoSelector(state),
     syncErrors: formSyncErrorsSelector(state),
     fields: formMetaSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     mergeType: valueSelector(state, 'mergeType'),
     startTime: valueSelector(state, 'startTime'),
     endTime: valueSelector(state, 'endTime'),

--- a/app/src/pages/inside/launchesPage/modals/moveToDebugModal/moveToDebugModal.jsx
+++ b/app/src/pages/inside/launchesPage/modals/moveToDebugModal/moveToDebugModal.jsx
@@ -26,14 +26,14 @@ import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { withModal, ModalLayout } from 'components/main/modal';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { LAUNCHES_MODAL_EVENTS } from 'components/main/analytics/events';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { messages } from './translations';
 
 @withModal('moveLaunchesModal')
 @injectIntl
 @connect(
   (state) => ({
-    url: URLS.launchUpdate(projectKeySelector(state)),
+    url: URLS.launchUpdate(activeProjectKeySelector(state)),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/logsPage/historyLine/historyLineItem/historyLineItemTooltip/historyLineItemTooltip.jsx
+++ b/app/src/pages/inside/logsPage/historyLine/historyLineItem/historyLineItemTooltip/historyLineItemTooltip.jsx
@@ -28,7 +28,7 @@ import { DottedPreloader } from 'components/preloaders/dottedPreloader';
 import BugIcon from 'common/img/bug-inline.svg';
 import CommentIcon from 'common/img/comment-inline.svg';
 import { DefectTypeItem } from 'pages/inside/common/defectTypeItem';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { Triangles } from '../triangles';
 import styles from './historyLineItemTooltip.scss';
 
@@ -66,7 +66,7 @@ const messages = defineMessages({
 });
 
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 @injectIntl
 export class HistoryLineItemTooltip extends Component {

--- a/app/src/pages/inside/logsPage/modals/copySendDefectModal/copySendDefectModal.jsx
+++ b/app/src/pages/inside/logsPage/modals/copySendDefectModal/copySendDefectModal.jsx
@@ -23,7 +23,7 @@ import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 
 const MESSAGE_TYPES = {
   button: 'button',
@@ -66,7 +66,7 @@ const messages = defineMessages({
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/projectSettingsPageContainer/content/analyzerContainer/modals/generateIndexModal/generateIndexModal.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/analyzerContainer/modals/generateIndexModal/generateIndexModal.jsx
@@ -22,7 +22,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
-import { fetchProjectAction, projectKeySelector } from 'controllers/project';
+import { fetchProjectAction } from 'controllers/project';
 import {
   showNotification,
   showDefaultErrorNotification,
@@ -31,6 +31,7 @@ import {
 import { withModal } from 'components/main/modal';
 import { ModalLayout } from 'componentLibrary/modal';
 import { hideModalAction } from 'controllers/modal';
+import { urlProjectKeySelector } from 'controllers/pages';
 import styles from './generateIndexModal.scss';
 
 const cx = classNames.bind(styles);
@@ -64,7 +65,7 @@ const messages = defineMessages({
 const GenerateIndexModal = ({ data }) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(urlProjectKeySelector);
 
   const onClickGenerate = () => {
     fetch(URLS.projectIndex(projectKey), { method: 'put' })

--- a/app/src/pages/inside/projectSettingsPageContainer/content/analyzerContainer/modals/removeIndexModal/removeIndexModal.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/analyzerContainer/modals/removeIndexModal/removeIndexModal.jsx
@@ -28,7 +28,7 @@ import {
 import { withModal } from 'components/main/modal';
 import { hideModalAction } from 'controllers/modal';
 import { ModalLayout } from 'componentLibrary/modal';
-import { projectKeySelector } from 'controllers/project';
+import { urlProjectKeySelector } from 'controllers/pages';
 
 const messages = defineMessages({
   removeIndexHeader: {
@@ -52,7 +52,7 @@ const messages = defineMessages({
 const RemoveIndexModal = () => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(urlProjectKeySelector);
 
   const onClickRemove = () => {
     fetch(URLS.projectIndex(projectKey), { method: 'delete' })

--- a/app/src/pages/inside/projectSettingsPageContainer/content/demoDataContent/generateDemoDataBlock/generateDemoDataBlock.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/demoDataContent/generateDemoDataBlock/generateDemoDataBlock.jsx
@@ -29,7 +29,7 @@ import {
 } from 'controllers/notification';
 import { useTracking } from 'react-tracking';
 import { PROJECT_SETTINGS_DEMO_DATA_EVENTS } from 'analyticsEvents/projectSettingsPageEvents';
-import { projectKeySelector } from 'controllers/project';
+import { urlProjectKeySelector } from 'controllers/pages';
 import styles from './generateDemoDataBlock.scss';
 import { LabeledPreloader } from '../../elements';
 
@@ -58,7 +58,7 @@ const messages = defineMessages({
 export const GenerateDemoDataBlock = ({ className }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { formatMessage } = useIntl();
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(urlProjectKeySelector);
   const dispatch = useDispatch();
   const { trackEvent } = useTracking();
 

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrations.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrations.jsx
@@ -30,8 +30,9 @@ import {
 } from 'controllers/pages';
 import { INTEGRATIONS } from 'common/constants/settingsTabs';
 import { redirect } from 'redux-first-router';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
 import { isEmptyObject } from 'common/utils';
+import { activeProjectKeySelector } from 'controllers/user';
 import { IntegrationInfo } from './integrationsList/integrationInfo';
 import { IntegrationsList } from './integrationsList';
 
@@ -44,7 +45,7 @@ export const Integrations = () => {
   const availableGroupedPlugins = useSelector(availableGroupedPluginsSelector);
   const plugins = useSelector(availablePluginsSelector);
   const organizationSlug = useSelector(projectOrganizationSlugSelector);
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(activeProjectKeySelector);
   const dispatch = useDispatch();
   const query = useSelector(querySelector);
   const [plugin, setPlugin] = useState({});

--- a/app/src/pages/inside/projectSettingsPageContainer/content/notifications/modals/addEditNotificationModal/addEditNotificationModal.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/notifications/modals/addEditNotificationModal/addEditNotificationModal.jsx
@@ -36,7 +36,7 @@ import { FieldText } from 'componentLibrary/fieldText';
 import { Checkbox } from 'componentLibrary/checkbox';
 import { PROJECT_SETTINGS_NOTIFICATIONS_EVENTS } from 'analyticsEvents/projectSettingsPageEvents';
 import { AttributeListFormField } from 'components/containers/AttributeListFormField';
-import { projectKeySelector } from 'controllers/project';
+import { urlProjectKeySelector } from 'controllers/pages';
 import { FieldElement } from '../../../elements';
 import {
   ATTRIBUTES_FIELD_KEY,
@@ -196,7 +196,7 @@ const AddEditNotificationModal = ({ data, data: { onSave }, handleSubmit, initia
   const { trackEvent } = useTracking();
   const dispatch = useDispatch();
 
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(urlProjectKeySelector);
   const [isEditorShown, setShowEditor] = React.useState(data.notification.attributes.length > 0);
   useEffect(() => {
     initialize(data.notification);

--- a/app/src/pages/inside/stepPage/modals/ignoreInAAModal/ignoreInAAModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/ignoreInAAModal/ignoreInAAModal.jsx
@@ -25,7 +25,7 @@ import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './ignoreInAAModal.scss';
 
 const cx = classNames.bind(styles);
@@ -65,7 +65,7 @@ const messages = defineMessages({
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/stepPage/modals/includeInAAModal/includeInAAModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/includeInAAModal/includeInAAModal.jsx
@@ -25,7 +25,7 @@ import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './includeInAAModal.scss';
 
 const cx = classNames.bind(styles);
@@ -65,7 +65,7 @@ const messages = defineMessages({
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/stepPage/modals/linkIssueModal/linkIssueModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/linkIssueModal/linkIssueModal.jsx
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
 import { reduxForm, FieldArray } from 'redux-form';
 import classNames from 'classnames/bind';
 import { injectIntl, defineMessages } from 'react-intl';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import { namedAvailableBtsIntegrationsSelector } from 'controllers/plugins';
 import { withModal } from 'components/main/modal';
 import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
@@ -35,7 +35,6 @@ import { BtsIntegrationSelector } from 'pages/inside/common/btsIntegrationSelect
 import { DarkModalLayout, ModalFooter } from 'components/main/modal/darkModalLayout';
 import { GhostButton } from 'components/buttons/ghostButton';
 import { hideModalAction } from 'controllers/modal';
-import { projectKeySelector } from 'controllers/project';
 import { getDefaultIssueModalConfig } from '../postIssueModal/utils';
 import { LinkIssueFields } from './linkIssueFields';
 import { messages as makeDecisionMessages } from '../makeDecisionModal/messages';
@@ -74,7 +73,7 @@ const messages = defineMessages({
   (state) => ({
     userId: userIdSelector(state),
     namedBtsIntegrations: namedAvailableBtsIntegrationsSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/stepPage/modals/makeDecisionModal/executionSection/executionSection.jsx
+++ b/app/src/pages/inside/stepPage/modals/makeDecisionModal/executionSection/executionSection.jsx
@@ -27,7 +27,7 @@ import { NOTIFICATION_TYPES, showNotification } from 'controllers/notification';
 import { TestItemDetails } from 'pages/inside/stepPage/modals/makeDecisionModal/elements/testItemDetails';
 import { historyItemsSelector } from 'controllers/log';
 import { TO_INVESTIGATE_LOCATOR_PREFIX } from 'common/constants/defectTypes';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import {
   ALL_LOADED_TI_FROM_HISTORY_LINE,
   CURRENT_EXECUTION_ONLY,
@@ -44,7 +44,7 @@ export const ExecutionSection = ({ modalState, setModalState, isBulkOperation, e
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
   const dispatch = useDispatch();
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(activeProjectKeySelector);
   const activeFilter = useSelector(activeFilterSelector);
   const [currentItemsLoading, setCurrentItemsLoading] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/app/src/pages/inside/stepPage/modals/makeDecisionModal/makeDecisionModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/makeDecisionModal/makeDecisionModal.jsx
@@ -34,7 +34,7 @@ import { TO_INVESTIGATE_LOCATOR_PREFIX } from 'common/constants/defectTypes';
 import { actionMessages } from 'common/constants/localization/eventsLocalization';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { useWindowResize } from 'common/hooks';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { MakeDecisionFooter } from './makeDecisionFooter';
 import { MakeDecisionTabs } from './makeDecisionTabs';
 import { MachineLearningSuggestions, SelectDefectManually, CopyFromHistoryLine } from './tabs';
@@ -60,7 +60,7 @@ const MakeDecision = ({ data }) => {
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
   const dispatch = useDispatch();
-  const projectKey = useSelector(projectKeySelector);
+  const projectKey = useSelector(activeProjectKeySelector);
   const historyItems = useSelector(historyItemsSelector);
   const isAnalyzerAvailable = !!useSelector(analyzerExtensionsSelector).length;
   const isBulkOperation = data.items && data.items.length > 1;

--- a/app/src/pages/inside/stepPage/modals/postIssueModal/postIssueModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/postIssueModal/postIssueModal.jsx
@@ -24,7 +24,7 @@ import { injectIntl, defineMessages } from 'react-intl';
 import { fetch, updateSessionItem } from 'common/utils';
 import { URLS } from 'common/urls';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
-import { userIdSelector } from 'controllers/user';
+import { activeProjectKeySelector, userIdSelector } from 'controllers/user';
 import {
   namedAvailableBtsIntegrationsSelector,
   uiExtensionPostIssueFormSelector,
@@ -38,7 +38,7 @@ import {
   normalizeFieldsWithOptions,
   mapFieldsToValues,
 } from 'components/fields/dynamicFieldsSection/utils';
-import { projectInfoSelector, projectKeySelector } from 'controllers/project';
+import { projectInfoSelector } from 'controllers/project';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { InputCheckbox } from 'components/inputs/inputCheckbox';
 import { ISSUE_TYPE_FIELD_KEY } from 'components/integrations/elements/bts/constants';
@@ -120,7 +120,7 @@ const messages = defineMessages({
 @track()
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
     projectInfo: projectInfoSelector(state),
     namedBtsIntegrations: namedAvailableBtsIntegrationsSelector(state),
     userId: userIdSelector(state),

--- a/app/src/pages/inside/stepPage/modals/testItemDetailsModal/testItemDetailsModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/testItemDetailsModal/testItemDetailsModal.jsx
@@ -30,6 +30,7 @@ import { FieldProvider } from 'components/fields/fieldProvider';
 import { fetch } from 'common/utils/fetch';
 import { URLS } from 'common/urls';
 import {
+  activeProjectKeySelector,
   activeProjectRoleSelector,
   userAccountRoleSelector,
   userIdSelector,
@@ -54,7 +55,6 @@ import { ContainerWithTabs } from 'components/main/containerWithTabs';
 import { StackTrace } from 'pages/inside/common/stackTrace';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { STEP_PAGE_EVENTS } from 'components/main/analytics/events/stepPageEvents';
-import { projectKeySelector } from 'controllers/project';
 import { messages } from './messages';
 import styles from './testItemDetailsModal.scss';
 
@@ -74,7 +74,7 @@ const cx = classNames.bind(styles);
     userProjectRole: activeProjectRoleSelector(state),
     userId: userIdSelector(state),
     launch: launchSelector(state),
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/pages/inside/stepPage/modals/unlinkIssueModal/unlinkIssueModal.jsx
+++ b/app/src/pages/inside/stepPage/modals/unlinkIssueModal/unlinkIssueModal.jsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import track from 'react-tracking';
 import classNames from 'classnames/bind';
 import { injectIntl, defineMessages } from 'react-intl';
-import { activeProjectSelector } from 'controllers/user';
+import { activeProjectKeySelector } from 'controllers/user';
 import { withModal } from 'components/main/modal';
 import {
   showNotification,
@@ -34,7 +34,6 @@ import { GhostButton } from 'components/buttons/ghostButton';
 import { hideModalAction } from 'controllers/modal';
 import { messages as makeDecisionMessages } from 'pages/inside/stepPage/modals/makeDecisionModal/messages';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
-import { projectKeySelector } from 'controllers/project';
 import styles from './unlinkIssueModal.scss';
 
 const cx = classNames.bind(styles);
@@ -59,8 +58,7 @@ const messages = defineMessages({
 @track()
 @connect(
   (state) => ({
-    url: URLS.testItemsUnlinkIssues(projectKeySelector(state)),
-    activeProject: activeProjectSelector(state),
+    url: URLS.testItemsUnlinkIssues(activeProjectKeySelector(state)),
   }),
   {
     showNotification,
@@ -72,7 +70,6 @@ export class UnlinkIssueModal extends Component {
     intl: PropTypes.object.isRequired,
     url: PropTypes.string.isRequired,
     showNotification: PropTypes.func.isRequired,
-    activeProject: PropTypes.string.isRequired,
     data: PropTypes.shape({
       items: PropTypes.array,
       fetchFunc: PropTypes.func,

--- a/app/src/pages/inside/stepPage/retries/retriesContainer.jsx
+++ b/app/src/pages/inside/stepPage/retries/retriesContainer.jsx
@@ -20,11 +20,11 @@ import { connect } from 'react-redux';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils/fetch';
 import { ERROR } from 'common/constants/logLevels';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import { Retries } from './retries';
 
 @connect((state) => ({
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))
 export class RetriesContainer extends Component {
   static propTypes = {

--- a/app/src/pages/inside/stepPage/stepGrid/defectType/issueList/issue/issueInfoTooltip/issueInfoTooltip.jsx
+++ b/app/src/pages/inside/stepPage/stepGrid/defectType/issueList/issue/issueInfoTooltip/issueInfoTooltip.jsx
@@ -20,13 +20,12 @@ import classNames from 'classnames/bind';
 import { connect } from 'react-redux';
 import { defineMessages, injectIntl } from 'react-intl';
 import { URLS } from 'common/urls';
-import { activeProjectSelector } from 'controllers/user';
+import { activeProjectKeySelector } from 'controllers/user';
 import { pluginByNameSelector, isPluginSupportsCommonCommand } from 'controllers/plugins';
 import { COMMAND_GET_ISSUE } from 'controllers/plugins/uiExtensions/constants';
 import { getStorageItem, updateStorageItem } from 'common/utils';
 import { ERROR_CANCELED, fetch } from 'common/utils/fetch';
 import { DottedPreloader } from 'components/preloaders/dottedPreloader';
-import { projectKeySelector } from 'controllers/project';
 import styles from './issueInfoTooltip.scss';
 
 const cx = classNames.bind(styles);
@@ -53,20 +52,18 @@ const messages = defineMessages({
 });
 
 const isResolved = (status) => status.toUpperCase() === STATUS_RESOLVED;
-const getStorageKey = (activeProject) => `${activeProject}_tickets`;
+const getStorageKey = (activeProjectKey) => `${activeProjectKey}_tickets`;
 
 const FETCH_ISSUE_INTERVAL = 900000; // min request interval = 15 min
 
 @connect((state, ownProps) => ({
-  activeProject: activeProjectSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
   plugin: pluginByNameSelector(state, ownProps.pluginName),
 }))
 @injectIntl
 export class IssueInfoTooltip extends Component {
   static propTypes = {
     intl: PropTypes.object.isRequired,
-    activeProject: PropTypes.string.isRequired,
     ticketId: PropTypes.string.isRequired,
     btsProject: PropTypes.string.isRequired,
     btsUrl: PropTypes.string.isRequired,
@@ -114,16 +111,16 @@ export class IssueInfoTooltip extends Component {
   };
 
   getIssueFromStorage = () => {
-    const { activeProject, ticketId, btsProject } = this.props;
-    const storageKey = getStorageKey(activeProject);
+    const { projectKey, ticketId, btsProject } = this.props;
+    const storageKey = getStorageKey(projectKey);
 
     const data = getStorageItem(storageKey) || {};
     return data[`${btsProject}_${ticketId}`] || {};
   };
 
   updateIssueInStorage = (data = {}) => {
-    const { activeProject, btsProject, ticketId } = this.props;
-    const storageKey = getStorageKey(activeProject);
+    const { projectKey, btsProject, ticketId } = this.props;
+    const storageKey = getStorageKey(projectKey);
 
     updateStorageItem(storageKey, { [`${btsProject}_${ticketId}`]: data });
   };

--- a/app/src/pages/inside/stepPage/stepGrid/groupHeader/groupHeader.jsx
+++ b/app/src/pages/inside/stepPage/stepGrid/groupHeader/groupHeader.jsx
@@ -21,7 +21,8 @@ import classNames from 'classnames/bind';
 import Link from 'redux-first-router-link';
 import { TEST_ITEM_PAGE, launchIdSelector, filterIdSelector } from 'controllers/pages';
 import { isTestItemsListSelector } from 'controllers/testItem';
-import { projectKeySelector, projectOrganizationSlugSelector } from 'controllers/project';
+import { projectOrganizationSlugSelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './groupHeader.scss';
 
 const cx = classNames.bind(styles);
@@ -41,7 +42,7 @@ export const GroupHeader = connect((state) => ({
   filterId: filterIdSelector(state),
   isTestItemsList: isTestItemsListSelector(state),
   organizationSlug: projectOrganizationSlugSelector(state),
-  projectKey: projectKeySelector(state),
+  projectKey: activeProjectKeySelector(state),
 }))(({ data, launchId, filterId, isTestItemsList, organizationSlug, projectKey }) => {
   const { itemPaths = [], launchPathName } = data[0].pathNames;
 

--- a/app/src/pages/inside/testItemPage/testItemPage.jsx
+++ b/app/src/pages/inside/testItemPage/testItemPage.jsx
@@ -29,7 +29,7 @@ import { SpinningPreloader } from 'components/preloaders/spinningPreloader';
 import { Breadcrumbs } from 'components/main/breadcrumbs';
 import { LEVEL_SUITE, LEVEL_TEST, LEVEL_STEP } from 'common/constants/launchLevels';
 import { STEP_PAGE_EVENTS } from 'components/main/analytics/events';
-import { userIdSelector, activeProjectSelector } from 'controllers/user';
+import { userIdSelector } from 'controllers/user';
 import { unselectAllItemsAction } from 'controllers/groupOperations';
 import {
   levelSelector,
@@ -143,7 +143,6 @@ const testItemPages = {
     breadcrumbs: breadcrumbsSelector(state),
     parentLaunch: launchSelector(state),
     userId: userIdSelector(state),
-    activeProject: activeProjectSelector(state),
     namespace: namespaceSelector(state),
   }),
   (dispatch) => ({
@@ -169,7 +168,6 @@ const testItemPages = {
 export class TestItemPage extends Component {
   static propTypes = {
     intl: PropTypes.object.isRequired,
-    activeProject: PropTypes.string.isRequired,
     namespace: PropTypes.string.isRequired,
     userId: PropTypes.string.isRequired,
     deleteTestItemsAction: PropTypes.func.isRequired,

--- a/app/src/pages/inside/uniqueErrorsPage/modals/uniqueErrorsAnalyzeModal.jsx
+++ b/app/src/pages/inside/uniqueErrorsPage/modals/uniqueErrorsAnalyzeModal.jsx
@@ -35,7 +35,7 @@ import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { ANALYZER_TYPES } from 'common/constants/analyzerTypes';
-import { projectKeySelector } from 'controllers/project';
+import { activeProjectKeySelector } from 'controllers/user';
 import styles from './uniqueErrorsAnalyzeModal.scss';
 
 const cx = classNames.bind(styles);
@@ -49,7 +49,7 @@ const cx = classNames.bind(styles);
 @injectIntl
 @connect(
   (state) => ({
-    projectKey: projectKeySelector(state),
+    projectKey: activeProjectKeySelector(state),
   }),
   {
     showNotification,

--- a/app/src/routes/routesMap.js
+++ b/app/src/routes/routesMap.js
@@ -22,11 +22,7 @@ import {
   setActiveProjectAction,
   activeProjectKeySelector,
 } from 'controllers/user';
-import {
-  fetchProjectAction,
-  projectKeySelector,
-  projectOrganizationSlugSelector,
-} from 'controllers/project';
+import { fetchProjectAction, projectOrganizationSlugSelector } from 'controllers/project';
 import {
   LOGIN_PAGE,
   REGISTRATION_PAGE,
@@ -276,7 +272,7 @@ export const onBeforeRouteChange = (dispatch, getState, { action }) => {
     type: nextPageType,
     payload: { projectKey: hashProjectKey, organizationSlug: hashOrganization },
   } = action;
-  let projectKey = projectKeySelector(getState());
+  let projectKey = activeProjectKeySelector(getState());
   let organizationSlug = projectOrganizationSlugSelector(getState());
   const currentPageType = pageSelector(getState());
   const authorized = isAuthorizedSelector(getState());


### PR DESCRIPTION
We can remove projectKey selector, and use activeProjectKey or urlProjectKey.
In components witch can be used in admin and user interfaces, we can use urlProjectKey, in all other cases we can use activeProjectKey