### PR TITLE
EPMRPP-81599 || change ellipsis for health check widget name

### DIFF
--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/columns/nameColumn.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/columns/nameColumn.jsx
@@ -30,10 +30,29 @@ export const NameColumn = (
 ) => {
   const color = value.passingRate < minPassingRate ? COLOR_DEEP_RED : COLOR_PASSED;
 
+  const calculateName = () => {
+    const ellipsisPlace = 45;
+    const lengthAtWhichAppearsEllipsis = 50;
+    const isNameLengthMoreThanFifty = value.attributeValue.length > lengthAtWhichAppearsEllipsis;
+
+    if (!isNameLengthMoreThanFifty) return <span>{value.attributeValue}</span>;
+
+    const nameBeforeEllipsis = value.attributeValue.slice(0, ellipsisPlace);
+    const lastFiveSymbol = value.attributeValue.slice(-5);
+
+    return (
+      <>
+        <span className={cx({ ellipsis: isNameLengthMoreThanFifty })}>{nameBeforeEllipsis}</span>
+        <span>{lastFiveSymbol}</span>
+      </>
+    );
+  };
+
   return (
     <div className={cx('name-col', className)}>
       {value.attributeValue ? (
         <div
+          title={value.attributeValue}
           className={cx('name-attr', { 'cursor-pointer': isClickableAttribute })}
           onClick={
             isClickableAttribute
@@ -41,7 +60,7 @@ export const NameColumn = (
               : undefined
           }
         >
-          <span title={value.attributeValue}>{value.attributeValue}</span>
+          {calculateName()}
         </div>
       ) : (
         <span className={cx('name-total', 'total-item')}>

--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/componentHealthCheckTable.scss
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/componentHealthCheckTable.scss
@@ -30,22 +30,23 @@
 .name-col {
   .name-attr {
     display: inline-block;
-    max-width: 115px;
+    width: 200px;
     font-family: $FONT-SEMIBOLD;
     color: $COLOR--topaz;
     font-size: 12px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     line-height: 1.3;
+  }
+
+  .ellipsis {
+    &::after {
+      content: '...';
+      display: inline;
+    }
   }
 
   .cursor-pointer {
     cursor: pointer;
     font-size: 12px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     line-height: 1.3;
   }
 

--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/messages.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/messages.jsx
@@ -40,6 +40,8 @@ import {
 } from 'components/widgets/singleLevelWidgets/tables/components/messages';
 import { NAME, CUSTOM_COLUMN, STATUS, PASS_RATE } from './constants';
 
+const nameColumnTitle = <FormattedMessage id={'Filter.name'} defaultMessage={'Name'} />;
+
 const statusColumnTitle = (
   <FormattedMessage id={'ComponentHealthCheckTable.statusColumn'} defaultMessage={'Status'} />
 );
@@ -73,8 +75,8 @@ const systemIssueColumnTitle = (
 
 export const COLUMN_NAMES_MAP = {
   [NAME]: () => ({
-    full: '',
-    short: '',
+    full: nameColumnTitle,
+    short: nameColumnTitle,
   }),
   [CUSTOM_COLUMN]: (name) => ({
     full: name,


### PR DESCRIPTION
[EPMRPP-81599](https://jiraeu.epam.com/browse/EPMRPP-81599)
Undone points: 3. The Value container size is flexible and adapts to the size of the widget.

What can be improved: variable names

---

After: 
![Screenshot_192](https://user-images.githubusercontent.com/70880574/220363311-aca8e6a3-6c3f-4120-b34e-849e9656707f.png)
