### PR TITLE
EPMRPP-105168 || Display custom values in organization settings and send GA events

### DIFF
--- a/app/src/common/utils/index.js
+++ b/app/src/common/utils/index.js
@@ -43,6 +43,7 @@ export {
   secondsToHours,
   hoursToDays,
   getApproximateTime,
+  humanizeDays,
 } from './timeDateUtils';
 export { connectRouter } from './connectRouter';
 export { uniqueId } from './uniqueId';

--- a/app/src/common/utils/timeDateUtils.js
+++ b/app/src/common/utils/timeDateUtils.js
@@ -161,6 +161,9 @@ export const daysToSeconds = (days) => moment.duration(days, 'days').asSeconds()
 export const secondsToHours = (seconds) => moment.duration(seconds, 'seconds').asHours();
 export const hoursToDays = (hours) => moment.duration(hours, 'hours').asDays();
 
+export const humanizeDays = (days, locale) =>
+  moment.duration(days, 'days').locale(locale).humanize({ d: Number.MAX_SAFE_INTEGER });
+
 export const getMillisecondsWoTimezone = (time) => {
   const date = new Date(time);
   const userTimezoneOffset = date.getTimezoneOffset() * 60000;

--- a/app/src/common/utils/timeDateUtils.test.js
+++ b/app/src/common/utils/timeDateUtils.test.js
@@ -25,6 +25,7 @@ import {
   daysToSeconds,
   secondsToHours,
   hoursToDays,
+  humanizeDays,
 } from './timeDateUtils';
 
 const NOW = Date.now();
@@ -168,5 +169,27 @@ describe('hoursToDays', () => {
 
   it('converts 36 hours to 1.5 days', () => {
     expect(hoursToDays(36)).toBe(1.5);
+  });
+});
+
+describe('humanizeDays', () => {
+  it('should return "a day" for 1 day in English', () => {
+    expect(humanizeDays(1, 'en')).toBe('a day');
+  });
+
+  it('should return "5 days" for 5 days in English', () => {
+    expect(humanizeDays(5, 'en')).toBe('5 days');
+  });
+
+  it('should return "день" for 1 day in Russian', () => {
+    expect(humanizeDays(1, 'ru')).toBe('день');
+  });
+
+  it('should return "5 дней" for 5 days in Russian', () => {
+    expect(humanizeDays(5, 'ru')).toBe('5 дней');
+  });
+
+  it('should return "3 дня" for 3 days in Russian', () => {
+    expect(humanizeDays(3, 'ru')).toBe('3 дня');
   });
 });

--- a/app/src/components/main/analytics/events/ga4Events/organizationsPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/organizationsPageEvents.ts
@@ -50,4 +50,14 @@ export const ORGANIZATION_PAGE_EVENTS = {
     element_name: 'export',
     number: appliedFiltersCount,
   }),
+  viewOrganizationSettings: (page: string) => ({
+    ...BASIC_EVENT_PARAMETERS,
+    place: `organization_settings_${page}`,
+  }),
+  updateOrganizationSettings: ({ keepLaunches, keepLogs, keepScreenshots }) => ({
+    ...BASIC_EVENT_PARAMETERS,
+    place: 'general',
+    element_name: 'button_submit',
+    type: `${keepLaunches}#${keepLogs}#${keepScreenshots}`,
+  }),
 };

--- a/app/src/pages/organization/organizationSettingsPage/content/generalTab/generalTab.jsx
+++ b/app/src/pages/organization/organizationSettingsPage/content/generalTab/generalTab.jsx
@@ -33,6 +33,8 @@ import { userRolesSelector } from 'controllers/pages';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { SpinningPreloader } from 'components/preloaders/spinningPreloader';
 import { settingsMessages } from 'common/constants/localization/settingsLocalization';
+import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
+import { useTracking } from 'react-tracking';
 import { useRetentionUtils } from './hooks';
 import { messages } from './generalTabMessages';
 import styles from './generalTab.scss';
@@ -45,6 +47,7 @@ const selector = formValueSelector(GENERAL_TAB_FORM);
 const GeneralTabForm = ({ initialize, handleSubmit }) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
+  const { trackEvent } = useTracking();
   const organizationId = useSelector(activeOrganizationIdSelector);
   const organizationName = useSelector(activeOrganizationNameSelector);
   const { attachments, launches, logs } = useSelector(activeOrganizationSettingsSelector);
