### PR TITLE
EPMRPP-81029 || Add dashboard creation limit

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -352,6 +352,7 @@
   "DashboardForm.editModalTitle": "Рэдагаваць панэль кіравання",
   "DashboardForm.modalCancelButtonText": "Адмяніць",
   "DashboardGrid.myDashboards": "Мае панэлі кіравання",
+  "DashboardHeaderButton.buttonTooltip": "Ліміт у 300 панэляў кiравання дасягнуты. Каб стварыць новыю, трэба выдаліць хаця б адну, створаныую раней",
   "DashboardGrid.sharedDashboards": "Апублікаваныя панэлі кіравання",
   "DashboardGridItem.dashboardIsShared": "Панэль кіравання апублікавана",
   "DashboardGridItem.dashboardIsSharedBy": "Панэль кіравання апублікавана",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -352,6 +352,7 @@
   "DashboardForm.editModalTitle": "редактировать панель управления",
   "DashboardForm.modalCancelButtonText": "Отменить",
   "DashboardGrid.myDashboards": "Мои панели управления",
+  "DashboardHeaderButton.buttonTooltip": "Достигнут предел в 300 панелей управления. Для создания новой необходимо удалить хотя бы одну созданную ранее",
   "DashboardGrid.sharedDashboards": "Доступные панели управления",
   "DashboardGridItem.dashboardIsShared": "Панель управления доступна",
   "DashboardGridItem.dashboardIsSharedBy": "Панель управления добавлена в доступ",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -352,6 +352,7 @@
   "DashboardForm.editModalTitle": "редагувати панель управління",
   "DashboardForm.modalCancelButtonText": "Скасувати",
   "DashboardGrid.myDashboards": "Мої панелі управління",
+  "DashboardHeaderButton.buttonTooltip": "Досягнуто ліміту в 300 панелей управління. Щоб створити новую, потрібно видалити принаймні одину, створеную раніше",
   "DashboardGrid.sharedDashboards": "Доступні панелі управління",
   "DashboardGridItem.dashboardIsShared": "Доступна Панель управління",
   "DashboardGridItem.dashboardIsSharedBy": "В Панель керування додано доступ",

--- a/app/src/controllers/dashboard/constants.js
+++ b/app/src/controllers/dashboard/constants.js
@@ -26,6 +26,7 @@ export const INITIAL_STATE = {
   gridType: '',
   fullScreenMode: false,
   loading: false,
+  pagePaginationInfo: {},
 };
 export const NAMESPACE = 'dashboards';
 export const FETCH_DASHBOARDS = 'fetchDashboards';

--- a/app/src/controllers/dashboard/constants.js
+++ b/app/src/controllers/dashboard/constants.js
@@ -26,7 +26,7 @@ export const INITIAL_STATE = {
   gridType: '',
   fullScreenMode: false,
   loading: false,
-  pagePaginationInfo: {},
+  pagination: {},
 };
 export const NAMESPACE = 'dashboards';
 export const FETCH_DASHBOARDS = 'fetchDashboards';
@@ -44,3 +44,5 @@ export const DASHBOARDS_TABLE_VIEW = 'table';
 export const DASHBOARDS_GRID_VIEW = 'grid';
 export const CHANGE_FULL_SCREEN_MODE = 'changeFullScreenMode';
 export const TOGGLE_FULL_SCREEN_MODE = 'toggleFullScreenMode';
+export const INCREASE_TOTAL_DASHBOARDS_LOCALLY = 'increaseTotalDashboardsLocally';
+export const DECREASE_TOTAL_DASHBOARDS_LOCALLY = 'decreaseTotalDashboardsLocally';

