### PR TITLE
EPMRPP-107146 || Deleting the last organization on the last page leads to empty state

### DIFF
--- a/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersListTable.jsx
+++ b/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersListTable.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 EPAM Systems
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,21 +23,10 @@ import { AbsRelTime } from 'components/main/absRelTime';
 import { MeatballMenuIcon, Popover } from '@reportportal/ui-kit';
 import { userInfoSelector } from 'controllers/user';
 import { getRoleBadgesData } from 'common/utils/permissions/getRoleTitle';
-import { NAMESPACE, SORTING_KEY } from 'controllers/instance/allUsers/constants';
 import { UserNameCell } from 'pages/common/membersPage/userNameCell/userNameCell';
 import { ACCOUNT_TYPE_DISPLAY_MAP } from 'common/constants/accountType';
-import {
-  DEFAULT_PAGE_SIZE,
-  DEFAULT_PAGINATION,
-  PAGE_KEY,
-  withPagination,
-} from 'controllers/pagination';
-import { SORTING_ASC, withSortingURL } from 'controllers/sorting';
-import {
-  DEFAULT_SORT_COLUMN,
-  allUsersPaginationSelector,
-  fetchAllUsersAction,
-} from 'controllers/instance/allUsers';
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGINATION, PAGE_KEY } from 'controllers/pagination';
+import { fetchAllUsersAction } from 'controllers/instance/allUsers';
 import { useTracking } from 'react-tracking';
 import { MembersListTable } from 'pages/common/users/membersListTable';
 import { messages } from 'pages/common/users/membersListTable/messages';
@@ -51,7 +40,7 @@ const cx = classNames.bind(styles);
 
 const getDisplayAccountType = (accountType) => ACCOUNT_TYPE_DISPLAY_MAP[accountType] || accountType;
 
