### PR TITLE
EPMRPP-81198 || fixed validation attribute value when you create launch filter

### DIFF
--- a/app/src/components/inputs/inputConditionalAttributes/inputConditionalAttributes.jsx
+++ b/app/src/components/inputs/inputConditionalAttributes/inputConditionalAttributes.jsx
@@ -143,6 +143,8 @@ export class InputConditionalAttributes extends Component {
   render() {
     const { value, keyURLCreator, valueURLCreator, projectId } = this.props;
     const inputConditions = this.getConditions();
+    const edited = true;
+
     return (
       <div className={cx('input-conditional-attributes', { opened: this.state.opened })}>
         <div className={cx('attributes-block')}>
@@ -158,6 +160,7 @@ export class InputConditionalAttributes extends Component {
             projectId={projectId}
             onConfirm={this.onChangeAttributes}
             nakedView
+            attribute={{ edited }}
           />
         </div>
         <div className={cx('conditions-block')} ref={this.setConditionsBlockRef}>

--- a/app/src/components/inputs/inputConditionalAttributes/inputConditionalAttributes.jsx
+++ b/app/src/components/inputs/inputConditionalAttributes/inputConditionalAttributes.jsx
@@ -143,7 +143,6 @@ export class InputConditionalAttributes extends Component {
   render() {
     const { value, keyURLCreator, valueURLCreator, projectId } = this.props;
     const inputConditions = this.getConditions();
-    const edited = true;
 
     return (
       <div className={cx('input-conditional-attributes', { opened: this.state.opened })}>
@@ -160,7 +159,6 @@ export class InputConditionalAttributes extends Component {
             projectId={projectId}
             onConfirm={this.onChangeAttributes}
             nakedView
-            attribute={{ edited }}
           />
         </div>
         <div className={cx('conditions-block')} ref={this.setConditionsBlockRef}>

--- a/app/src/components/main/attributeList/editableAttribute/attributeEditor/attributeEditor.jsx
+++ b/app/src/components/main/attributeList/editableAttribute/attributeEditor/attributeEditor.jsx
@@ -68,7 +68,12 @@ export class AttributeEditor extends Component {
     keyURLCreator: PropTypes.func,
     valueURLCreator: PropTypes.func,
     intl: PropTypes.object.isRequired,
-    attribute: PropTypes.object,
+    attribute: PropTypes.shape({
+      edited: PropTypes.bool,
+      system: PropTypes.bool,
+      key: PropTypes.string,
+      value: PropTypes.string,
+    }),
     customClass: PropTypes.string,
     nakedView: PropTypes.bool,
   };
@@ -85,6 +90,8 @@ export class AttributeEditor extends Component {
     attribute: {
       edited: true,
       system: false,
+      key: '',
+      value: '',
     },
     customClass: '',
     nakedView: false,

--- a/app/src/components/main/attributeList/editableAttribute/attributeEditor/attributeEditor.jsx
+++ b/app/src/components/main/attributeList/editableAttribute/attributeEditor/attributeEditor.jsx
@@ -82,7 +82,10 @@ export class AttributeEditor extends Component {
     keyURLCreator: null,
     valueURLCreator: null,
     invalid: false,
-    attribute: {},
+    attribute: {
+      edited: true,
+      system: false,
+    },
     customClass: '',
     nakedView: false,
   };


### PR DESCRIPTION
[EPMRPP-81198](https://jiraeu.epam.com/browse/EPMRPP-81198)
in other places of the application we have the Editable capability and we have props attribute.edited, but in this place we create new filter and this.props.attribute.edited === undefined
![Screenshot_181](https://user-images.githubusercontent.com/70880574/213392252-51ea562c-a4d2-4b0f-9fda-184b6d6d6427.png)

Before: 
https://jiraeu.epam.com/secure/attachment/2131767/81198.mp4 

---
After: 
![Screenshot_180](https://user-images.githubusercontent.com/70880574/213391295-785a975f-d25f-4d1d-b4f8-9a9ef002e4d1.png)


---