### PR TITLE
Implement batch test case duplication

### DIFF
--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -377,6 +377,8 @@ export const URLS = {
   testCaseDetails: (projectKey, testCaseId) =>
     `${urlBase}project/${projectKey}/tms/test-case/${testCaseId}`,
   bulkUpdateTestCases: (projectKey) => `${urlBase}project/${projectKey}/tms/test-case/batch`,
+  testCaseBatchDuplicate: (projectKey) =>
+    `${urlBase}project/${projectKey}/tms/test-case/batch/duplicate`,
   testCases: (projectKey, query = {}) =>
     `${urlBase}project/${projectKey}/tms/test-case${getQueryParams(query)}`,
   testPlan: (projectKey, query = {}) =>

--- a/app/src/components/main/notification/notificationList/notificationList.jsx
+++ b/app/src/components/main/notification/notificationList/notificationList.jsx
@@ -220,6 +220,10 @@ const messages = defineMessages({
     id: 'TestCaseLibraryPage.testCaseFolderDuplicatedSuccess',
     defaultMessage: 'Folder has been duplicated successfully.',
   },
+  testCasesDuplicatedSuccess: {
+    id: 'TestCaseLibraryPage.testCasesDuplicatedSuccess',
+    defaultMessage: 'Test cases have been duplicated successfully.',
+  },
   testCaseDeletedSuccess: {
     id: 'TestCaseLibraryPage.testCaseDeletedSuccess',
     defaultMessage: 'Test case has been deleted successfully.',

--- a/app/src/pages/inside/common/buttonSwitcher/buttonSwitcher.tsx
+++ b/app/src/pages/inside/common/buttonSwitcher/buttonSwitcher.tsx
@@ -23,7 +23,7 @@ import styles from './buttonSwitcher.scss';
 const cx = createClassnames(styles);
 
 export enum ButtonSwitcherOption {
-  EXISTED = 'existed',
+  EXISTING = 'existing',
   NEW = 'new',
 }
 
@@ -40,7 +40,7 @@ export const ButtonSwitcher = ({
   createNewButtonTitle,
   handleActiveButton,
 }: ButtonSwitcherProps) => {
-  const [activeButton, setActiveButton] = useState(ButtonSwitcherOption.EXISTED);
+  const [activeButton, setActiveButton] = useState(ButtonSwitcherOption.EXISTING);
 
   useEffect(() => {
     handleActiveButton(activeButton);
@@ -53,10 +53,10 @@ export const ButtonSwitcher = ({
         <button
           type="button"
           className={cx('buttons-switcher__button', {
-            'buttons-switcher__button--active': activeButton === ButtonSwitcherOption.EXISTED,
+            'buttons-switcher__button--active': activeButton === ButtonSwitcherOption.EXISTING,
           })}
           onClick={() => {
-            setActiveButton(ButtonSwitcherOption.EXISTED);
+            setActiveButton(ButtonSwitcherOption.EXISTING);
           }}
         >
           {existingButtonTitle}

--- a/app/src/pages/inside/testCaseLibraryPage/addToLaunchModal/messages.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/addToLaunchModal/messages.ts
@@ -32,7 +32,7 @@ export const messages = defineMessages({
   },
   addToLaunchButton: {
     id: 'TestCaseLibraryPage.addToLaunchModal.addToLaunchButton',
-    defaultMessage: 'Add to existed launch',
+    defaultMessage: 'Add to existing launch',
   },
   createNewLaunchButton: {
     id: 'TestCaseLibraryPage.addToLaunchModal.createNewLaunchButton',

--- a/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/batchDuplicateToFolderModal.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/batchDuplicateToFolderModal.scss
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.batch-duplicate-modal {
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  &__description {
+    margin-bottom: 16px;
+
+    b {
+      font-weight: var(--rp-ui-base-fw-bold);
+    }
+  }
+
+  &__autocomplete {
+    margin-top: 0;
+  }
+}

--- a/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/batchDuplicateToFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/batchDuplicateToFolderModal.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import { reduxForm, InjectedFormProps, formValueSelector } from 'redux-form';
+import { noop } from 'es-toolkit';
+import { Modal } from '@reportportal/ui-kit';
+
+import { UseModalData } from 'common/hooks';
+import { createClassnames } from 'common/utils';
+import { withModal, hideModalAction } from 'controllers/modal';
+import { commonValidators } from 'common/utils/validation';
+import { coerceToNumericId } from 'pages/inside/testCaseLibraryPage/utils';
+import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
+import { ModalLoadingOverlay } from 'components/modalLoadingOverlay';
+import { ButtonSwitcher, ButtonSwitcherOption } from 'pages/inside/common/buttonSwitcher';
+import { FieldProvider, FieldErrorHint } from 'components/fields';
+import { FolderWithFullPath } from 'controllers/testCase';
+
+import { CreateFolderForm } from '../../testCaseFolders/shared/CreateFolderForm';
+import { CreateFolderAutocomplete } from '../../testCaseFolders/shared/CreateFolderAutocomplete';
+import { sharedFolderMessages } from '../../testCaseFolders/modals/messages';
+import { commonMessages as testCaseCommonMessages } from '../../commonMessages';
+import { useBatchDuplicateToFolder } from './useBatchDuplicateToFolder';
+import { messages } from './messages';
+
+import styles from './batchDuplicateToFolderModal.scss';
+
+const cx = createClassnames(styles);
+
+export const BATCH_DUPLICATE_TO_FOLDER_MODAL_KEY = 'batchDuplicateToFolderModalKey';
+const BATCH_DUPLICATE_TO_FOLDER_FORM = 'batchDuplicateToFolderForm';
+
+export interface BatchDuplicateToFolderModalData {
+  selectedTestCaseIds: number[];
+  count: number;
+}
+
+interface BatchDuplicateToFolderFormValues {
+  mode?: ButtonSwitcherOption;
+  destinationFolder?: { id: number };
+  folderName?: string;
+  parentFolder?: { id: number };
+  isRootFolder?: boolean;
+}
+
+type BatchDuplicateToFolderModalProps = UseModalData<BatchDuplicateToFolderModalData>;
+
+const BatchDuplicateToFolderModal = reduxForm<
+  BatchDuplicateToFolderFormValues,
+  BatchDuplicateToFolderModalProps
+>({
+  form: BATCH_DUPLICATE_TO_FOLDER_FORM,
+  destroyOnUnmount: true,
+  shouldValidate: () => true,
+  validate: (values, props) => {
+    const errors: Partial<Record<keyof BatchDuplicateToFolderFormValues, string>> = {};
+
+    if (props.data) {
+      const isExistingMode = values.mode === ButtonSwitcherOption.EXISTING;
+
+      if (isExistingMode) {
+        errors.destinationFolder = commonValidators.requiredField(values.destinationFolder);
+      } else {
+        errors.folderName = commonValidators.requiredField(values.folderName);
+
+        if (!values.isRootFolder) {
+          errors.parentFolder = commonValidators.requiredField(values.parentFolder);
+        }
+      }
+    }
+
+    return errors;
+  },
+  initialValues: {
+    mode: ButtonSwitcherOption.EXISTING,
+    destinationFolder: undefined,
+    folderName: '',
+    parentFolder: undefined,
+    isRootFolder: false,
+  },
+})(({
+  dirty,
+  handleSubmit,
+  change,
+  data,
+}: BatchDuplicateToFolderModalProps &
+  InjectedFormProps<BatchDuplicateToFolderFormValues, BatchDuplicateToFolderModalProps>) => {
+  const { formatMessage } = useIntl();
+  const dispatch = useDispatch();
+  const { isLoading, batchDuplicate } = useBatchDuplicateToFolder();
+  const [currentMode, setCurrentMode] = useState(ButtonSwitcherOption.EXISTING);
+
+  const selectedTestCaseIds = useMemo(
+    () => data?.selectedTestCaseIds || [],
+    [data?.selectedTestCaseIds],
+  );
+  const count = data?.count || 0;
+
+  const selector = formValueSelector(BATCH_DUPLICATE_TO_FOLDER_FORM);
+  const isRootFolder = Boolean(
+    useSelector((state) => selector(state, 'isRootFolder') as boolean | undefined),
+  );
+
+  const handleModeChange = useCallback(
+    (mode: ButtonSwitcherOption) => {
+      setCurrentMode(mode);
+      change('mode', mode);
+
+      if (mode === ButtonSwitcherOption.EXISTING) {
+        change('folderName', '');
+        change('parentFolder', undefined);
+        change('isRootFolder', false);
+      } else {
+        change('destinationFolder', undefined);
+      }
+    },
+    [change],
+  );
+
+  const handleFolderSelect = useCallback(
+    ({ selectedItem }: { selectedItem: FolderWithFullPath }) => {
+      change('destinationFolder', selectedItem);
+    },
+    [change],
+  );
+
+  const onSubmit = useCallback(
+    (values: BatchDuplicateToFolderFormValues) => {
+      if (currentMode === ButtonSwitcherOption.EXISTING) {
+        const testFolderId = coerceToNumericId(values.destinationFolder?.id);
+
+        if (testFolderId) {
+          batchDuplicate({
+            testCaseIds: selectedTestCaseIds,
+            testFolderId,
+          }).catch(noop);
+        }
+      } else {
+        batchDuplicate({
+          testCaseIds: selectedTestCaseIds,
+          testFolder: {
+            name: values.folderName || '',
+            parentTestFolderId: coerceToNumericId(values.parentFolder?.id ?? null),
+          },
+        }).catch(noop);
+      }
+    },
+    [currentMode, batchDuplicate, selectedTestCaseIds],
+  );
+
+  const hideModal = () => dispatch(hideModalAction());
+
+  const description = (
+    <div className={cx('batch-duplicate-modal__description')}>
+      {formatMessage(messages.batchDuplicateDescription, {
+        count,
+        b: (text) => <b>{text}</b>,
+      })}
+    </div>
+  );
+
+  const okButton = useMemo(
+    () => ({
+      children: formatMessage(COMMON_LOCALE_KEYS.DUPLICATE),
+      disabled: isLoading,
+      onClick: handleSubmit(onSubmit) as () => void,
+    }),
+    [formatMessage, handleSubmit, onSubmit, isLoading],
+  );
+
+  const cancelButton = useMemo(
+    () => ({
+      children: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
+      disabled: isLoading,
+    }),
+    [formatMessage, isLoading],
+  );
+
+  return (
+    <Modal
+      title={formatMessage(messages.batchDuplicateToFolderTitle)}
+      okButton={okButton}
+      cancelButton={cancelButton}
+      allowCloseOutside={!dirty}
+      onClose={hideModal}
+    >
+      <form className={cx('batch-duplicate-modal__form')}>
+        <ButtonSwitcher
+          description={description}
+          existingButtonTitle={formatMessage(messages.duplicateToExistingFolder)}
+          createNewButtonTitle={formatMessage(messages.createNewFolder)}
+          handleActiveButton={handleModeChange}
+        />
+        {currentMode === ButtonSwitcherOption.EXISTING && (
+          <FieldProvider name="destinationFolder">
+            <FieldErrorHint provideHint={false}>
+              <CreateFolderAutocomplete
+                name="destinationFolder"
+                label={formatMessage(sharedFolderMessages.folderDestination)}
+                placeholder={formatMessage(testCaseCommonMessages.searchFolderToSelect)}
+                onStateChange={handleFolderSelect}
+                className={cx('batch-duplicate-modal__autocomplete')}
+              />
+            </FieldErrorHint>
+          </FieldProvider>
+        )}
+        {currentMode === ButtonSwitcherOption.NEW && (
+          <CreateFolderForm
+            isToggled={isRootFolder}
+            toggleLabel={formatMessage(messages.duplicateToRootDirectory)}
+            toggleFieldName="isRootFolder"
+            parentFolderFieldName="parentFolder"
+            parentFolderFieldLabel={formatMessage(sharedFolderMessages.parentFolder)}
+            folderNameFieldName="folderName"
+            toggleDisabled={false}
+            isInvertedToggle
+            change={change}
+          />
+        )}
+        <ModalLoadingOverlay isVisible={isLoading} />
+      </form>
+    </Modal>
+  );
+});
+
+export default withModal(BATCH_DUPLICATE_TO_FOLDER_MODAL_KEY)(BatchDuplicateToFolderModal);

--- a/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/index.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { useBatchDuplicateToFolderModal } from './useBatchDuplicateToFolderModal';
+export { BATCH_DUPLICATE_TO_FOLDER_MODAL_KEY } from './batchDuplicateToFolderModal';

--- a/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/messages.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/messages.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineMessages } from 'react-intl';
+
+export const messages = defineMessages({
+  batchDuplicateToFolderTitle: {
+    id: 'BatchDuplicateToFolderModal.title',
+    defaultMessage: 'Duplicate to Folder',
+  },
+  batchDuplicateDescription: {
+    id: 'BatchDuplicateToFolderModal.description',
+    defaultMessage:
+      'You are about to copy <b>{count}</b> selected test {count, plural, one {case} other {cases}} to a new location',
+  },
+  duplicateToExistingFolder: {
+    id: 'BatchDuplicateToFolderModal.duplicateToExistingFolder',
+    defaultMessage: 'Duplicate to existing folder',
+  },
+  createNewFolder: {
+    id: 'BatchDuplicateToFolderModal.createNewFolder',
+    defaultMessage: 'Create new folder',
+  },
+  duplicateToRootDirectory: {
+    id: 'BatchDuplicateToFolderModal.duplicateToRootDirectory',
+    defaultMessage: 'Duplicate to root directory',
+  },
+});

--- a/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/useBatchDuplicateToFolder.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/useBatchDuplicateToFolder.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { fetch } from 'common/utils';
+import { URLS } from 'common/urls';
+import { hideModalAction } from 'controllers/modal';
+import { showSuccessNotification, showErrorNotification } from 'controllers/notification';
+import { useDebouncedSpinner } from 'common/hooks';
+import { projectKeySelector } from 'controllers/project';
+import { updateFolderCounterAction } from 'controllers/testCase/actionCreators';
+import {
+  getTestCaseByFolderIdAction,
+  getAllTestCasesAction,
+  testCasesPageSelector,
+} from 'controllers/testCase';
+import { urlFolderIdSelector } from 'controllers/pages';
+import { getTestCaseRequestParams } from 'pages/inside/testCaseLibraryPage/utils';
+
+interface BatchDuplicateParams {
+  testCaseIds: number[];
+  testFolderId?: number;
+  testFolder?: {
+    name: string;
+    parentTestFolderId?: number;
+  };
+}
+
+export const useBatchDuplicateToFolder = () => {
+  const { isLoading, showSpinner, hideSpinner } = useDebouncedSpinner();
+  const dispatch = useDispatch();
+  const projectKey = useSelector(projectKeySelector);
+  const urlFolderId = useSelector(urlFolderIdSelector);
+  const testCasesPageData = useSelector(testCasesPageSelector);
+
+  const batchDuplicate = useCallback(
+    async ({ testCaseIds, testFolder, testFolderId }: BatchDuplicateParams) => {
+      showSpinner();
+
+      try {
+        await fetch(URLS.testCaseBatchDuplicate(projectKey), {
+          method: 'POST',
+          data: { testCaseIds, testFolder, testFolderId },
+        });
+
+        // TODO: Get created folder id after backend supports it
+        const targetFolderId = testFolderId || null;
+
+        if (targetFolderId) {
+          dispatch(
+            updateFolderCounterAction({
+              folderId: targetFolderId,
+              delta: testCaseIds.length,
+            }),
+          );
+        }
+
+        const paginationParams = getTestCaseRequestParams(testCasesPageData);
+        const isViewingTargetFolder = targetFolderId && Number(urlFolderId) === targetFolderId;
+        const isViewingAllTestCases = !urlFolderId && !targetFolderId;
+
+        if (isViewingTargetFolder) {
+          dispatch(
+            getTestCaseByFolderIdAction({
+              folderId: targetFolderId,
+              ...paginationParams,
+            }),
+          );
+        }
+
+        if (isViewingAllTestCases) {
+          dispatch(getAllTestCasesAction(paginationParams));
+        }
+
+        dispatch(hideModalAction());
+        dispatch(
+          showSuccessNotification({
+            messageId: 'testCasesDuplicatedSuccess',
+          }),
+        );
+      } catch {
+        dispatch(
+          showErrorNotification({
+            messageId: 'errorOccurredTryAgain',
+          }),
+        );
+      } finally {
+        hideSpinner();
+      }
+    },
+    [projectKey, dispatch, showSpinner, hideSpinner, urlFolderId, testCasesPageData],
+  );
+
+  return { batchDuplicate, isLoading };
+};

--- a/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/useBatchDuplicateToFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/allTestCasesPage/batchDuplicateToFolderModal/useBatchDuplicateToFolderModal.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useModal } from 'common/hooks';
+
+import BatchDuplicateToFolderModal, {
+  BATCH_DUPLICATE_TO_FOLDER_MODAL_KEY,
+  BatchDuplicateToFolderModalData,
+} from './batchDuplicateToFolderModal';
+
+export const useBatchDuplicateToFolderModal = () =>
+  useModal<BatchDuplicateToFolderModalData>({
+    modalKey: BATCH_DUPLICATE_TO_FOLDER_MODAL_KEY,
+    renderModal: (data) => <BatchDuplicateToFolderModal data={data} />,
+  });

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseModal.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseModal.scss
@@ -26,7 +26,7 @@
   > div {
     display: flex;
     flex: 1;
-    min-height: 0;
+    min-height: 39px;
   }
 
   &__content-wrapper {

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/createFolderModal/createFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/createFolderModal/createFolderModal.tsx
@@ -47,7 +47,7 @@ const CreateFolderModal = reduxForm<FolderFormValues>({
       parentFolder: isToggled ? commonValidators.requiredField(parentFolder) : undefined,
     };
   },
-})(({ dirty, handleSubmit, change, untouch }: InjectedFormProps<FolderFormValues>) => {
+})(({ dirty, handleSubmit, change }: InjectedFormProps<FolderFormValues>) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const isCreatingFolder = useSelector(isCreatingFolderSelector);
@@ -76,11 +76,9 @@ const CreateFolderModal = reduxForm<FolderFormValues>({
       toggleFieldName="isToggled"
       parentFolderFieldName={PARENT_FOLDER_FIELD}
       parentFolderFieldLabel={formatMessage(sharedFolderMessages.parentFolder)}
-      formName={CREATE_FORM_NAME}
       handleSubmit={handleSubmit}
       onSubmit={onSubmit}
       change={change}
-      untouch={untouch}
     />
   );
 });

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/duplicateFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/duplicateFolderModal.tsx
@@ -63,7 +63,6 @@ const DuplicateFolderModal = reduxForm<DuplicateFolderFormValues, DuplicateFolde
   },
   handleSubmit,
   change,
-  untouch,
   initialize,
 }: DuplicateFolderModalProps &
   InjectedFormProps<DuplicateFolderFormValues, DuplicateFolderModalProps>) => {
@@ -119,12 +118,10 @@ const DuplicateFolderModal = reduxForm<DuplicateFolderFormValues, DuplicateFolde
       isInvertedToggle
       parentFolderFieldName="destinationFolder"
       parentFolderFieldLabel={formatMessage(sharedFolderMessages.folderDestination)}
-      formName={DUPLICATE_FORM_NAME}
       customContent={customContent}
       handleSubmit={handleSubmit}
       onSubmit={onSubmit}
       change={change}
-      untouch={untouch}
     />
   );
 });

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/folderModal/folderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/folderModal/folderModal.tsx
@@ -14,23 +14,18 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { useIntl } from 'react-intl';
-import { useDispatch, useSelector } from 'react-redux';
-import { registerField, unregisterField, InjectedFormProps } from 'redux-form';
+import { useDispatch } from 'react-redux';
+import { InjectedFormProps } from 'redux-form';
 import { Modal } from '@reportportal/ui-kit';
-import { isEmpty } from 'es-toolkit/compat';
 
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { createClassnames } from 'common/utils';
-import { FolderWithFullPath, transformedFoldersWithFullPathSelector } from 'controllers/testCase';
 import { ModalLoadingOverlay } from 'components/modalLoadingOverlay';
 import { hideModalAction } from 'controllers/modal';
-import { FieldProvider, FieldErrorHint } from 'components/fields';
 
-import { commonMessages } from '../../../commonMessages';
-import { FolderNameField, ParentFolderToggle } from '../folderFormFields';
-import { CreateFolderAutocomplete } from '../../shared/CreateFolderAutocomplete/createFolderAutocomplete';
+import { CreateFolderForm } from '../../shared/CreateFolderForm';
 
 import styles from './folderModal.scss';
 
@@ -44,7 +39,6 @@ interface FolderModalConfig {
   toggleFieldName: string;
   parentFolderFieldName: string;
   parentFolderFieldLabel: string;
-  formName: string;
   toggleDisabled?: boolean;
   isInvertedToggle?: boolean;
   customContent?: ReactNode;
@@ -52,7 +46,7 @@ interface FolderModalConfig {
 }
 
 type FolderModalProps = FolderModalConfig &
-  Pick<InjectedFormProps<unknown>, 'dirty' | 'handleSubmit' | 'change' | 'untouch'>;
+  Pick<InjectedFormProps<unknown>, 'dirty' | 'handleSubmit' | 'change'>;
 
 export const FolderModal = ({
   title,
@@ -64,36 +58,15 @@ export const FolderModal = ({
   toggleDisabled = false,
   parentFolderFieldName,
   parentFolderFieldLabel,
-  formName,
   isInvertedToggle = false,
   customContent,
   handleSubmit,
   change,
-  untouch,
   onSubmit,
 }: FolderModalProps) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const hideModal = () => dispatch(hideModalAction());
-  const folders = useSelector(transformedFoldersWithFullPathSelector);
-  const computedShouldRenderToggle = !isEmpty(folders);
-
-  const handleToggleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
-    const shouldShowParentField = isInvertedToggle ? !target.checked : target.checked;
-
-    if (shouldShowParentField) {
-      dispatch(registerField(formName, parentFolderFieldName, 'Field'));
-      untouch(parentFolderFieldName);
-    } else {
-      dispatch(unregisterField(formName, parentFolderFieldName));
-    }
-
-    change(toggleFieldName, target.checked);
-  };
-
-  const handleFolderSelect = ({ selectedItem }: { selectedItem: FolderWithFullPath }) => {
-    change(parentFolderFieldName, selectedItem);
-  };
 
   const okButton = {
     children: formatMessage(COMMON_LOCALE_KEYS.CREATE),
@@ -119,29 +92,16 @@ export const FolderModal = ({
     >
       <form className={cx('folder-modal__form')}>
         {customContent}
-        <FolderNameField />
-        {computedShouldRenderToggle && (
-          <ParentFolderToggle
-            isToggled={isToggled}
-            onToggle={handleToggleChange}
-            disabled={toggleDisabled}
-            label={toggleLabel}
-            className={cx('folder-modal__toggle')}
-          />
-        )}
-        {(isInvertedToggle ? !isToggled : isToggled) && (
-          <FieldProvider name={parentFolderFieldName}>
-            <FieldErrorHint provideHint={false}>
-              <CreateFolderAutocomplete
-                name={parentFolderFieldName}
-                label={parentFolderFieldLabel}
-                placeholder={formatMessage(commonMessages.searchFolderToSelect)}
-                onStateChange={handleFolderSelect}
-                className={cx('folder-modal__parent-folder')}
-              />
-            </FieldErrorHint>
-          </FieldProvider>
-        )}
+        <CreateFolderForm
+          isToggled={isToggled}
+          toggleLabel={toggleLabel}
+          toggleFieldName={toggleFieldName}
+          parentFolderFieldName={parentFolderFieldName}
+          parentFolderFieldLabel={parentFolderFieldLabel}
+          toggleDisabled={toggleDisabled}
+          isInvertedToggle={isInvertedToggle}
+          change={change}
+        />
         <ModalLoadingOverlay isVisible={isLoading} />
       </form>
     </Modal>

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderForm/createFolderForm.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderForm/createFolderForm.scss
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.create-folder-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__toggle {
+    width: fit-content;
+    margin-top: 8px;
+  }
+
+  &__autocomplete {
+    margin-top: 0;
+  }
+}

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderForm/createFolderForm.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderForm/createFolderForm.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeEvent, useCallback } from 'react';
+import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
+import { isEmpty } from 'es-toolkit/compat';
+
+import { createClassnames } from 'common/utils';
+import { FolderWithFullPath, transformedFoldersWithFullPathSelector } from 'controllers/testCase';
+import { FieldProvider, FieldErrorHint } from 'components/fields';
+
+import { commonMessages } from '../../../commonMessages';
+import { FolderNameField, ParentFolderToggle } from '../../modals/folderFormFields';
+import { CreateFolderAutocomplete } from '../CreateFolderAutocomplete';
+
+import styles from './createFolderForm.scss';
+
+const cx = createClassnames(styles);
+
+interface CreateFolderFormProps {
+  isToggled: boolean;
+  toggleLabel: string;
+  toggleFieldName: string;
+  parentFolderFieldName: string;
+  parentFolderFieldLabel: string;
+  folderNameFieldName?: string;
+  toggleDisabled?: boolean;
+  isInvertedToggle?: boolean;
+  className?: string;
+  change: (field: string, value: unknown) => void;
+}
+
+export const CreateFolderForm = ({
+  isToggled,
+  toggleLabel,
+  toggleFieldName,
+  parentFolderFieldName,
+  parentFolderFieldLabel,
+  folderNameFieldName = 'folderName',
+  toggleDisabled = false,
+  isInvertedToggle = false,
+  className,
+  change,
+}: CreateFolderFormProps) => {
+  const { formatMessage } = useIntl();
+  const folders = useSelector(transformedFoldersWithFullPathSelector);
+
+  const shouldRenderToggle = !isEmpty(folders);
+
+  const handleToggleChange = useCallback(
+    ({ target }: ChangeEvent<HTMLInputElement>) => {
+      change(toggleFieldName, target.checked);
+    },
+    [toggleFieldName, change],
+  );
+
+  const handleFolderSelection = useCallback(
+    ({ selectedItem }: { selectedItem: FolderWithFullPath }) => {
+      change(parentFolderFieldName, selectedItem);
+    },
+    [change, parentFolderFieldName],
+  );
+
+  return (
+    <div className={cx('create-folder-form', className)}>
+      <FolderNameField name={folderNameFieldName} />
+      {shouldRenderToggle && (
+        <ParentFolderToggle
+          isToggled={isToggled}
+          disabled={toggleDisabled}
+          label={toggleLabel}
+          className={cx('create-folder-form__toggle')}
+          onToggle={handleToggleChange}
+        />
+      )}
+      {isToggled !== isInvertedToggle && (
+        <FieldProvider name={parentFolderFieldName}>
+          <FieldErrorHint provideHint={false}>
+            <CreateFolderAutocomplete
+              name={parentFolderFieldName}
+              label={parentFolderFieldLabel}
+              placeholder={formatMessage(commonMessages.searchFolderToSelect)}
+              className={cx('create-folder-form__autocomplete')}
+              onStateChange={handleFolderSelection}
+            />
+          </FieldErrorHint>
+        </FieldProvider>
+      )}
+    </div>
+  );
+};

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderForm/index.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderForm/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CreateFolderForm } from './createFolderForm';


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->

https://github.com/user-attachments/assets/795ab6ae-b594-4d48-8e58-aa56fad7292a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch "Duplicate to Folder" modal to duplicate multiple selected test cases into an existing or new folder; integrated into the All Test Cases menu and shows a success notification.

* **Improvements**
  * Improved folder creation/selection form and styling for clearer UX.
  * Wording updates: "existing" launch/launches and related message strings for clearer copy.
* **Localization**
  * Added new user-facing messages for duplication flows and modal text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->