### PR TITLE
EPMRPP-104183 || Fix delete organization modal functionality

### DIFF
--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -154,8 +154,7 @@ export const URLS = {
     `${urlCommonBase}organizations/${organizationId}/projects/${projectId}`,
   organizationSettings: (organizationId) =>
     `${urlCommonBase}organizations/${organizationId}/settings`,
-  organizationById: (organizationId) =>
-    `${urlCommonBase}organizations/${organizationId}`,
+  organizationById: (organizationId) => `${urlCommonBase}organizations/${organizationId}`,
 
   projectByName: (projectKey) => `${urlBase}project/${projectKey}`,
   project: (ids = []) => `${urlBase}project?ids=${ids.join(',')}`,

--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -154,6 +154,8 @@ export const URLS = {
     `${urlCommonBase}organizations/${organizationId}/projects/${projectId}`,
   organizationSettings: (organizationId) =>
     `${urlCommonBase}organizations/${organizationId}/settings`,
+  organizationById: (organizationId) =>
+    `${urlCommonBase}organizations/${organizationId}`,
 
   projectByName: (projectKey) => `${urlBase}project/${projectKey}`,
   project: (ids = []) => `${urlBase}project?ids=${ids.join(',')}`,

--- a/app/src/common/utils/permissions/index.ts
+++ b/app/src/common/utils/permissions/index.ts
@@ -49,5 +49,6 @@ export {
   canExportOrganizations,
   canInviteUserToOrganization,
   canSeeActivityOption,
+  canDeleteOrganization,
 } from './permissions';
 export { getRoleTitle, getRoleBadgesData, getOrgRoleTitle } from './getRoleTitle';

--- a/app/src/common/utils/validation/validate.js
+++ b/app/src/common/utils/validation/validate.js
@@ -85,6 +85,10 @@ export const itemNameEntity = composeValidators([
   isNotEmpty,
   ({ value }) => composeValidators([isNotEmpty, lengthRange(3, 256)])(value),
 ]);
+
+export const createOrganizationNameValidator = (expectedName) => (enteredName) =>
+  enteredName && enteredName.toLowerCase() === expectedName.toLowerCase();
+
 export const launchNumericEntity = composeValidators([
   isNotEmpty,
   ({ value }) => composeValidators([isNotEmpty, maxLength(18), regex(/^[0-9]+$/)])(value),

--- a/app/src/components/main/notification/notificationList/notificationList.jsx
+++ b/app/src/components/main/notification/notificationList/notificationList.jsx
@@ -59,6 +59,14 @@ const messages = defineMessages({
     id: 'ProjectsPage.deleteProjectSuccess',
     defaultMessage: "The project ''{name}'' has been successfully deleted",
   },
+  deleteOrganizationSuccess: {
+    id: 'OrganizationsPage.deleteOrganizationSuccess',
+    defaultMessage: "The organization ''{name}'' has been deleted successfully",
+  },
+  deleteOrganizationError: {
+    id: 'OrganizationsPage.deleteOrganizationError',
+    defaultMessage: 'An error occurred during deleting the organization: {error}',
+  },
   updateProjectSuccess: {
     id: 'ProjectsPage.updateProjectSuccess',
     defaultMessage: 'The project has been updated successfully',

--- a/app/src/controllers/organization/actionCreators.js
+++ b/app/src/controllers/organization/actionCreators.js
@@ -21,6 +21,7 @@ import {
   SET_ACTIVE_ORGANIZATION,
   UPDATE_ORGANIZATION_SETTINGS,
   UPDATE_ORGANIZATION_SETTINGS_SUCCESS,
+  DELETE_ORGANIZATION,
 } from './constants';
 
 export const prepareActiveOrganizationProjectsAction = (payload) => ({
@@ -50,5 +51,10 @@ export const updateOrganizationSettingsAction = (payload) => ({
 
 export const updateOrganizationSettingsSuccessAction = (payload) => ({
   type: UPDATE_ORGANIZATION_SETTINGS_SUCCESS,
+  payload,
+});
+
+export const deleteOrganizationAction = (payload) => ({
+  type: DELETE_ORGANIZATION,
   payload,
 });

--- a/app/src/controllers/organization/constants.js
+++ b/app/src/controllers/organization/constants.js
@@ -28,3 +28,5 @@ export const PREPARE_ACTIVE_ORGANIZATION_SETTINGS = 'prepareActiveOrganizationSe
 
 export const UPDATE_ORGANIZATION_SETTINGS = 'updateOrganizationSettings';
 export const UPDATE_ORGANIZATION_SETTINGS_SUCCESS = 'updateOrganizationSettingsSuccess';
+
+export const DELETE_ORGANIZATION = 'deleteOrganization';

--- a/app/src/controllers/organization/sagas.js
+++ b/app/src/controllers/organization/sagas.js
@@ -35,7 +35,6 @@ import { fetch } from 'common/utils';
 import { updateOrganizationSettingsSuccessAction } from './actionCreators';
 import { hideModalAction } from 'controllers/modal';
 import { fetchFilteredOrganizationsAction } from 'controllers/instance/organizations';
-import { showSuccessNotification } from 'controllers/notification';
 
 function* fetchOrganizationBySlug({ payload: slug }) {
   try {

--- a/app/src/pages/instance/organizationsPage/messages.js
+++ b/app/src/pages/instance/organizationsPage/messages.js
@@ -112,7 +112,8 @@ export const messages = defineMessages({
   },
   deleteOrganizationConfirmMessage: {
     id: 'OrganizationsPage.deleteOrganizationConfirmMessage',
-    defaultMessage: 'Are you sure you want to delete "{organizationName}" organization? All organization projects and data will be deleted.',
+    defaultMessage:
+      'Are you sure you want to delete "{organizationName}" organization? All organization projects and data will be deleted.',
   },
   confirmOrganizationNameEntry: {
     id: 'OrganizationsPage.confirmOrganizationNameEntry',

--- a/app/src/pages/instance/organizationsPage/messages.js
+++ b/app/src/pages/instance/organizationsPage/messages.js
@@ -102,4 +102,36 @@ export const messages = defineMessages({
     id: 'OrganizationsPage.activity',
     defaultMessage: 'Activity',
   },
+  deleteOrganization: {
+    id: 'OrganizationsPage.deleteOrganization',
+    defaultMessage: 'Delete',
+  },
+  deleteOrganizationModalTitle: {
+    id: 'OrganizationsPage.deleteOrganizationModalTitle',
+    defaultMessage: 'Delete organization',
+  },
+  deleteOrganizationConfirmMessage: {
+    id: 'OrganizationsPage.deleteOrganizationConfirmMessage',
+    defaultMessage: 'Are you sure you want to delete "{organizationName}" organization? All organization projects and data will be deleted.',
+  },
+  confirmOrganizationNameEntry: {
+    id: 'OrganizationsPage.confirmOrganizationNameEntry',
+    defaultMessage: 'Type the organization name to confirm deletion',
+  },
+  organizationNamePlaceholder: {
+    id: 'OrganizationsPage.organizationNamePlaceholder',
+    defaultMessage: 'Organization name',
+  },
+  deleteOrganizationSuccess: {
+    id: 'OrganizationsPage.deleteOrganizationSuccess',
+    defaultMessage: 'The organization has been deleted successfully',
+  },
+  deleteOrganizationError: {
+    id: 'OrganizationsPage.deleteOrganizationError',
+    defaultMessage: 'Error during organization deletion: {error}',
+  },
+  invalidOrganizationNameEntry: {
+    id: 'OrganizationsPage.invalidOrganizationNameEntry',
+    defaultMessage: 'The entered text does not match the required keyword',
+  },
 });

--- a/app/src/pages/instance/organizationsPage/organizationsPage.jsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPage.jsx
@@ -35,6 +35,7 @@ import { OrganizationsPageHeader } from './organizationsPageHeader';
 import { OrganizationsPanelView } from './organizationsPanelView';
 import { messages } from './messages';
 import { NoAssignedEmptyPage } from './noAssignedEmptyPage';
+import './organizationsPanelView/modals/deleteOrganizationModal';
 import styles from './organizationsPage.scss';
 
 const cx = classNames.bind(styles);

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/meatballMenu/meatballMenu.scss
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/meatballMenu/meatballMenu.scss
@@ -33,4 +33,23 @@
   outline: none;
   background: none;
   border: none;
+  padding: 8px 12px;
+  display: block;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+
+  &:hover {
+    color: var(--color-text-link);
+    background-color: var(--color-bg-hover);
+  }
+
+  &.delete-option {
+    color: var(--color-text-danger);
+
+    &:hover {
+      color: var(--color-text-danger-hover);
+      background-color: var(--color-bg-danger-hover);
+    }
+  }
 }

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/meatballMenu/meatballMenu.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/meatballMenu/meatballMenu.tsx
@@ -20,11 +20,15 @@ import Link from 'redux-first-router-link';
 import { useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
 import { MeatballMenuIcon, Popover } from '@reportportal/ui-kit';
-import { setActiveOrganizationAction, deleteOrganizationAction } from 'controllers/organization/actionCreators';
+import {
+  setActiveOrganizationAction,
+  deleteOrganizationAction,
+} from 'controllers/organization/actionCreators';
 import { canSeeActivityOption, canDeleteOrganization } from 'common/utils/permissions';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
 import { ORGANIZATIONS_ACTIVITY_PAGE, userRolesSelector } from 'controllers/pages';
 import { showModalAction } from 'controllers/modal';
+import DeleteOrganizationModal from '../modals/deleteOrganizationModal/deleteOrganizationModal';
 import { messages } from '../../messages';
 import styles from './meatballMenu.scss';
 
@@ -53,18 +57,22 @@ export const MeatballMenu = ({ organization }: MeatballMenuProps) => {
 
   const handleDeleteClick = () => {
     handleClick('delete_menu');
-    dispatch(showModalAction({
-      id: 'deleteOrganizationModal',
-      data: {
-        organizationName: organization.name,
-        onConfirm: () => {
-          dispatch(deleteOrganizationAction({
+    const data = {
+      organizationName: organization.name,
+      onConfirm: () => {
+        dispatch(
+          deleteOrganizationAction({
             organizationId: organization.id,
             organizationName: organization.name,
-          }));
-        },
+          }),
+        );
       },
-    }));
+    };
+    dispatch(
+      showModalAction({
+        component: <DeleteOrganizationModal data={data} />,
+      }),
+    );
   };
 
   return (

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/meatballMenu/meatballMenu.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/meatballMenu/meatballMenu.tsx
@@ -20,10 +20,11 @@ import Link from 'redux-first-router-link';
 import { useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
 import { MeatballMenuIcon, Popover } from '@reportportal/ui-kit';
-import { setActiveOrganizationAction } from 'controllers/organization/actionCreators';
-import { canSeeActivityOption } from 'common/utils/permissions';
+import { setActiveOrganizationAction, deleteOrganizationAction } from 'controllers/organization/actionCreators';
+import { canSeeActivityOption, canDeleteOrganization } from 'common/utils/permissions';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
 import { ORGANIZATIONS_ACTIVITY_PAGE, userRolesSelector } from 'controllers/pages';
+import { showModalAction } from 'controllers/modal';
 import { messages } from '../../messages';
 import styles from './meatballMenu.scss';
 
@@ -31,6 +32,8 @@ const cx = classNames.bind(styles) as typeof classNames;
 
 interface Organization {
   slug: string;
+  id: string;
+  name: string;
 }
 
 interface MeatballMenuProps {
@@ -46,6 +49,22 @@ export const MeatballMenu = ({ organization }: MeatballMenuProps) => {
   const handleClick = (elementName: string) => {
     dispatch(setActiveOrganizationAction(organization));
     trackEvent(ORGANIZATION_PAGE_EVENTS.meatballMenu(elementName));
+  };
+
+  const handleDeleteClick = () => {
+    handleClick('delete_menu');
+    dispatch(showModalAction({
+      id: 'deleteOrganizationModal',
+      data: {
+        organizationName: organization.name,
+        onConfirm: () => {
+          dispatch(deleteOrganizationAction({
+            organizationId: organization.id,
+            organizationName: organization.name,
+          }));
+        },
+      },
+    }));
   };
 
   return (
@@ -64,6 +83,15 @@ export const MeatballMenu = ({ organization }: MeatballMenuProps) => {
             >
               <span>{formatMessage(messages.activity)}</span>
             </Link>
+          )}
+          {canDeleteOrganization(userRoles) && (
+            <button
+              type="button"
+              className={cx('option-link', 'delete-option')}
+              onClick={handleDeleteClick}
+            >
+              <span>{formatMessage(messages.deleteOrganization)}</span>
+            </button>
           )}
         </div>
       }

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.scss
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.scss
@@ -1,5 +1,5 @@
-/*
- * Copyright 2019 EPAM Systems
+/*!
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-import * as validators from './validate';
-import * as boundValidators from './commonValidators';
-import * as asyncValidation from './asyncValidation';
-
-export { bindMessageToValidator, composeBoundValidators } from './validatorHelpers';
-
-export const validateAsync = asyncValidation;
-export const validate = validators;
-export const commonValidators = boundValidators;
-export const { createOrganizationNameValidator } = validators;
+.message {
+  margin-bottom: 24px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+} 

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.scss
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.scss
@@ -18,4 +18,4 @@
   margin-bottom: 24px;
   color: var(--color-text-primary);
   line-height: 1.5;
-} 
+}

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.tsx
@@ -28,7 +28,6 @@ import { ModalButtonProps } from 'types/common';
 import { useDispatch } from 'react-redux';
 import { useTracking } from 'react-tracking';
 import classNames from 'classnames/bind';
-import { createOrganizationNameValidator } from 'common/utils/validation';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
 import { messages } from '../../../messages';
 import styles from './deleteOrganizationModal.scss';
@@ -49,7 +48,8 @@ interface ModalProps {
   };
 }
 
-type DeleteOrganizationModalProps = InjectedFormProps<DeleteOrganizationFormProps, ModalProps> & ModalProps;
+type DeleteOrganizationModalProps = InjectedFormProps<DeleteOrganizationFormProps, ModalProps> &
+  ModalProps;
 
 const DeleteOrganizationModal: FC<DeleteOrganizationModalProps> = ({
   data: { onConfirm, organizationName },
@@ -115,4 +115,4 @@ export default reduxForm<DeleteOrganizationFormProps, ModalProps>({
       organizationName: organizationNameValidator(inputOrganizationValue),
     };
   },
-})(DeleteOrganizationModal); 
+})(DeleteOrganizationModal);

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/deleteOrganizationModal.tsx
@@ -1,0 +1,118 @@
+/*!
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC } from 'react';
+import { useIntl } from 'react-intl';
+import { InjectedFormProps, reduxForm } from 'redux-form';
+import { FieldErrorHint } from 'components/fields/fieldErrorHint';
+import { FieldProvider } from 'components/fields/fieldProvider';
+import { commonValidators } from 'common/utils/validation';
+import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
+import { BoundValidator } from 'common/utils/validation/types';
+import { Modal, FieldText } from '@reportportal/ui-kit';
+import { hideModalAction } from 'controllers/modal';
+import { ModalButtonProps } from 'types/common';
+import { useDispatch } from 'react-redux';
+import { useTracking } from 'react-tracking';
+import classNames from 'classnames/bind';
+import { createOrganizationNameValidator } from 'common/utils/validation';
+import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
+import { messages } from '../../../messages';
+import styles from './deleteOrganizationModal.scss';
+
+const cx = classNames.bind(styles) as typeof classNames;
+
+const ORGANIZATION_NAME_FIELD = 'organizationName';
+const DELETE_ORGANIZATION_FORM = 'deleteOrganizationForm';
+
+interface DeleteOrganizationFormProps {
+  [ORGANIZATION_NAME_FIELD]: string;
+}
+
+interface ModalProps {
+  data: {
+    onConfirm: () => void;
+    organizationName: string;
+  };
+}
+
+type DeleteOrganizationModalProps = InjectedFormProps<DeleteOrganizationFormProps, ModalProps> & ModalProps;
+
+const DeleteOrganizationModal: FC<DeleteOrganizationModalProps> = ({
+  data: { onConfirm, organizationName },
+  handleSubmit,
+  anyTouched,
+  invalid,
+}) => {
+  const dispatch = useDispatch();
+  const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
+
+  const hideModal = () => {
+    trackEvent(ORGANIZATION_PAGE_EVENTS.meatballMenu('delete_organization_modal_cancel'));
+    dispatch(hideModalAction());
+  };
+
+  const onSubmit = () => {
+    trackEvent(ORGANIZATION_PAGE_EVENTS.meatballMenu('delete_organization_modal_delete'));
+    onConfirm();
+  };
+
+  const okButton: ModalButtonProps = {
+    children: formatMessage(COMMON_LOCALE_KEYS.DELETE),
+    onClick: handleSubmit(onSubmit) as () => void,
+    variant: 'danger',
+    disabled: anyTouched && invalid,
+  };
+
+  const cancelButton: ModalButtonProps = {
+    children: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
+  };
+
+  return (
+    <Modal
+      title={formatMessage(messages.deleteOrganizationModalTitle)}
+      okButton={okButton}
+      cancelButton={cancelButton}
+      onClose={hideModal}
+    >
+      <p className={cx('message')}>
+        {formatMessage(messages.deleteOrganizationConfirmMessage, { organizationName })}
+      </p>
+      <FieldProvider name={ORGANIZATION_NAME_FIELD}>
+        <FieldErrorHint provideHint={false}>
+          <FieldText
+            label={formatMessage(messages.confirmOrganizationNameEntry)}
+            defaultWidth={false}
+            placeholder={formatMessage(messages.organizationNamePlaceholder)}
+          />
+        </FieldErrorHint>
+      </FieldProvider>
+    </Modal>
+  );
+};
+
+export default reduxForm<DeleteOrganizationFormProps, ModalProps>({
+  form: DELETE_ORGANIZATION_FORM,
+  validate: ({ organizationName: inputOrganizationValue }, { data: { organizationName } }) => {
+    const organizationNameValidator: BoundValidator =
+      commonValidators.createKeywordMatcherValidator(organizationName);
+
+    return {
+      organizationName: organizationNameValidator(inputOrganizationValue),
+    };
+  },
+})(DeleteOrganizationModal); 

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/index.ts
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/index.ts
@@ -1,5 +1,5 @@
-/*
- * Copyright 2019 EPAM Systems
+/*!
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,4 @@
  * limitations under the License.
  */
 
-import * as validators from './validate';
-import * as boundValidators from './commonValidators';
-import * as asyncValidation from './asyncValidation';
-
-export { bindMessageToValidator, composeBoundValidators } from './validatorHelpers';
-
-export const validateAsync = asyncValidation;
-export const validate = validators;
-export const commonValidators = boundValidators;
-export const { createOrganizationNameValidator } = validators;
+export { default as DeleteOrganizationModal } from './deleteOrganizationModal'; 

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/index.ts
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationModal/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default as DeleteOrganizationModal } from './deleteOrganizationModal'; 
+export { default as DeleteOrganizationModal } from './deleteOrganizationModal';


### PR DESCRIPTION
## Summary
Fixed the delete organization modal functionality that was not working when clicking the 'Delete' button.

## Changes Made
1. **Fixed compilation error**: Removed duplicate import of `showSuccessNotification` in organization sagas
2. **Fixed unused variable error**: Removed unused import of `createOrganizationNameValidator` in delete organization modal
3. **Fixed modal not displaying**: 
   - Added proper import of `DeleteOrganizationModal` component in meatball menu
   - Fixed `showModalAction` call to pass component as JSX element instead of component reference
   - This matches the pattern used elsewhere in the codebase

## Testing
- Type check passes without errors
- Code formatting applied successfully
- Delete organization modal now displays correctly when clicking the Delete button
- Modal allows users to confirm deletion by typing the organization name

## Related
- Jira ticket: EPMRPP-104183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for authorized users to delete organizations directly from the organizations page.
  * Introduced a confirmation modal requiring users to type the organization's name before deletion.
  * Provided localized messages and feedback for successful or failed deletion actions.

* **Style**
  * Enhanced menu and modal styles for improved clarity and user experience, including distinct styling for delete actions.

* **Bug Fixes**
  * N/A

* **Documentation**
  * N/A

* **Chores**
  * N/A

<!-- end of auto-generated comment: release notes by coderabbit.ai -->