--- a/app/src/controllers/dashboard/index.js
+++ b/app/src/controllers/dashboard/index.js
@@ -32,6 +32,7 @@ export {
   activeDashboardItemSelector,
   dashboardFullScreenModeSelector,
   loadingSelector,
+  totalDashboardsSelector,
 } from './selectors';
 export {
   DASHBOARDS_TABLE_VIEW,

--- a/app/src/controllers/dashboard/reducer.js
+++ b/app/src/controllers/dashboard/reducer.js
@@ -24,6 +24,7 @@ import {
   PROJECT_DASHBOARD_ITEM_PAGE,
   PROJECT_DASHBOARD_PRINT_PAGE,
 } from 'controllers/pages';
+import { paginationReducer } from 'controllers/pagination';
 import {
   ADD_DASHBOARD_SUCCESS,
   CHANGE_FULL_SCREEN_MODE,
@@ -67,6 +68,7 @@ const reducer = combineReducers({
   gridType: gridTypeReducer,
   fullScreenMode: fullScreenModeReducer,
   loading: loadingReducer(NAMESPACE),
+  pagePaginationInfo: paginationReducer(NAMESPACE),
 });
 
 export const dashboardReducer = createPageScopedReducer(reducer, [

--- a/app/src/controllers/dashboard/reducer.js
+++ b/app/src/controllers/dashboard/reducer.js
@@ -29,6 +29,8 @@ import {
   ADD_DASHBOARD_SUCCESS,
   CHANGE_FULL_SCREEN_MODE,
   CHANGE_VISIBILITY_TYPE,
+  DECREASE_TOTAL_DASHBOARDS_LOCALLY,
+  INCREASE_TOTAL_DASHBOARDS_LOCALLY,
   INITIAL_STATE,
   NAMESPACE,
   REMOVE_DASHBOARD_SUCCESS,
@@ -63,12 +65,23 @@ const fullScreenModeReducer = (state = INITIAL_STATE.fullScreenMode, { type, pay
   }
 };
 
+const totalDashboardsReducer = (state = INITIAL_STATE.pagination, { type }) => {
+  switch (type) {
+    case INCREASE_TOTAL_DASHBOARDS_LOCALLY:
+      return { ...state, totalElements: state.totalElements + 1 };
+    case DECREASE_TOTAL_DASHBOARDS_LOCALLY:
+      return { ...state, totalElements: state.totalElements - 1 };
+    default:
+      return state;
+  }
+};
+
 const reducer = combineReducers({
   dashboards: queueReducers(fetchReducer(NAMESPACE, { contentPath: 'content' }), dashboardsReducer),
   gridType: gridTypeReducer,
   fullScreenMode: fullScreenModeReducer,
   loading: loadingReducer(NAMESPACE),
-  pagePaginationInfo: paginationReducer(NAMESPACE),
+  pagination: queueReducers(paginationReducer(NAMESPACE), totalDashboardsReducer),
 });
 
 export const dashboardReducer = createPageScopedReducer(reducer, [

--- a/app/src/controllers/dashboard/sagas.js
+++ b/app/src/controllers/dashboard/sagas.js
@@ -48,6 +48,8 @@ import {
   REMOVE_DASHBOARD_SUCCESS,
   CHANGE_FULL_SCREEN_MODE,
   TOGGLE_FULL_SCREEN_MODE,
+  INCREASE_TOTAL_DASHBOARDS_LOCALLY,
+  DECREASE_TOTAL_DASHBOARDS_LOCALLY,
 } from './constants';
 import {
   dashboardFullScreenModeSelector,
@@ -117,6 +119,7 @@ function* addDashboard({ payload: dashboard }) {
   });
 
   yield put(addDashboardSuccessAction({ id, owner, ...dashboard }));
+  yield put({ type: INCREASE_TOTAL_DASHBOARDS_LOCALLY });
   yield put(
     showNotification({
       messageId: 'addDashboardSuccess',
@@ -161,6 +164,7 @@ function* removeDashboard({ payload: id }) {
       method: 'delete',
     });
     yield put(deleteDashboardSuccessAction(id));
+    yield put({ type: DECREASE_TOTAL_DASHBOARDS_LOCALLY });
     yield put(
       showNotification({
         messageId: 'deleteDashboardSuccess',

--- a/app/src/controllers/dashboard/selectors.js
+++ b/app/src/controllers/dashboard/selectors.js
@@ -36,7 +36,7 @@ export const activeDashboardItemSelector = createSelector(
 );
 
 export const totalDashboardsSelector = (state) =>
-  domainSelector(state).pagePaginationInfo.totalElements || 0;
+  domainSelector(state).pagination.totalElements || 0;
 
 export const dashboardFullScreenModeSelector = (state) => domainSelector(state).fullScreenMode;
 

--- a/app/src/controllers/dashboard/selectors.js
+++ b/app/src/controllers/dashboard/selectors.js
@@ -35,6 +35,9 @@ export const activeDashboardItemSelector = createSelector(
     dashboardItems.find((item) => item.id === activeDashboardId) || {},
 );
 
+export const totalDashboardsSelector = (state) =>
+  domainSelector(state).pagePaginationInfo.totalElements || 0;
+
 export const dashboardFullScreenModeSelector = (state) => domainSelector(state).fullScreenMode;
 
 export const querySelector = createQueryParametersSelector();

--- a/app/src/pages/inside/common/dashboardPageHeader/addDashboardButton/addDashboardButton.jsx
+++ b/app/src/pages/inside/common/dashboardPageHeader/addDashboardButton/addDashboardButton.jsx
@@ -41,11 +41,9 @@ const messages = defineMessages({
 });
 
 const TooltipComponent = ({ formatMessage }) => <p>{formatMessage(messages.buttonTooltip)}</p>;
-
 TooltipComponent.propTypes = {
   formatMessage: PropTypes.func,
 };
-
 TooltipComponent.defaultProps = {
   formatMessage: () => {},
 };

--- a/app/src/pages/inside/common/dashboardPageHeader/addDashboardButton/addDashboardButton.jsx
+++ b/app/src/pages/inside/common/dashboardPageHeader/addDashboardButton/addDashboardButton.jsx
@@ -24,6 +24,7 @@ import { GhostButton } from 'components/buttons/ghostButton';
 import { addDashboardAction } from 'controllers/dashboard';
 import { showModalAction } from 'controllers/modal';
 import { DASHBOARD_PAGE_EVENTS } from 'components/main/analytics/events';
+import { withTooltip } from 'components/main/tooltips/tooltip';
 import AddDashboardIcon from './img/ic-add-dash-inline.svg';
 import styles from './addDashboardButton.scss';
 
@@ -33,7 +34,25 @@ const messages = defineMessages({
     id: 'DashboardForm.addModalTitle',
     defaultMessage: 'Add New Dashboard',
   },
+  buttonTooltip: {
+    id: 'DashboardHeaderButton.buttonTooltip',
+    defaultMessage: `The limit of 300 dashboards has been reached. To create a new one you need to delete at least one created previously`,
+  },
 });
+
+const TooltipComponent = ({ formatMessage }) => <p>{formatMessage(messages.buttonTooltip)}</p>;
+
+TooltipComponent.propTypes = {
+  formatMessage: PropTypes.func,
+};
+
+TooltipComponent.defaultProps = {
+  formatMessage: () => {},
+};
+
+const ButtonWithTooltip = withTooltip({
+  TooltipComponent,
+})(GhostButton);
 
 @connect(null, {
   showModal: showModalAction,
@@ -47,6 +66,7 @@ export class AddDashboardButton extends Component {
     showModal: PropTypes.func,
     addDashboard: PropTypes.func,
     eventsInfo: PropTypes.object,
+    disabled: PropTypes.bool,
     tracking: PropTypes.shape({
       trackEvent: PropTypes.func,
       getTrackingData: PropTypes.func,
@@ -57,6 +77,7 @@ export class AddDashboardButton extends Component {
     showModal: () => {},
     addDashboard: () => {},
     eventsInfo: {},
+    disabled: false,
   };
 
   onAddDashboardItem = () => {
@@ -73,13 +94,19 @@ export class AddDashboardButton extends Component {
   };
 
   render() {
-    const { intl } = this.props;
+    const { intl, disabled } = this.props;
 
     return (
       <div className={cx('add-dashboard-btn')}>
-        <GhostButton onClick={this.onAddDashboardItem} icon={AddDashboardIcon}>
-          {intl.formatMessage(messages.addModalTitle)}
-        </GhostButton>
+        {disabled ? (
+          <ButtonWithTooltip disabled formatMessage={intl.formatMessage} icon={AddDashboardIcon}>
+            {intl.formatMessage(messages.addModalTitle)}
+          </ButtonWithTooltip>
+        ) : (
+          <GhostButton onClick={this.onAddDashboardItem} icon={AddDashboardIcon}>
+            {intl.formatMessage(messages.addModalTitle)}
+          </GhostButton>
+        )}
       </div>
     );
   }

--- a/app/src/pages/inside/common/dashboardPageHeader/dashboardPageHeader.jsx
+++ b/app/src/pages/inside/common/dashboardPageHeader/dashboardPageHeader.jsx
@@ -29,6 +29,7 @@ import {
   dashboardItemsSelector,
   dashboardItemPropTypes,
   totalDashboardsSelector,
+  loadingSelector,
 } from 'controllers/dashboard';
 import { InputDropdown } from 'components/inputs/inputDropdown';
 import { NavLink } from 'components/main/navLink';
@@ -51,6 +52,7 @@ const DASHBOARDS_LIMIT = 300;
   dashboardsToDisplay: dashboardItemsSelector(state),
   activeItemId: activeDashboardIdSelector(state),
   totalDashboards: totalDashboardsSelector(state),
+  isLoading: loadingSelector(state),
 }))
 @injectIntl
 export class DashboardPageHeader extends Component {
@@ -111,18 +113,9 @@ export class DashboardPageHeader extends Component {
     );
 
   render() {
-    const {
-      activeItemId,
-      eventsInfo,
-      dashboardsToDisplay,
-      isLoading,
-      totalDashboards,
-    } = this.props;
+    const { activeItemId, eventsInfo, isLoading, totalDashboards } = this.props;
 
-    const isCalculateExtraItems = totalDashboards > DASHBOARDS_LIMIT;
-    const extraItemsCount = isCalculateExtraItems ? totalDashboards - DASHBOARDS_LIMIT : 0;
-    const isAboveLimit = dashboardsToDisplay.length + extraItemsCount >= DASHBOARDS_LIMIT;
-
+    const isAboveLimit = totalDashboards >= DASHBOARDS_LIMIT;
     const disabled = isLoading || isAboveLimit;
 
     return (

--- a/app/src/pages/inside/dashboardPage/dashboardPage.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardPage.jsx
@@ -220,7 +220,7 @@ export class DashboardPage extends Component {
     return (
       <PageLayout>
         <PageHeader breadcrumbs={this.getBreadcrumbs()}>
-          <DashboardPageHeader eventsInfo={eventsInfo} />
+          <DashboardPageHeader isLoading={loading} eventsInfo={eventsInfo} />
         </PageHeader>
         <PageSection>
           <DashboardPageToolbar

--- a/app/src/pages/inside/dashboardPage/dashboardPage.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardPage.jsx
@@ -220,7 +220,7 @@ export class DashboardPage extends Component {
     return (
       <PageLayout>
         <PageHeader breadcrumbs={this.getBreadcrumbs()}>
-          <DashboardPageHeader isLoading={loading} eventsInfo={eventsInfo} />
+          <DashboardPageHeader eventsInfo={eventsInfo} />
         </PageHeader>
         <PageSection>
           <DashboardPageToolbar


### PR DESCRIPTION
Now users can't create more than 300 dashboards.
If the user already has more than 300 dashboards, he needs to delete them, until the total amount becomes less than 300 to have the ability to create new ones.