@@ -58,6 +61,10 @@ const GeneralTabForm = ({ initialize, handleSubmit }) => {
   const { getLaunchesOptions, getLogOptions, getScreenshotsOptions } =
     useRetentionUtils(formValues);
   const isDisabled = !canPerformUpdate || processingData;
+
+  useEffect(() => {
+    trackEvent(ORGANIZATION_PAGE_EVENTS.viewOrganizationSettings('general'));
+  }, [trackEvent]);
 
   useEffect(() => {
     if (organizationName) {
@@ -80,6 +87,7 @@ const GeneralTabForm = ({ initialize, handleSubmit }) => {
     };
 
     dispatch(updateOrganizationSettingsAction({ organizationId, retentionPolicy }));
+    trackEvent(ORGANIZATION_PAGE_EVENTS.updateOrganizationSettings(formData));
   };
 
   return isLoading ? (

--- a/app/src/pages/organization/organizationSettingsPage/content/generalTab/hooks.js
+++ b/app/src/pages/organization/organizationSettingsPage/content/generalTab/hooks.js
@@ -15,21 +15,43 @@
  */
 
 import { settingsMessages } from 'common/constants/localization/settingsLocalization';
+import { humanizeDays } from 'common/utils';
 import { useIntl } from 'react-intl';
 
 export const useRetentionUtils = (formValues) => {
-  const { formatMessage } = useIntl();
+  const { locale, formatMessage } = useIntl();
 
-  const getRetentionOptions = () => {
-    return [
-      { label: formatMessage(settingsMessages.week1), value: 7 },
-      { label: formatMessage(settingsMessages.week2), value: 14 },
-      { label: formatMessage(settingsMessages.week3), value: 21 },
-      { label: formatMessage(settingsMessages.month1), value: 30 },
-      { label: formatMessage(settingsMessages.month3), value: 90 },
-      { label: formatMessage(settingsMessages.month6), value: 180 },
-      { label: formatMessage(settingsMessages.forever), value: 0 },
-    ];
+  const baseOptions = [
+    { label: formatMessage(settingsMessages.week1), value: 7 },
+    { label: formatMessage(settingsMessages.week2), value: 14 },
+    { label: formatMessage(settingsMessages.week3), value: 21 },
+    { label: formatMessage(settingsMessages.month1), value: 30 },
+    { label: formatMessage(settingsMessages.month3), value: 90 },
+    { label: formatMessage(settingsMessages.month6), value: 180 },
+    { label: formatMessage(settingsMessages.forever), value: 0 },
+  ];
+
+  const sortValues = (a, b) => {
+    if (a.value === 0) {
+      return 1;
+    }
+
+    if (b.value === 0) {
+      return -1;
+    }
+
+    return a.value - b.value;
+  };
+
+  const getRetentionOptions = (value) => {
+    const options = [...baseOptions];
+
+    if (!options.some((elem) => elem.value === value)) {
+      options.push({ label: humanizeDays(value, locale), value });
+      options.sort(sortValues);
+    }
+
+    return options;
   };
 
   const formatInputValues = (values) => {
@@ -47,7 +69,7 @@ export const useRetentionUtils = (formValues) => {
 
   const getLaunchesOptions = () => {
     const inputValues = formatInputValues(formValues);
-    const options = getRetentionOptions();
+    const options = getRetentionOptions(formValues.keepLaunches);
     const newOptions = options.map((elem) => {
       const disabled =
         elem.value !== 0 &&
@@ -64,7 +86,7 @@ export const useRetentionUtils = (formValues) => {
 
   const getLogOptions = () => {
     const inputValues = formatInputValues(formValues);
-    const options = getRetentionOptions();
+    const options = getRetentionOptions(formValues.keepLogs);
     const newOptions = options.map((elem) => {
       const disabled =
         elem.value === 0
@@ -87,7 +109,7 @@ export const useRetentionUtils = (formValues) => {
 
   const getScreenshotsOptions = () => {
     const inputValues = formatInputValues(formValues);
-    const options = getRetentionOptions();
+    const options = getRetentionOptions(formValues.keepScreenshots);
     const newOptions = options.map((elem) => {
       const isHidden =
         elem.value === 0 ? elem.value !== inputValues.keepLogs : elem.value > inputValues.keepLogs;


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?

## Visuals
![Screenshot 2025-07-08 103353](https://github.com/user-attachments/assets/a075b560-d53e-420b-9c0a-b533c0c415ec)
![Screenshot 2025-07-08 103405](https://github.com/user-attachments/assets/56a9a965-c82a-4f2a-8337-49b4f8bfeff5)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new utility for displaying human-readable durations in days, supporting multiple languages.
  * Introduced enhanced analytics tracking for viewing and updating organization settings.
  * Retention period dropdowns now dynamically show custom options based on user input, with labels localized to the current language.

* **Bug Fixes**
  * Improved pluralization and localization for retention period labels in English and Russian.

* **Tests**
  * Added tests to verify correct localization and pluralization of the new human-readable days utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->