### PR TITLE
EPMRPP-82778 || Show 'Next Error' feature only for detailed log view

### DIFF
--- a/app/src/controllers/log/index.js
+++ b/app/src/controllers/log/index.js
@@ -83,7 +83,6 @@ export {
   errorLogsItemsSelector,
   isLoadMoreStackTraceVisible,
   logViewModeSelector,
-  isLogPageWithOutNestedSteps,
   isLogPageWithNestedSteps,
   pageLoadingSelector,
   includeAllLaunchesSelector,

--- a/app/src/controllers/log/selectors.js
+++ b/app/src/controllers/log/selectors.js
@@ -261,7 +261,7 @@ export const logViewModeSelector = (state) => {
   return hasChildren || isLaunchLog ? LAUNCH_LOG_VIEW : DETAILED_LOG_VIEW;
 };
 
-export const isLogPageWithOutNestedSteps = createSelector(
+const isLogPageWithoutNestedSteps = createSelector(
   logItemsSelector,
   pagePropertiesSelector,
   (items, pageQuery) => {
@@ -272,6 +272,6 @@ export const isLogPageWithOutNestedSteps = createSelector(
   },
 );
 export const isLogPageWithNestedSteps = createSelector(
-  isLogPageWithOutNestedSteps,
+  isLogPageWithoutNestedSteps,
   (value) => !value,
 );

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -249,6 +249,7 @@ export class LogItemInfoTabs extends Component {
 
   toggleSauceLabsIntegrationContent = () => {
     this.props.tracking.trackEvent(LOG_PAGE_EVENTS.SAUCE_LABS_BTN);
+    // TODO: Handle SauceLabs integration as independent tab
     this.props.setActiveTabId('logs');
     this.props.onToggleSauceLabsIntegrationView();
   };

--- a/app/src/pages/inside/logsPage/logsGridToolbar/logsGridToolbar.jsx
+++ b/app/src/pages/inside/logsPage/logsGridToolbar/logsGridToolbar.jsx
@@ -28,7 +28,6 @@ import {
   getLogViewMode,
   setLogViewMode,
   DETAILED_LOG_VIEW,
-  isLogPageWithOutNestedSteps,
   isLogPageWithNestedSteps,
 } from 'controllers/log';
 import { InputSlider } from 'components/inputs/inputSlider';
@@ -73,7 +72,6 @@ const messages = defineMessages({
 @track()
 @connect((state) => ({
   userId: userIdSelector(state),
-  isLogView: isLogPageWithOutNestedSteps(state),
   isNestedStepsView: isLogPageWithNestedSteps(state),
 }))
 export class LogsGridToolbar extends Component {
@@ -97,7 +95,6 @@ export class LogsGridToolbar extends Component {
     onHideEmptySteps: PropTypes.func,
     onHidePassedLogs: PropTypes.func,
     logPageMode: PropTypes.string,
-    isLogView: PropTypes.bool,
     isNestedStepsView: PropTypes.bool,
     withAttachments: PropTypes.bool,
     isEmptyStepsHidden: PropTypes.bool,
@@ -114,7 +111,6 @@ export class LogsGridToolbar extends Component {
     onHideEmptySteps: () => {},
     onHidePassedLogs: () => {},
     logPageMode: DETAILED_LOG_VIEW,
-    isLogView: true,
     isNestedStepsView: false,
     withAttachments: false,
     isEmptyStepsHidden: false,
@@ -183,9 +179,9 @@ export class LogsGridToolbar extends Component {
   };
 
   isConsoleViewMode = () => {
-    const { isLogView } = this.props;
+    const { isNestedStepsView } = this.props;
     const { logViewMode } = this.state;
-    return logViewMode === CONSOLE && isLogView;
+    return logViewMode === CONSOLE && !isNestedStepsView;
   };
 
   render() {
@@ -197,7 +193,6 @@ export class LogsGridToolbar extends Component {
       onChangePage,
       logLevel,
       logPageMode,
-      isLogView,
       isNestedStepsView,
       withAttachments,
       isPassedLogsHidden,
@@ -215,13 +210,15 @@ export class LogsGridToolbar extends Component {
             <div className={cx('log-level')}>
               <InputSlider options={LOG_LEVELS} value={logLevel} onChange={this.changeLogLevel} />
             </div>
-            <div className={cx('aside-element')}>
-              <ErrorLogsControl
-                errorLogs={errorLogs}
-                highlightErrorLog={highlightErrorLog}
-                errorLogIndex={errorLogIndex}
-              />
-            </div>
+            {logPageMode === DETAILED_LOG_VIEW && (
+              <div className={cx('aside-element')}>
+                <ErrorLogsControl
+                  errorLogs={errorLogs}
+                  highlightErrorLog={highlightErrorLog}
+                  errorLogIndex={errorLogIndex}
+                />
+              </div>
+            )}
           </div>
           <div className={cx('aside')}>
             <div className={cx('aside-element-block')}>
@@ -258,7 +255,7 @@ export class LogsGridToolbar extends Component {
               >
                 {Parser(MarkdownIcon)}
               </button>
-              {isLogView && (
+              {!isNestedStepsView && (
                 <button
                   className={cx('mode-button', 'console', { active: logViewMode === CONSOLE })}
                   onClick={this.toggleConsoleView}

--- a/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
+++ b/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
@@ -185,30 +185,35 @@ export class LogsGridWrapper extends Component {
   };
 
   componentDidMount() {
-    const errorLogId = getStorageItem(ERROR_LOG_INDEX_KEY);
-    if (errorLogId) {
-      const { errorLogs } = this.props;
-      const errorLogIndex = errorLogs.findIndex(({ id }) => id === errorLogId);
-      removeStorageItem(ERROR_LOG_INDEX_KEY);
-      const fetchErrorLogCb = () => this.setState({ skipHighlightOnRender: false, errorLogIndex });
-      this.props.fetchErrorLog(errorLogs[errorLogIndex], fetchErrorLogCb);
+    if (this.props.logViewMode === DETAILED_LOG_VIEW) {
+      const errorLogId = getStorageItem(ERROR_LOG_INDEX_KEY);
+      if (errorLogId) {
+        const { errorLogs } = this.props;
+        const errorLogIndex = errorLogs.findIndex(({ id }) => id === errorLogId);
+        removeStorageItem(ERROR_LOG_INDEX_KEY);
+        const fetchErrorLogCb = () =>
+          this.setState({ skipHighlightOnRender: false, errorLogIndex });
+        this.props.fetchErrorLog(errorLogs[errorLogIndex], fetchErrorLogCb);
+      }
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      this.props.logLevelId !== prevProps.logLevelId ||
-      this.props.logStatus !== prevProps.logStatus ||
-      this.props.withAttachments !== prevProps.withAttachments ||
-      this.props.hideEmptySteps !== prevProps.hideEmptySteps ||
-      this.props.hidePassedLogs !== prevProps.hidePassedLogs ||
-      this.props.retryId !== prevProps.retryId ||
-      this.props.sortingDirection !== prevProps.sortingDirection ||
-      this.props.filter !== prevProps.filter ||
-      this.props.pageSize !== prevProps.pageSize
-    ) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ errorLogIndex: null, skipHighlightOnRender: false });
+    if (this.props.logViewMode === DETAILED_LOG_VIEW) {
+      if (
+        this.props.logLevelId !== prevProps.logLevelId ||
+        this.props.logStatus !== prevProps.logStatus ||
+        this.props.withAttachments !== prevProps.withAttachments ||
+        this.props.hideEmptySteps !== prevProps.hideEmptySteps ||
+        this.props.hidePassedLogs !== prevProps.hidePassedLogs ||
+        this.props.retryId !== prevProps.retryId ||
+        this.props.sortingDirection !== prevProps.sortingDirection ||
+        this.props.filter !== prevProps.filter ||
+        this.props.pageSize !== prevProps.pageSize
+      ) {
+        // eslint-disable-next-line react/no-did-update-set-state
+        this.setState({ errorLogIndex: null, skipHighlightOnRender: false });
+      }
     }
   }
 


### PR DESCRIPTION
Also in this PR:
`isLogPageWithOutNestedSteps` usage removed from 'LogsGridToolbar' as it is an opposite to `isLogPageWithNestedSteps` which is already used inside of the component.