### PR TITLE
EPMRPP-109430 || Export formatMethodType utility for plugins

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/intl-pluralrules": "1.3.9",
         "@formatjs/intl-relativetimeformat": "4.5.1",
         "@formatjs/intl-utils": "1.6.0",
-        "@reportportal/ui-kit": "^0.0.1-alpha.116",
+        "@reportportal/ui-kit": "^0.0.1-alpha.117",
         "axios": "^1.8.2",
         "c3": "0.7.20",
         "chart.js": "2.9.4",
@@ -3831,9 +3831,9 @@
       "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
     },
     "node_modules/@reportportal/ui-kit": {
-      "version": "0.0.1-alpha.116",
-      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.116.tgz",
-      "integrity": "sha512-FNLjzUclzGPT6f9njZuMdL5nTgVRblL6rcuYJqam1V9TlILRA2xBM18yVrZkFsS/anq+xrnsGvnqIzI4BWHPCg==",
+      "version": "0.0.1-alpha.117",
+      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.117.tgz",
+      "integrity": "sha512-14JGmDACtE/CM5Z6rZDdRdbNkWWYD2HdOHeIcHmXXUVk2hGm8Mzb5oV1GXsiHqB1/3Hr6oAD70wLawUfQEiMmw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "@formatjs/intl-pluralrules": "1.3.9",
     "@formatjs/intl-relativetimeformat": "4.5.1",
     "@formatjs/intl-utils": "1.6.0",
-    "@reportportal/ui-kit": "^0.0.1-alpha.116",
+    "@reportportal/ui-kit": "^0.0.1-alpha.117",
     "axios": "^1.8.2",
     "c3": "0.7.20",
     "chart.js": "2.9.4",

--- a/app/src/controllers/plugins/uiExtensions/createImportProps.js
+++ b/app/src/controllers/plugins/uiExtensions/createImportProps.js
@@ -181,6 +181,7 @@ import { updateLaunchLocallyAction } from 'controllers/launch';
 import { getDefectTypeLabel } from 'components/main/analytics/events/common/utils';
 import { formatAttribute, parseQueryAttributes } from 'common/utils/attributeUtils';
 import { createNamespacedQuery } from 'common/utils/routingUtils';
+import { formatMethodType } from 'common/utils/localizationUtils';
 import {
   publicPluginsSelector,
   createGlobalNamedIntegrationsSelector,
@@ -413,6 +414,7 @@ export const createImportProps = (pluginName) => ({
     formatDateRangeToMinutesString,
     getUserProjectSettingsFromStorage,
     updateUserProjectSettingsInStorage,
+    formatMethodType,
   },
   validators: {
     attributesArray,


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?


## Export formatMethodType utility for plugins

### Changes
- Added `formatMethodType` to the `utils` section in `createImportProps.js`
- Updated `@reportportal/ui-kit` version to `^0.0.1-alpha.117` in `package.json`

### Purpose
Enables plugins to display localized Method Type labels (e.g., "Test" instead of "STEP", "Before Method" instead of "BEFORE_METHOD") by reusing existing localization infrastructure from service-ui.

### Impact
Plugins can now access `formatMethodType` through `useExtensionProps().utils` to format method type constants consistently with the main application.

## Links

https://jiraeu.epam.com/browse/EPMRPP-109430