### PR TITLE
EPMRPP-80671 || Improve attribute options in Notifications

### DIFF
--- a/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/addEditNotificationCaseModal.jsx
+++ b/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/addEditNotificationCaseModal.jsx
@@ -77,7 +77,7 @@ export class AddEditNotificationCaseModal extends Component {
     initialize: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     dirty: PropTypes.bool.isRequired,
-    resetSection: PropTypes.func.isRequired,
+    change: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -114,7 +114,7 @@ export class AddEditNotificationCaseModal extends Component {
     const {
       intl: { formatMessage },
       data: { isNewCase, onConfirm, eventsInfo },
-      resetSection,
+      change,
       handleSubmit,
     } = this.props;
 
@@ -141,7 +141,7 @@ export class AddEditNotificationCaseModal extends Component {
         closeIconEventInfo={eventsInfo.closeIcon}
         renderHeaderElements={this.renderHeaderElements}
       >
-        <NotificationCaseFormFields resetSection={resetSection} />
+        <NotificationCaseFormFields change={change} />
       </ModalLayout>
     );
   }

--- a/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/addEditNotificationCaseModal.jsx
+++ b/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/addEditNotificationCaseModal.jsx
@@ -77,6 +77,7 @@ export class AddEditNotificationCaseModal extends Component {
     initialize: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     dirty: PropTypes.bool.isRequired,
+    resetSection: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -113,6 +114,7 @@ export class AddEditNotificationCaseModal extends Component {
     const {
       intl: { formatMessage },
       data: { isNewCase, onConfirm, eventsInfo },
+      resetSection,
       handleSubmit,
     } = this.props;
 
@@ -139,7 +141,7 @@ export class AddEditNotificationCaseModal extends Component {
         closeIconEventInfo={eventsInfo.closeIcon}
         renderHeaderElements={this.renderHeaderElements}
       >
-        <NotificationCaseFormFields />
+        <NotificationCaseFormFields resetSection={resetSection} />
       </ModalLayout>
     );
   }

--- a/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/notificationCaseFormFields/notificationCaseFormFields.jsx
+++ b/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/notificationCaseFormFields/notificationCaseFormFields.jsx
@@ -65,10 +65,12 @@ export class NotificationCaseFormFields extends Component {
       getTrackingData: PropTypes.func,
     }).isRequired,
     attributesValue: PropTypes.array,
+    resetSection: PropTypes.func,
   };
   static defaultProps = {
     activeProject: '',
     attributesValue: [],
+    resetSection: () => {},
   };
 
   getDropdownInputConfig = () => {
@@ -107,16 +109,25 @@ export class NotificationCaseFormFields extends Component {
   getAttributesConditionOptions = () => {
     const {
       intl: { formatMessage },
+      attributesValue,
+      resetSection,
     } = this.props;
+    const hasOneAttrOrLess = attributesValue.filter((attribute) => 'key' in attribute).length <= 1;
+
+    if (attributesValue.length === 1) {
+      resetSection([ATTRIBUTES_OPERATOR_FIELD_KEY]);
+    }
 
     return [
       {
         ownValue: ATTRIBUTES_OPERATORS.AND,
         label: formatMessage(messages[ATTRIBUTES_OPERATORS.AND]),
+        disabled: hasOneAttrOrLess,
       },
       {
         ownValue: ATTRIBUTES_OPERATORS.OR,
         label: formatMessage(messages[ATTRIBUTES_OPERATORS.OR]),
+        disabled: hasOneAttrOrLess,
       },
     ];
   };

--- a/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/notificationCaseFormFields/notificationCaseFormFields.jsx
+++ b/app/src/pages/common/settingsPage/notificationsTab/modals/addEditNotificationCaseModal/notificationCaseFormFields/notificationCaseFormFields.jsx
@@ -65,7 +65,7 @@ export class NotificationCaseFormFields extends Component {
       getTrackingData: PropTypes.func,
     }).isRequired,
     attributesValue: PropTypes.array,
-    resetSection: PropTypes.func,
+    change: PropTypes.func,
   };
   static defaultProps = {
     activeProject: '',
@@ -110,12 +110,12 @@ export class NotificationCaseFormFields extends Component {
     const {
       intl: { formatMessage },
       attributesValue,
-      resetSection,
+      change,
     } = this.props;
     const hasOneAttrOrLess = attributesValue.filter((attribute) => 'key' in attribute).length <= 1;
 
     if (attributesValue.length === 1) {
-      resetSection([ATTRIBUTES_OPERATOR_FIELD_KEY]);
+      change(ATTRIBUTES_OPERATOR_FIELD_KEY, ATTRIBUTES_OPERATORS.AND);
     }
 
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Now when we have less than one attribute the options AND/OR are disabled. It becomes active only when at least two attr are added.