### PR TITLE
Fill folder field in create test case modal based on modal context

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/createTestCaseModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/createTestCaseModal.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { FormEvent, MouseEvent } from 'react';
+import { FormEvent, MouseEvent, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
-import { reduxForm } from 'redux-form';
+import { reduxForm, InjectedFormProps } from 'redux-form';
 import { Modal } from '@reportportal/ui-kit';
 
 import { createClassnames, commonValidators } from 'common/utils';
@@ -59,22 +59,39 @@ export interface CreateTestCaseFormData {
   tags?: string[];
 }
 
-export const CreateTestCaseModal = reduxForm<CreateTestCaseFormData>({
+interface CreateTestCaseModalProps {
+  data?: {
+    folder?: FolderWithFullPath;
+  };
+}
+
+export const CreateTestCaseModal = reduxForm<CreateTestCaseFormData, CreateTestCaseModalProps>({
   form: CREATE_TEST_CASE_FORM_NAME,
-  initialValues: {
-    priority: 'unspecified',
-    manualScenarioType: 'STEPS',
-    executionEstimationTime: 5,
-  },
   validate: ({ name, folder, linkToRequirements }) => ({
     name: commonValidators.requiredField(name),
     folder: commonValidators.requiredField(folder),
     linkToRequirements: commonValidators.optionalUrl(linkToRequirements),
   }),
-})(({ dirty, handleSubmit }) => {
+})(({
+  data,
+  dirty,
+  initialize,
+  handleSubmit,
+}: InjectedFormProps<CreateTestCaseFormData, CreateTestCaseModalProps> &
+  CreateTestCaseModalProps) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const { isCreateTestCaseLoading, createTestCase } = useCreateTestCase();
+
+  useEffect(() => {
+    initialize({
+      priority: 'unspecified',
+      manualScenarioType: 'STEPS',
+      executionEstimationTime: 5,
+      folder: data?.folder,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const okButton = {
     children: (

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/useCreateTestCaseModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/useCreateTestCaseModal.tsx
@@ -14,12 +14,28 @@
  * limitations under the License.
  */
 
+import { useSelector } from 'react-redux';
+
 import { useModal } from 'common/hooks';
+import { urlFolderIdSelector } from 'controllers/pages';
+import { transformedFoldersWithFullPathSelector, FolderWithFullPath } from 'controllers/testCase';
 
 import { CREATE_TEST_CASE_MODAL_KEY, CreateTestCaseModal } from './createTestCaseModal';
 
-export const useCreateTestCaseModal = () =>
-  useModal({
+interface CreateTestCaseModalData {
+  folder?: FolderWithFullPath;
+}
+
+export const useCreateTestCaseModal = () => {
+  const folderId = useSelector(urlFolderIdSelector);
+  const folders = useSelector(transformedFoldersWithFullPathSelector);
+
+  const currentContextFolder = folders.find(({ id }) => id === Number(folderId));
+
+  return useModal<CreateTestCaseModalData>({
     modalKey: CREATE_TEST_CASE_MODAL_KEY,
-    renderModal: () => <CreateTestCaseModal />,
+    renderModal: (data) => (
+      <CreateTestCaseModal data={{ ...data, folder: data?.folder || currentContextFolder }} />
+    ),
   });
+};

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
@@ -100,7 +100,7 @@ export const TestCaseLibraryPage = () => {
                   <Button
                     variant="ghost"
                     data-automation-id="createTestCase"
-                    onClick={openCreateTestCaseModal}
+                    onClick={() => openCreateTestCaseModal()}
                   >
                     {formatMessage(commonMessages.createTestCase)}
                   </Button>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->

https://github.com/user-attachments/assets/3a120a7a-bcd0-4e63-9811-3dba4e8ea03d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Create Test Case modal now auto-selects the current folder context when opened.
  - Supports opening the modal with a preselected folder passed in.
- Bug Fixes
  - Form fields in the Create Test Case modal now initialize correctly when the target folder changes, preventing stale or missing defaults.
- Refactor
  - Simplified modal opening logic for consistency, without changing visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->