### PR TITLE
Fix long UI service docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY ./app/ /usr/src/app/
 RUN export NODE_OPTIONS="--max-old-space-size=4096"
-RUN npm ci && npm run build && npm run test
+RUN npm ci && npm run build
 
 FROM nginxinc/nginx-unprivileged:alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY ./app/ /usr/src/app/
 RUN export NODE_OPTIONS="--max-old-space-size=4096"
-RUN npm ci && npm run lint && npm run test:coverage && npm run build
+RUN npm ci && npm run build && npm run test
 
 FROM nginxinc/nginx-unprivileged:alpine
 


### PR DESCRIPTION
Decided to remove `lint` and `test` commands form `Dockerfile` to speed up image building process.
Linting and testing steps are still present as CI workflow steps.