### PR TITLE
Disallow closing modals on outside click when form is filled

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/createTestCaseModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/createTestCaseModal.tsx
@@ -62,7 +62,7 @@ export const CreateTestCaseModal = reduxForm<CreateTestCaseFormData>({
     name: commonValidators.requiredField(name),
     folder: commonValidators.requiredField(folder),
   }),
-})(({ handleSubmit }) => {
+})(({ dirty, handleSubmit }) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const { isCreateTestCaseLoading, createTestCase } = useCreateTestCase();
@@ -88,6 +88,7 @@ export const CreateTestCaseModal = reduxForm<CreateTestCaseFormData>({
       okButton={okButton}
       className={cx('create-test-case-modal')}
       cancelButton={cancelButton}
+      allowCloseOutside={!dirty}
       onClose={() => dispatch(hideModalAction())}
     >
       <div className={cx('create-test-case-modal__content-wrapper')}>

--- a/app/src/pages/inside/testCaseLibraryPage/expandedOptions/createFolderModal/createFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/expandedOptions/createFolderModal/createFolderModal.tsx
@@ -70,6 +70,7 @@ interface CreateFolderModalProps {
 
 const CreateFolderModalComponent = ({
   data: { shouldRenderToggle },
+  dirty,
   handleSubmit,
   change,
   untouch,
@@ -123,6 +124,7 @@ const CreateFolderModalComponent = ({
       title={formatMessage(commonMessages.createFolder)}
       okButton={okButton}
       cancelButton={cancelButton}
+      allowCloseOutside={!dirty}
       onClose={hideModal}
     >
       <form onSubmit={handleSubmit(onSubmit)} className={cx('create-folder-modal__form')}>

--- a/app/src/pages/inside/testPlansPage/createTestPlanModal/createTestPlanModal.tsx
+++ b/app/src/pages/inside/testPlansPage/createTestPlanModal/createTestPlanModal.tsx
@@ -62,7 +62,7 @@ export const CreateTestPlanModal = reduxForm<CreateTestPlanFormValues>({
   validate: ({ name }) => ({
     name: commonValidators.requiredField(name),
   }),
-})(({ handleSubmit }) => {
+})(({ dirty, handleSubmit }) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const { isCreateTestPlanLoading, createTestPlan } = useCreateTestPlan();
@@ -88,6 +88,7 @@ export const CreateTestPlanModal = reduxForm<CreateTestPlanFormValues>({
       okButton={okButton}
       className={cx('create-test-plan-modal')}
       cancelButton={cancelButton}
+      allowCloseOutside={!dirty}
       onClose={() => dispatch(hideModalAction())}
     >
       <div className={cx('create-test-plan-modal__content-wrapper')}>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modals for creating test cases, folders, and test plans now prevent accidental closing by clicking outside when there are unsaved changes in the form, helping to safeguard user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->