### PR TITLE
EPMRPP-81046 || Impossible to report test items to project with "demo" name

### DIFF
--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -254,7 +254,7 @@ export const URLS = {
   userInviteExternal: () => `${urlBase}user/bid`,
   userUnasign: (activeProject) => `${urlBase}project/${activeProject}/unassign`,
 
-  generateDemoData: (projectId) => `${urlBase}demo/${projectId}`,
+  generateDemoData: (projectId) => `${urlBase}demo/${projectId}/generate`,
   getFileById: (projectId, dataId, loadThumbnail) =>
     `${urlBase}data/${projectId}/${dataId}${getQueryParams({ loadThumbnail })}`,
 


### PR DESCRIPTION
Request /v1/demo/item call endpoint for demo data generation not test item creation
Url  for demo data generation changed to /v1/demo/{projectName}/generate to avoid url collision.
Also required to change url on ui