### PR TITLE
nginx-unprivileged common issue patch

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,5 @@
 worker_processes  1;
+pid /tmp/nginx.pid
 events {
     worker_connections  1024;
 }


### PR DESCRIPTION
Permission denied error when run as non-root. See Common Issues - https://hub.docker.com/r/nginxinc/nginx-unprivileged