-const AllUsersListTableComponent = ({
+export const AllUsersListTable = ({
   users,
   onChangeSorting,
   sortingDirection,
@@ -188,7 +177,7 @@ const AllUsersListTableComponent = ({
       primaryColumn={primaryColumn}
       fixedColumns={fixedColumns}
       onTableSorting={onTableSorting}
-      showPagination={users.length > 0}
+      showPagination={itemCount > 0}
       sortingDirection={sortingDirection}
       pageSize={pageSize}
       activePage={activePage}
@@ -201,7 +190,7 @@ const AllUsersListTableComponent = ({
   );
 };
 
-AllUsersListTableComponent.propTypes = {
+AllUsersListTable.propTypes = {
   users: PropTypes.array,
   sortingDirection: PropTypes.string,
   onChangeSorting: PropTypes.func,
@@ -213,20 +202,8 @@ AllUsersListTableComponent.propTypes = {
   onChangePageSize: PropTypes.func.isRequired,
 };
 
-AllUsersListTableComponent.defaultProps = {
+AllUsersListTable.defaultProps = {
   users: [],
   pageSize: DEFAULT_PAGE_SIZE,
   activePage: DEFAULT_PAGINATION[PAGE_KEY],
 };
-
-export const AllUsersListTable = withSortingURL({
-  defaultFields: [DEFAULT_SORT_COLUMN],
-  defaultDirection: SORTING_ASC,
-  sortingKey: SORTING_KEY,
-  namespace: NAMESPACE,
-})(
-  withPagination({
-    paginationSelector: allUsersPaginationSelector,
-    namespace: NAMESPACE,
-  })(AllUsersListTableComponent),
-);

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/organizationsPanelView.jsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/organizationsPanelView.jsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2024 EPAM Systems
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,11 @@
 
 import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
-import { SORTING_ASC, withSortingURL } from 'controllers/sorting';
-import { DEFAULT_PAGINATION, PAGE_KEY, withPagination } from 'controllers/pagination';
+import { DEFAULT_PAGINATION, PAGE_KEY } from 'controllers/pagination';
 import { PaginationWrapper } from 'components/main/paginationWrapper';
-import { organizationsListPaginationSelector } from 'controllers/instance/organizations';
 import {
   DEFAULT_LIMITATION,
   DEFAULT_PAGE_SIZE_OPTIONS,
-  NAMESPACE,
-  ORGANIZATIONS_DEFAULT_SORT_COLUMN,
-  SORTING_KEY,
 } from 'controllers/instance/organizations/constants';
 import styles from './organizationsPanelView.scss';
 import { OrganizationsPanels } from './organizationsPanels';
@@ -33,7 +28,7 @@ import { OrganizationsTable } from './organizationsTable';
 
 const cx = classNames.bind(styles);
 
-const OrganizationsPanelViewWrapped = ({
+export const OrganizationsPanelView = ({
   organizationsList,
   pageSize,
   activePage,
@@ -47,7 +42,7 @@ const OrganizationsPanelViewWrapped = ({
   onChangeSorting,
 }) => (
   <PaginationWrapper
-    showPagination={organizationsList.length > 0}
+    showPagination={itemCount > 0}
     pageSize={pageSize}
     activePage={activePage}
     totalItems={itemCount}
@@ -70,7 +65,7 @@ const OrganizationsPanelViewWrapped = ({
   </PaginationWrapper>
 );
 
-OrganizationsPanelViewWrapped.propTypes = {
+OrganizationsPanelView.propTypes = {
   organizationsList: PropTypes.array,
   pageSize: PropTypes.number,
   activePage: PropTypes.number,
@@ -84,20 +79,8 @@ OrganizationsPanelViewWrapped.propTypes = {
   onChangeSorting: PropTypes.func,
 };
 
-OrganizationsPanelViewWrapped.defaultProps = {
+OrganizationsPanelView.defaultProps = {
   organizationsList: [],
   pageSize: DEFAULT_LIMITATION,
   activePage: DEFAULT_PAGINATION[PAGE_KEY],
 };
-
-export const OrganizationsPanelView = withSortingURL({
-  defaultDirection: SORTING_ASC,
-  defaultFields: [ORGANIZATIONS_DEFAULT_SORT_COLUMN],
-  sortingKey: SORTING_KEY,
-  namespace: NAMESPACE,
-})(
-  withPagination({
-    paginationSelector: organizationsListPaginationSelector,
-    namespace: NAMESPACE,
-  })(OrganizationsPanelViewWrapped),
-);

--- a/app/src/pages/organization/organizationProjectsPage/organizationProjectsPage.jsx
+++ b/app/src/pages/organization/organizationProjectsPage/organizationProjectsPage.jsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2024 EPAM Systems
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,17 @@
  */
 
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import { canCreateProject } from 'common/utils/permissions';
 import classNames from 'classnames/bind';
 import Parser from 'html-react-parser';
 import { BubblesLoader, PlusIcon } from '@reportportal/ui-kit';
 import { useIntl } from 'react-intl';
-import { loadingSelector, projectsSelector } from 'controllers/organization/projects/selectors';
+import {
+  loadingSelector,
+  projectsSelector,
+  projectsPaginationSelector,
+} from 'controllers/organization/projects/selectors';
 import { activeOrganizationLoadingSelector } from 'controllers/organization/selectors';
 import { userRolesSelector } from 'controllers/pages';
 import { showModalAction } from 'controllers/modal';
@@ -33,12 +38,29 @@ import { assignedProjectsSelector } from 'controllers/user';
 import { ProjectsPageHeader } from './projectsPageHeader';
 import EmptyIcon from './img/empty-projects-icon-inline.svg';
 import { messages } from './messages';
-import { ProjectsListTableWrapper } from './projectsListTable';
+import { ProjectsListTable } from './projectsListTable';
+import { withPagination } from 'controllers/pagination';
+import { withSortingURL } from 'controllers/sorting';
+import {
+  NAMESPACE,
+  DEFAULT_SORT_COLUMN,
+  SORTING_KEY,
+} from 'controllers/organization/projects/constants';
+import { SORTING_ASC } from 'controllers/sorting';
 import styles from './organizationProjectsPage.scss';
 
 const cx = classNames.bind(styles);
 
-export const OrganizationProjectsPage = () => {
+const OrganizationProjectsPageComponent = ({
+  sortingDirection,
+  onChangeSorting,
+  pageSize,
+  activePage,
+  itemCount,
+  pageCount,
+  onChangePage,
+  onChangePageSize,
+}) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const userRoles = useSelector(userRolesSelector);
@@ -64,7 +86,6 @@ export const OrganizationProjectsPage = () => {
     };
   });
 
-  const isProjectsEmpty = !projectsLoading && projects.length === 0;
   const [searchValue, setSearchValue] = useState(null);
   const [appliedFiltersCount, setAppliedFiltersCount] = useState(0);
 
@@ -120,11 +141,23 @@ export const OrganizationProjectsPage = () => {
       );
     }
 
-    if (isProjectsEmpty) {
+    if (itemCount === 0) {
       return getEmptyPageState();
     }
 
-    return <ProjectsListTableWrapper projects={projectsWithAssignedRoles} />;
+    return (
+      <ProjectsListTable
+        projects={projectsWithAssignedRoles}
+        sortingDirection={sortingDirection}
+        onChangeSorting={onChangeSorting}
+        pageSize={pageSize}
+        activePage={activePage}
+        itemCount={itemCount}
+        pageCount={pageCount}
+        onChangePage={onChangePage}
+        onChangePageSize={onChangePageSize}
+      />
+    );
   };
 
   return (
@@ -141,3 +174,26 @@ export const OrganizationProjectsPage = () => {
     </div>
   );
 };
+
+OrganizationProjectsPageComponent.propTypes = {
+  sortingDirection: PropTypes.string,
+  onChangeSorting: PropTypes.func,
+  pageSize: PropTypes.number,
+  activePage: PropTypes.number,
+  itemCount: PropTypes.number,
+  pageCount: PropTypes.number,
+  onChangePage: PropTypes.func,
+  onChangePageSize: PropTypes.func,
+};
+
+export const OrganizationProjectsPage = withSortingURL({
+  defaultFields: [DEFAULT_SORT_COLUMN],
+  defaultDirection: SORTING_ASC,
+  sortingKey: SORTING_KEY,
+  namespace: NAMESPACE,
+})(
+  withPagination({
+    paginationSelector: projectsPaginationSelector,
+    namespace: NAMESPACE,
+  })(OrganizationProjectsPageComponent),
+);

--- a/app/src/pages/organization/organizationProjectsPage/projectsListTable/index.js
+++ b/app/src/pages/organization/organizationProjectsPage/projectsListTable/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { ProjectsListTableWrapper } from './projectsListTable';
+export { ProjectsListTable } from './projectsListTable';

--- a/app/src/pages/organization/organizationProjectsPage/projectsListTable/projectsListTable.jsx
+++ b/app/src/pages/organization/organizationProjectsPage/projectsListTable/projectsListTable.jsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2024 EPAM Systems
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,21 +21,13 @@ import { Table } from '@reportportal/ui-kit';
 import classNames from 'classnames/bind';
 import { useDispatch, useSelector } from 'react-redux';
 import { AbsRelTime } from 'components/main/absRelTime';
-import { SORTING_ASC, withSortingURL } from 'controllers/sorting';
-import { DEFAULT_PAGINATION, PAGE_KEY, withPagination } from 'controllers/pagination';
+import { DEFAULT_PAGINATION, PAGE_KEY } from 'controllers/pagination';
 import { PaginationWrapper } from 'components/main/paginationWrapper';
 import {
   activeOrganizationSelector,
   prepareActiveOrganizationProjectsAction,
 } from 'controllers/organization';
-import {
-  DEFAULT_LIMITATION,
-  DEFAULT_PAGE_SIZE_OPTIONS,
-  DEFAULT_SORT_COLUMN,
-  projectsPaginationSelector,
-  SORTING_KEY,
-} from 'controllers/organization/projects';
-import { NAMESPACE } from 'controllers/organization/projects/constants';
+import { DEFAULT_LIMITATION, DEFAULT_PAGE_SIZE_OPTIONS } from 'controllers/organization/projects';
 import { ProjectActionMenu } from 'pages/organization/organizationProjectsPage/projectsListTable/projectActionMenu';
 import { messages } from '../messages';
 import { ProjectName } from './projectName';
@@ -126,7 +118,7 @@ export const ProjectsListTable = ({
 
   return (
     <PaginationWrapper
-      showPagination={projects.length > 0}
+      showPagination={itemCount > 0}
       pageSize={pageSize}
       activePage={activePage}
       totalItems={itemCount}
@@ -168,15 +160,3 @@ ProjectsListTable.defaultProps = {
   activePage: DEFAULT_PAGINATION[PAGE_KEY],
   pageSize: DEFAULT_LIMITATION,
 };
-
-export const ProjectsListTableWrapper = withSortingURL({
-  defaultFields: [DEFAULT_SORT_COLUMN],
-  defaultDirection: SORTING_ASC,
-  sortingKey: SORTING_KEY,
-  namespace: NAMESPACE,
-})(
-  withPagination({
-    paginationSelector: projectsPaginationSelector,
-    namespace: NAMESPACE,
-  })(ProjectsListTable),
-);

--- a/app/src/pages/organization/organizationUsersPage/organizationUsersListTable/organizationUsersListTable.jsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersListTable/organizationUsersListTable.jsx
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2024 EPAM Systems
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AbsRelTime } from 'components/main/absRelTime';
 import { userInfoSelector } from 'controllers/user';
 import { getRoleBadgesData } from 'common/utils/permissions/getRoleTitle';
-import { SORTING_ASC, withSortingURL } from 'controllers/sorting';
-import { DEFAULT_SORT_COLUMN } from 'controllers/members/constants';
-import {
-  DEFAULT_PAGE_SIZE,
-  DEFAULT_PAGINATION,
-  PAGE_KEY,
-  withPagination,
-} from 'controllers/pagination';
-import {
-  NAMESPACE,
-  prepareActiveOrganizationUsersAction,
-  usersPaginationSelector,
-} from 'controllers/organization/users';
-import { SORTING_KEY } from 'controllers/organization/projects';
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGINATION, PAGE_KEY } from 'controllers/pagination';
+import { prepareActiveOrganizationUsersAction } from 'controllers/organization/users';
 import { UserNameCell } from 'pages/common/membersPage/userNameCell/userNameCell';
 import { MembersListTable } from '../../../common/users/membersListTable';
 import { messages } from '../../../common/users/membersListTable/messages';
@@ -44,7 +32,7 @@ import styles from './organizationUsersListTable.scss';
 
 const cx = classNames.bind(styles);
 
-const OrgTeamListTableWrapped = ({
+export const OrganizationTeamListTable = ({
   users,
   onChangeSorting,
   sortingDirection,
@@ -147,7 +135,7 @@ const OrgTeamListTableWrapped = ({
       primaryColumn={primaryColumn}
       fixedColumns={fixedColumns}
       onTableSorting={onTableSorting}
-      showPagination={users.length > 0}
+      showPagination={itemCount > 0}
       renderRowActions={(metaData) => <OrganizationUsersActionMenu user={metaData} />}
       sortingDirection={sortingDirection}
       pageSize={pageSize}
@@ -160,7 +148,7 @@ const OrgTeamListTableWrapped = ({
   );
 };
 
-OrgTeamListTableWrapped.propTypes = {
+OrganizationTeamListTable.propTypes = {
   users: PropTypes.array,
   sortingDirection: PropTypes.string,
   onChangeSorting: PropTypes.func,
@@ -172,20 +160,8 @@ OrgTeamListTableWrapped.propTypes = {
   onChangePageSize: PropTypes.func.isRequired,
 };
 
-OrgTeamListTableWrapped.defaultProps = {
+OrganizationTeamListTable.defaultProps = {
   users: [],
   pageSize: DEFAULT_PAGE_SIZE,
   activePage: DEFAULT_PAGINATION[PAGE_KEY],
 };
-
-export const OrganizationTeamListTable = withSortingURL({
-  defaultFields: [DEFAULT_SORT_COLUMN],
-  defaultDirection: SORTING_ASC,
-  sortingKey: SORTING_KEY,
-  namespace: NAMESPACE,
-})(
-  withPagination({
-    paginationSelector: usersPaginationSelector,
-    namespace: NAMESPACE,
-  })(OrgTeamListTableWrapped),
-);

--- a/app/src/pages/organization/organizationUsersPage/organizationUsersPage.jsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersPage.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 EPAM Systems
+ * Copyright 2025 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,20 @@
 import { useDispatch, useSelector } from 'react-redux';
 import classNames from 'classnames/bind';
 import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
 import {
   fetchOrganizationUsersAction,
   loadingSelector,
   usersSelector,
+  usersPaginationSelector,
 } from 'controllers/organization/users';
+import { NAMESPACE } from 'controllers/organization/users/constants';
+import { withPagination } from 'controllers/pagination';
+import { withSortingURL, SORTING_ASC } from 'controllers/sorting';
+import { DEFAULT_SORT_COLUMN } from 'controllers/members/constants';
+import { SORTING_KEY } from 'controllers/organization/projects';
 import { OrganizationTeamListTable } from 'pages/organization/organizationUsersPage/organizationUsersListTable/organizationUsersListTable';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { EmptyPageState } from 'pages/common';
@@ -45,7 +52,16 @@ import styles from './organizationUsersPage.scss';
 
 const cx = classNames.bind(styles);
 
-export const OrganizationUsersPage = () => {
+const OrganizationUsersPageComponent = ({
+  sortingDirection,
+  onChangeSorting,
+  pageSize,
+  activePage,
+  itemCount,
+  pageCount,
+  onChangePage,
+  onChangePageSize,
+}) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const { trackEvent } = useTracking();
@@ -53,7 +69,6 @@ export const OrganizationUsersPage = () => {
   const { id: organizationId, slug: organizationSlug } = useSelector(activeOrganizationSelector);
   const isUsersLoading = useSelector(loadingSelector);
   const [searchValue, setSearchValue] = useState(null);
-  const isEmptyUsers = users.length === 0;
   const userRoles = useSelector(userRolesSelector);
   const hasPermission = canInviteUserToOrganization(userRoles);
 
@@ -79,7 +94,7 @@ export const OrganizationUsersPage = () => {
     return searchValue === null ? (
       <EmptyUsersPageState
         isLoading={isUsersLoading}
-        isNotEmpty={!isEmptyUsers}
+        isNotEmpty={itemCount > 0}
         hasPermission
         showInviteUserModal={showInviteUserModal}
       />
@@ -103,8 +118,45 @@ export const OrganizationUsersPage = () => {
           setSearchValue={setSearchValue}
           onInvite={showInviteUserModal}
         />
-        {isEmptyUsers ? getEmptyPageState() : <OrganizationTeamListTable users={users} />}
+        {itemCount === 0 ? (
+          getEmptyPageState()
+        ) : (
+          <OrganizationTeamListTable
+            users={users}
+            sortingDirection={sortingDirection}
+            onChangeSorting={onChangeSorting}
+            pageSize={pageSize}
+            activePage={activePage}
+            itemCount={itemCount}
+            pageCount={pageCount}
+            onChangePage={onChangePage}
+            onChangePageSize={onChangePageSize}
+          />
+        )}
       </div>
     </ScrollWrapper>
   );
 };
+
+OrganizationUsersPageComponent.propTypes = {
+  sortingDirection: PropTypes.string,
+  onChangeSorting: PropTypes.func,
+  pageSize: PropTypes.number,
+  activePage: PropTypes.number,
+  itemCount: PropTypes.number,
+  pageCount: PropTypes.number,
+  onChangePage: PropTypes.func,
+  onChangePageSize: PropTypes.func,
+};
+
+export const OrganizationUsersPage = withSortingURL({
+  defaultFields: [DEFAULT_SORT_COLUMN],
+  defaultDirection: SORTING_ASC,
+  sortingKey: SORTING_KEY,
+  namespace: NAMESPACE,
+})(
+  withPagination({
+    paginationSelector: usersPaginationSelector,
+    namespace: NAMESPACE,
+  })(OrganizationUsersPageComponent),
+);


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?

## Motivation 
### Problem
Pagination redirect logic was inconsistent across pages. Some pages showed empty states when navigating to non-existent pages. Additionally, deleting the last item on the last page caused empty state display instead of proper pagination handling.

### Root Cause
The HOC `withPagination` was applied to nested table components instead of parent page components, preventing pagination logic from executing when child components didn't render.
https://github.com/reportportal/service-ui/blob/df34997e5dc5b3e1be808ecbe94e37f274518cf0/app/src/controllers/pagination/withPagination.jsx#L75
```javascript
      componentDidUpdate() {
        if (this.props.totalPages === undefined) return;
        if (this.props.page > this.props.totalPages) {
          this.changePaginationOptions({ page: this.props.totalPages });
        }
      }
```

### Solution
Moved HOCs (`withPagination` and `withSortingURL`) from child components to parent page components, ensuring pagination logic runs at page level regardless of child component rendering.

### Result
All pages now consistently redirect to last available page when navigating to non-existent pages, providing consistent user experience.
