### PR TITLE
Adjust plugin display name

### DIFF
--- a/app/src/common/constants/pluginNames.js
+++ b/app/src/common/constants/pluginNames.js
@@ -25,6 +25,7 @@ export const JIRA = 'jira';
 export const RALLY = 'rally';
 export const EMAIL = 'email';
 export const SAUCE_LABS = 'saucelabs';
+export const SAUCE_LABS_TITLE = 'Sauce Labs';
 export const SAML = 'saml';
 export const LDAP = 'ldap';
 export const AD = 'ad';

--- a/app/src/components/integrations/constants.js
+++ b/app/src/components/integrations/constants.js
@@ -24,17 +24,6 @@ import LdapIcon from 'common/img/plugins/ldap.png';
 import DefaultPluginIcon from 'common/img/plugins/default-plugin-icon.svg';
 import ActiveDirectoryIcon from 'common/img/plugins/activeDirectory.png';
 
-// Constants for plugins that do not provide UI extensions in their bundles
-export const PLUGIN_NAME_TITLES = {
-  [JIRA]: 'JIRA Server',
-  [RALLY]: 'RALLY',
-  [EMAIL]: 'Email Server',
-  [SAUCE_LABS]: 'Sauce Labs',
-  [SAML]: 'SAML',
-  [LDAP]: 'LDAP',
-  [AD]: 'Active Directory',
-};
-
 export const PLUGIN_IMAGES_MAP = {
   [JIRA]: JiraIcon,
   [RALLY]: RallyIcon,

--- a/app/src/components/integrations/containers/integrationInfoContainer/instancesSection/instancesSection.jsx
+++ b/app/src/components/integrations/containers/integrationInfoContainer/instancesSection/instancesSection.jsx
@@ -42,7 +42,6 @@ import {
   isIntegrationSupportsMultipleInstances,
   isPluginBuiltin,
 } from 'components/integrations/utils';
-import { PLUGIN_NAME_TITLES } from 'components/integrations/constants';
 import { EMAIL, LDAP } from 'common/constants/pluginNames';
 import { combineNameAndEmailToFrom } from 'common/utils';
 import { InstancesList } from './instancesList';
@@ -195,12 +194,12 @@ export class InstancesSection extends Component {
     );
 
   createIntegration = (formData, metaData) => {
-    const { isGlobal, instanceType } = this.props;
+    const { isGlobal, instanceType, pluginDetails } = this.props;
     const updatedFormData = instanceType === EMAIL ? combineNameAndEmailToFrom(formData) : formData;
     const data = {
       enabled: true,
       integrationParameters: updatedFormData,
-      name: updatedFormData.integrationName || PLUGIN_NAME_TITLES[instanceType],
+      name: updatedFormData.integrationName || pluginDetails.name,
     };
 
     this.props.addIntegrationAction(
@@ -217,6 +216,7 @@ export class InstancesSection extends Component {
       intl: { formatMessage },
       instanceType,
       tracking,
+      pluginDetails,
     } = this.props;
     tracking.trackEvent(getUninstallPluginBtnClickEvent(instanceType));
 
@@ -224,7 +224,7 @@ export class InstancesSection extends Component {
       id: 'confirmationModal',
       data: {
         message: formatMessage(messages.uninstallPluginConfirmation, {
-          pluginName: PLUGIN_NAME_TITLES[instanceType] || instanceType,
+          pluginName: pluginDetails.name || instanceType,
         }),
         onConfirm: this.removePlugin,
         title: formatMessage(messages.uninstallPluginTitle),

--- a/app/src/components/integrations/containers/integrationInfoContainer/integrationInfoContainer.jsx
+++ b/app/src/components/integrations/containers/integrationInfoContainer/integrationInfoContainer.jsx
@@ -22,7 +22,6 @@ import {
   namedProjectIntegrationsSelector,
   namedGlobalIntegrationsSelector,
 } from 'controllers/plugins';
-import { PLUGIN_NAME_TITLES } from '../../constants';
 import { PLUGIN_DESCRIPTIONS_MAP } from '../../messages';
 import { InfoSection } from './infoSection';
 import { InstancesSection } from './instancesSection';
@@ -70,7 +69,7 @@ export class IntegrationInfoContainer extends Component {
       showToggleConfirmationModal,
       events,
     } = this.props;
-    const pluginTitle = PLUGIN_NAME_TITLES[name] || name;
+    const pluginTitle = details.name || name;
 
     return (
       <Fragment>

--- a/app/src/components/integrations/elements/integrationSettings/connectionSection/connectionSection.jsx
+++ b/app/src/components/integrations/elements/integrationSettings/connectionSection/connectionSection.jsx
@@ -24,7 +24,6 @@ import track from 'react-tracking';
 import moment from 'moment';
 import Parser from 'html-react-parser';
 import { showModalAction } from 'controllers/modal';
-import { PLUGIN_NAME_TITLES } from 'components/integrations/constants';
 import { namedProjectIntegrationsSelector } from 'controllers/plugins';
 import { PLUGINS_PAGE_EVENTS, SETTINGS_PAGE_EVENTS } from 'components/main/analytics/events';
 import { SystemMessage } from 'componentLibrary/systemMessage';
@@ -107,6 +106,7 @@ export class ConnectionSection extends Component {
       integrationParameters: PropTypes.object,
       integrationType: PropTypes.object,
       projectId: PropTypes.number,
+      details: PropTypes.object,
     }).isRequired,
   };
 
@@ -162,7 +162,7 @@ export class ConnectionSection extends Component {
       projectIntegrations,
       pluginName,
       isEditable,
-      data: { name, creator, creationDate },
+      data: { name, creator, creationDate, details },
     } = this.props;
 
     const availableProjectIntegrations = projectIntegrations[pluginName] || [];
@@ -177,7 +177,7 @@ export class ConnectionSection extends Component {
               caption={formatMessage(messages.connectionFailedCapture)}
             >
               {formatMessage(messages.connectionFailedDescription, {
-                pluginName: PLUGIN_NAME_TITLES[pluginName] || pluginName,
+                pluginName: details.name || pluginName,
               })}
             </SystemMessage>
           </div>

--- a/app/src/components/integrations/elements/integrationSettings/integrationSettings.jsx
+++ b/app/src/components/integrations/elements/integrationSettings/integrationSettings.jsx
@@ -132,7 +132,7 @@ export const IntegrationSettings = (props) => {
     isGlobal,
   } = props;
   const pluginName = data.integrationType?.name;
-  const isLdap = pluginName === LDAP;
+  const isLdap = data.integrationType?.name === LDAP;
 
   return (
     <div className={cx('integration-settings')}>

--- a/app/src/components/integrations/elements/integrationSettings/integrationSettings.jsx
+++ b/app/src/components/integrations/elements/integrationSettings/integrationSettings.jsx
@@ -132,7 +132,7 @@ export const IntegrationSettings = (props) => {
     isGlobal,
   } = props;
   const pluginName = data.integrationType?.name;
-  const isLdap = data.integrationType?.name === LDAP;
+  const isLdap = pluginName === LDAP;
 
   return (
     <div className={cx('integration-settings')}>

--- a/app/src/components/integrations/index.js
+++ b/app/src/components/integrations/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { PLUGIN_IMAGES_MAP, PLUGIN_NAME_TITLES, PLUGIN_DEFAULT_IMAGE } from './constants';
+export { PLUGIN_IMAGES_MAP, PLUGIN_DEFAULT_IMAGE } from './constants';
 export { INTEGRATIONS_SETTINGS_COMPONENTS_MAP } from './settingsComponentsMap';
 export { AddIntegrationModal } from './modals/addIntegrationModal';
 export { AddLdapIntegrationModal } from './modals/addLdapIntegrationModal';

--- a/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
+++ b/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
@@ -90,10 +90,10 @@ export class PluginsItem extends Component {
 
   onChangeHandler = () => {
     const {
-      data: { name, enabled, details: { pluginLocation } = {} },
+      data: { name, enabled, details: { name: displayName, pluginLocation } = {} },
       showToggleConfirmationModal,
     } = this.props;
-    const pluginName = PLUGIN_NAME_TITLES[name] || name;
+    const pluginName = displayName || name;
 
     showToggleConfirmationModal(enabled, pluginName, this.toggleActiveHandler, pluginLocation);
   };
@@ -106,11 +106,11 @@ export class PluginsItem extends Component {
         uploadedBy,
         enabled,
         groupType,
-        details: { version, disabledPluginTooltip } = {},
+        details: { name: displayName, version, disabledPluginTooltip } = {},
       },
       toggleable,
     } = this.props;
-    const pluginName = PLUGIN_NAME_TITLES[name] || name;
+    const pluginName = displayName || name;
 
     return (
       <div

--- a/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
+++ b/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
@@ -119,7 +119,9 @@ export class PluginsItem extends Component {
           enabled
             ? ''
             : disabledPluginTooltip ||
-              formatMessage(PLUGIN_DISABLED_MESSAGES_BY_GROUP_TYPE[groupType], { name: displayName })
+              formatMessage(PLUGIN_DISABLED_MESSAGES_BY_GROUP_TYPE[groupType], {
+                name: displayName,
+              })
         }
       >
         <div className={cx('plugins-info-block')}>

--- a/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
+++ b/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
@@ -23,7 +23,6 @@ import {
   getPluginItemClickEvent,
   getDisablePluginItemClickEvent,
 } from 'components/main/analytics/events';
-import { PLUGIN_NAME_TITLES } from 'components/integrations/constants';
 import { PLUGIN_DISABLED_MESSAGES_BY_GROUP_TYPE } from 'components/integrations/messages';
 import { InputSwitcher } from 'components/inputs/inputSwitcher';
 import { PluginIcon } from 'components/integrations/elements/pluginIcon';
@@ -90,12 +89,12 @@ export class PluginsItem extends Component {
 
   onChangeHandler = () => {
     const {
-      data: { name, enabled, details: { name: displayName, pluginLocation } = {} },
+      data: { name, enabled, details: { name: detailsName, pluginLocation } = {} },
       showToggleConfirmationModal,
     } = this.props;
-    const pluginName = displayName || name;
+    const displayName = detailsName || name;
 
-    showToggleConfirmationModal(enabled, pluginName, this.toggleActiveHandler, pluginLocation);
+    showToggleConfirmationModal(enabled, displayName, this.toggleActiveHandler, pluginLocation);
   };
 
   render() {
@@ -106,11 +105,11 @@ export class PluginsItem extends Component {
         uploadedBy,
         enabled,
         groupType,
-        details: { name: displayName, version, disabledPluginTooltip } = {},
+        details: { name: detailsName, version, disabledPluginTooltip } = {},
       },
       toggleable,
     } = this.props;
-    const pluginName = displayName || name;
+    const displayName = detailsName || name;
 
     return (
       <div
@@ -120,17 +119,17 @@ export class PluginsItem extends Component {
           enabled
             ? ''
             : disabledPluginTooltip ||
-              formatMessage(PLUGIN_DISABLED_MESSAGES_BY_GROUP_TYPE[groupType], { name: pluginName })
+              formatMessage(PLUGIN_DISABLED_MESSAGES_BY_GROUP_TYPE[groupType], { name: displayName })
         }
       >
         <div className={cx('plugins-info-block')}>
           <PluginIcon
             className={cx('plugins-image')}
             pluginData={this.props.data}
-            alt={pluginName}
+            alt={displayName}
           />
           <div className={cx('plugins-info')}>
-            <span className={cx('plugins-name')}>{pluginName}</span>
+            <span className={cx('plugins-name')}>{displayName}</span>
             <span className={cx('plugins-author')}>{`by ${uploadedBy || 'Report Portal'}`}</span>
             <span
               className={cx('plugins-version')}

--- a/app/src/pages/admin/pluginsPage/pluginsTabs/installedTab/installedTab.jsx
+++ b/app/src/pages/admin/pluginsPage/pluginsTabs/installedTab/installedTab.jsx
@@ -37,7 +37,6 @@ import {
 } from 'components/integrations/containers';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { showModalAction } from 'controllers/modal';
-import { PLUGIN_NAME_TITLES } from 'components/integrations';
 import { InputDropdown } from 'components/inputs/inputDropdown';
 import {
   INSTALLED_PLUGINS_SUBPAGE,
@@ -302,7 +301,7 @@ export class InstalledTab extends Component {
     this.changeSubPage({
       type: INSTALLED_PLUGINS_SUBPAGE,
       data: pageData,
-      title: PLUGIN_NAME_TITLES[pageData.name] || pageData.name,
+      title: pageData.details.name || pageData.name,
     });
 
   renderFilterMobileBlock = () => (

--- a/app/src/pages/inside/common/btsIntegrationSelector/btsIntegrationSelector.jsx
+++ b/app/src/pages/inside/common/btsIntegrationSelector/btsIntegrationSelector.jsx
@@ -20,7 +20,6 @@ import classNames from 'classnames/bind';
 import { injectIntl, defineMessages } from 'react-intl';
 import { Dropdown } from 'componentLibrary/dropdown';
 import { FieldElement } from 'pages/inside/projectSettingsPageContainer/content/elements';
-import { PLUGIN_NAME_TITLES } from 'components/integrations';
 import styles from './btsIntegrationSelector.scss';
 
 const cx = classNames.bind(styles);
@@ -51,7 +50,7 @@ export class BtsIntegrationSelector extends Component {
     super(props);
     this.pluginNamesOptions = Object.keys(props.namedBtsIntegrations).map((key) => ({
       value: key,
-      label: PLUGIN_NAME_TITLES[key] || key,
+      label: key,
     }));
   }
 

--- a/app/src/pages/inside/common/btsIntegrationSelector/btsIntegrationSelector.jsx
+++ b/app/src/pages/inside/common/btsIntegrationSelector/btsIntegrationSelector.jsx
@@ -50,7 +50,7 @@ export class BtsIntegrationSelector extends Component {
     super(props);
     this.pluginNamesOptions = Object.keys(props.namedBtsIntegrations).map((key) => ({
       value: key,
-      label: key,
+      label: props.namedBtsIntegrations[key][0]?.integrationType.details.name || key,
     }));
   }
 

--- a/app/src/pages/inside/common/itemInfo/itemInfo.jsx
+++ b/app/src/pages/inside/common/itemInfo/itemInfo.jsx
@@ -22,7 +22,8 @@ import { injectIntl, defineMessages } from 'react-intl';
 import classNames from 'classnames/bind';
 import Parser from 'html-react-parser';
 import { fromNowFormat } from 'common/utils';
-import { SAUCE_LABS } from 'common/constants/pluginNames';
+import { SAUCE_LABS, SAUCE_LABS_TITLE } from 'common/constants/pluginNames';
+
 import { isStepLevelSelector, formatItemName } from 'controllers/testItem';
 import {
   availableIntegrationsByPluginNameSelector,
@@ -33,7 +34,6 @@ import { ANALYZER_TYPES } from 'common/constants/analyzerTypes';
 import { RETENTION_POLICY } from 'common/constants/retentionPolicy';
 import { MarkdownViewer } from 'components/main/markdown';
 import { LAUNCHES_PAGE_EVENTS } from 'components/main/analytics/events';
-import { PLUGIN_NAME_TITLES } from 'components/integrations';
 import { getSauceLabsConfig } from 'components/integrations/integrationProviders/sauceLabsIntegration/utils';
 import { formatMethodType, formatStatus } from 'common/utils/localizationUtils';
 import PencilIcon from 'common/img/pencil-icon-inline.svg';
@@ -123,7 +123,7 @@ export class ItemInfo extends Component {
     const isSauceLabsIntegrationAvailable = !!getSauceLabsConfig(this.props.value.attributes);
     if (isSauceLabsIntegrationAvailable && this.props.sauceLabsIntegrations.length) {
       return (
-        <i className={cx('sauce-labs-label')} title={PLUGIN_NAME_TITLES[SAUCE_LABS]}>
+        <i className={cx('sauce-labs-label')} title={SAUCE_LABS_TITLE}>
           {Parser(SauceLabsIcon)}
         </i>
       );

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/sauceLabsIntegrationButton/sauceLabsIntegrationButton.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/sauceLabsIntegrationButton/sauceLabsIntegrationButton.jsx
@@ -18,14 +18,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Parser from 'html-react-parser';
 import SauceLabsIcon from 'common/img/plugins/sauce-labs-gray-inline.svg';
-import { SAUCE_LABS } from 'common/constants/pluginNames';
-import { PLUGIN_NAME_TITLES } from 'components/integrations';
+import { SAUCE_LABS_TITLE } from 'common/constants/pluginNames';
 import styles from './sauceLabsIntegrationButton.scss';
 
 const cx = classNames.bind(styles);
 
 export const SauceLabsIntegrationButton = ({ active, onClick }) => {
-  const title = PLUGIN_NAME_TITLES[SAUCE_LABS];
+  const title = SAUCE_LABS_TITLE;
 
   return (
     <button className={cx('sauce-labs-integration-button', { active })} onClick={onClick}>

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/index.js
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/index.js
@@ -13,4 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+export { AddIntegrationModal } from 'components/integrations/modals/addIntegrationModal';
+export { AddLdapIntegrationModal } from 'components/integrations/modals/addLdapIntegrationModal';
+export { DeleteIntegrationModal } from 'components/integrations/modals/deleteIntegrationModal';
+
 export { IntegrationInfo } from './integrationInfo';

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationHeader/integrationHeader.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationHeader/integrationHeader.jsx
@@ -20,7 +20,6 @@ import { useIntl } from 'react-intl';
 import classNames from 'classnames/bind';
 import Parser from 'html-react-parser';
 import { Button } from '@reportportal/ui-kit';
-import { PLUGIN_NAME_TITLES } from 'components/integrations';
 import { PLUGIN_DESCRIPTIONS_MAP } from 'components/integrations/messages';
 import { PluginIcon } from 'components/integrations/elements/pluginIcon';
 import { Breadcrumbs } from 'componentLibrary/breadcrumbs';
@@ -38,7 +37,7 @@ export const IntegrationHeader = (props) => {
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
   const {
-    data: { name, details = {} },
+    data: { name, details = { name } },
     data,
     onAddProjectIntegration,
     onResetProjectIntegration,
@@ -48,9 +47,11 @@ export const IntegrationHeader = (props) => {
     breadcrumbs,
   } = props;
 
+  const displayName = details.name || name;
   const isProjectIntegrationAddLimited =
     [EMAIL, SAUCE_LABS].includes(name) && availableProjectIntegrations.length > 0;
-  const { documentationLink = '' } = details;
+
+  const documentationLink = details.documentation || details.documentationLink || '';
   const analyticsData = withButton ? 'integrations' : 'no_integrations';
 
   const handleDocumentationClick = () => {
@@ -92,7 +93,7 @@ export const IntegrationHeader = (props) => {
           <PluginIcon className={cx('integration-image')} pluginData={data} alt={name} />
           <div className={cx('integration-info-block')}>
             <div className={cx('integration-data-block')}>
-              <span className={cx('integration-name')}>{PLUGIN_NAME_TITLES[name] || name}</span>
+              <span className={cx('integration-name')}>{displayName}</span>
               <span className={cx('integration-version')}>
                 {details.version && `${formatMessage(messages.version)} ${details.version}`}
               </span>

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
@@ -117,7 +117,7 @@ export const IntegrationInfo = (props) => {
     const newData = {
       enabled: true,
       integrationParameters: updatedFormData,
-      name: updatedFormData.integrationName,
+      name: updatedFormData.integrationName || details.name,
     };
     trackEvent(PROJECT_SETTINGS_INTEGRATION.CLICK_CREATE_INTEGRATION_MODAL(pluginName));
     dispatch(addIntegrationAction(newData, false, pluginName, openIntegration, metaData));

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
@@ -28,7 +28,6 @@ import {
 } from 'controllers/user';
 import { uiExtensionIntegrationSettingsSelector } from 'controllers/plugins/uiExtensions/selectors';
 import { canUpdateSettings } from 'common/utils/permissions';
-import { PLUGIN_NAME_TITLES } from 'components/integrations';
 import { showModalAction } from 'controllers/modal';
 import {
   namedGlobalIntegrationsSelector,
@@ -118,7 +117,7 @@ export const IntegrationInfo = (props) => {
     const newData = {
       enabled: true,
       integrationParameters: updatedFormData,
-      name: updatedFormData.integrationName || PLUGIN_NAME_TITLES[pluginName],
+      name: updatedFormData.integrationName,
     };
     trackEvent(PROJECT_SETTINGS_INTEGRATION.CLICK_CREATE_INTEGRATION_MODAL(pluginName));
     dispatch(addIntegrationAction(newData, false, pluginName, openIntegration, metaData));
@@ -205,7 +204,7 @@ export const IntegrationInfo = (props) => {
     },
     {
       id: pluginName,
-      title: `${PLUGIN_NAME_TITLES[pluginName] || pluginName} ${formatMessage(messages.settings)}`,
+      title: `${details.name || pluginName} ${formatMessage(messages.settings)}`,
       link: pluginIntegrationListLink,
     },
     {

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationsListItem/integrationsListItem.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationsListItem/integrationsListItem.jsx
@@ -19,7 +19,6 @@ import { defineMessages, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Parser from 'html-react-parser';
-import { PLUGIN_NAME_TITLES } from 'components/integrations/constants';
 import { PLUGIN_DESCRIPTIONS_MAP } from 'components/integrations/messages';
 import { PluginIcon } from 'components/integrations/elements/pluginIcon';
 import styles from './integrationsListItem.scss';
@@ -36,10 +35,12 @@ export const messages = defineMessages({
 export const IntegrationsListItem = (props) => {
   const { formatMessage } = useIntl();
   const {
-    integrationType: { name, details = {} },
+    integrationType: { name, details = { name } },
     integrationType,
     onItemClick,
   } = props;
+
+  const displayName = details.name || name;
 
   const itemClickHandler = () => {
     onItemClick(integrationType);
@@ -50,10 +51,10 @@ export const IntegrationsListItem = (props) => {
       onClick={itemClickHandler}
       data-automation-id="listItem"
     >
-      <PluginIcon className={cx('integration-image')} pluginData={integrationType} alt={name} />
+      <PluginIcon className={cx('integration-image')} pluginData={integrationType} alt={displayName} />
       <div className={cx('integration-info-block')}>
         <div className={cx('integration-data-block')}>
-          <span className={cx('integration-name')}>{PLUGIN_NAME_TITLES[name] || name}</span>
+          <span className={cx('integration-name')}>{displayName}</span>
           <span className={cx('integration-version')}>
             {details.version && `${formatMessage(messages.version)} ${details.version}`}
           </span>

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationsListItem/integrationsListItem.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationsListItem/integrationsListItem.jsx
@@ -51,7 +51,11 @@ export const IntegrationsListItem = (props) => {
       onClick={itemClickHandler}
       data-automation-id="listItem"
     >
-      <PluginIcon className={cx('integration-image')} pluginData={integrationType} alt={displayName} />
+      <PluginIcon
+        className={cx('integration-image')}
+        pluginData={integrationType}
+        alt={displayName}
+      />
       <div className={cx('integration-info-block')}>
         <div className={cx('integration-data-block')}>
           <span className={cx('integration-name')}>{displayName}</span>


### PR DESCRIPTION
This pull request focuses on removing the `PLUGIN_NAME_TITLES` constant and updating the code to use the `details.name` property directly for plugin names. The changes span multiple files and components, ensuring that the plugin name is consistently retrieved from the `details` object.

Key changes include:

### Removal of `PLUGIN_NAME_TITLES` Constant:
* [`app/src/components/integrations/containers/integrationInfoContainer/integrationInfoContainer.jsx`](diffhunk://#diff-b5a3dc458a50031423d560a179934eba5282ca74b09855529709897241710e97L25): Removed the import of `PLUGIN_NAME_TITLES` and updated the `pluginTitle` to use `details.name` instead. [[1]](diffhunk://#diff-b5a3dc458a50031423d560a179934eba5282ca74b09855529709897241710e97L25) [[2]](diffhunk://#diff-b5a3dc458a50031423d560a179934eba5282ca74b09855529709897241710e97L73-R72)
* [`app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx`](diffhunk://#diff-4f5503d5b6f8b9027b2016cbc9cccdbca439aba6e41112aa8963397d3a4a720aL26): Removed the import of `PLUGIN_NAME_TITLES` and updated multiple references to use `details.name` for `pluginName`. [[1]](diffhunk://#diff-4f5503d5b6f8b9027b2016cbc9cccdbca439aba6e41112aa8963397d3a4a720aL26) [[2]](diffhunk://#diff-4f5503d5b6f8b9027b2016cbc9cccdbca439aba6e41112aa8963397d3a4a720aL93-R97) [[3]](diffhunk://#diff-4f5503d5b6f8b9027b2016cbc9cccdbca439aba6e41112aa8963397d3a4a720aL109-R112) [[4]](diffhunk://#diff-4f5503d5b6f8b9027b2016cbc9cccdbca439aba6e41112aa8963397d3a4a720aL123-R132)
* [`app/src/pages/admin/pluginsPage/pluginsTabs/installedTab/installedTab.jsx`](diffhunk://#diff-8e39fcfc456f48e940934f4cb5314804d07ceebdf42481587f193e4223f61ccfL40): Removed the import of `PLUGIN_NAME_TITLES` and updated the `title` to use `pageData.details.name`. [[1]](diffhunk://#diff-8e39fcfc456f48e940934f4cb5314804d07ceebdf42481587f193e4223f61ccfL40) [[2]](diffhunk://#diff-8e39fcfc456f48e940934f4cb5314804d07ceebdf42481587f193e4223f61ccfL305-R304)
* [`app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationHeader/integrationHeader.jsx`](diffhunk://#diff-658180506b1b9693b5ba948e1bcd52be9f9c0dc1abcaa0cb9540e39bf09e7d63L23): Removed the import of `PLUGIN_NAME_TITLES` and updated the `integration-name` to use `details.name`. [[1]](diffhunk://#diff-658180506b1b9693b5ba948e1bcd52be9f9c0dc1abcaa0cb9540e39bf09e7d63L23) [[2]](diffhunk://#diff-658180506b1b9693b5ba948e1bcd52be9f9c0dc1abcaa0cb9540e39bf09e7d63L41-R40) [[3]](diffhunk://#diff-658180506b1b9693b5ba948e1bcd52be9f9c0dc1abcaa0cb9540e39bf09e7d63R50-R54) [[4]](diffhunk://#diff-658180506b1b9693b5ba948e1bcd52be9f9c0dc1abcaa0cb9540e39bf09e7d63L95-R96)
* [`app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationsListItem/integrationsListItem.jsx`](diffhunk://#diff-a4ea0d10d67f5f809d0ca8eef4a1a7e6ef654edac811ef2a06630e354490333cL22): Removed the import of `PLUGIN_NAME_TITLES` and updated the `integration-name` to use `details.name`. [[1]](diffhunk://#diff-a4ea0d10d67f5f809d0ca8eef4a1a7e6ef654edac811ef2a06630e354490333cL22) [[2]](diffhunk://#diff-a4ea0d10d67f5f809d0ca8eef4a1a7e6ef654edac811ef2a06630e354490333cL39-R44) [[3]](diffhunk://#diff-a4ea0d10d67f5f809d0ca8eef4a1a7e6ef654edac811ef2a06630e354490333cL53-R57)