### PR TITLE
EPMRPP-107143 || Delete organization modal is closed when clicking outside the modal with entered text

### DIFF
--- a/app/src/controllers/instance/organizations/constants.ts
+++ b/app/src/controllers/instance/organizations/constants.ts
@@ -44,3 +44,7 @@ export enum SortingFields {
 }
 
 export const ORGANIZATIONS_DEFAULT_SORT_COLUMN = SortingFields.NAME;
+
+export const ERROR_CODES = {
+  NOT_FOUND: 40429,
+};

--- a/app/src/controllers/instance/organizations/sagas.js
+++ b/app/src/controllers/instance/organizations/sagas.js
@@ -29,6 +29,7 @@ import {
   FETCH_FILTERED_ORGANIZATIONS,
   NAMESPACE,
   DELETE_ORGANIZATION,
+  ERROR_CODES,
 } from './constants';
 import { fetch } from 'common/utils';
 
@@ -61,14 +62,12 @@ function* deleteOrganization({ payload: { organizationId, onSuccess } }) {
     });
     yield put(showSuccessNotification({ messageId: 'deleteOrganizationSuccess' }));
     onSuccess?.();
-  } catch (err) {
-    const error = err.message;
-    yield put(
-      showErrorNotification({
-        messageId: 'deleteOrganizationError',
-        values: { error },
-      }),
-    );
+  } catch ({ errorCode }) {
+    yield put(showErrorNotification({ messageId: 'deleteOrganizationError' }));
+
+    if (errorCode === ERROR_CODES.NOT_FOUND) {
+      yield fetchFilteredOrganizations();
+    }
   }
 }
 

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationsModal/deleteOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationsModal/deleteOrganizationModal.tsx
@@ -56,6 +56,7 @@ const DeleteOrganizationModal = ({
   handleSubmit,
   anyTouched,
   invalid,
+  dirty,
 }: DeleteOrganizationModalProps) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
@@ -83,6 +84,7 @@ const DeleteOrganizationModal = ({
       title={formatMessage(messages.deleteOrganization)}
       okButton={okButton}
       cancelButton={cancelButton}
+      allowCloseOutside={!dirty}
     >
       <div className={cx('modal-content')}>
         <p>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?

## Links
[EPMRPP-107143](https://jiraeu.epam.com/browse/EPMRPP-107143)
[EPMRPP-107157](https://jiraeu.epam.com/browse/EPMRPP-107157)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Delete Organization modal now prevents accidental dismissal by disabling outside-click close when there are unsaved changes.
- Bug Fixes
  - When attempting to delete an organization that no longer exists, the list automatically refreshes to reflect the current state.
  - Error notifications for failed deletions are now clearer and consistent, without exposing technical details.
- Improvements
  - More robust handling of edge cases in organization deletion to reduce stale or inaccurate items in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->