### PR TITLE
EPMRPP-110452 || add isDebugMode prop support to nameLinkSelector

### DIFF
--- a/app/src/controllers/testItem/selectors.js
+++ b/app/src/controllers/testItem/selectors.js
@@ -273,7 +273,7 @@ export const nameLinkSelector = (state, ownProps) => {
     payload.filterId = ALL;
   }
   let testItemIds = ownLinkParams?.testItemIds || testItemIdsSelector(state);
-  const isDebugMode = debugModeSelector(state);
+  const isDebugMode = ownLinkParams?.isDebugMode ?? debugModeSelector(state);
   let query = pagePropertiesSelector(state);
   const testItem = ownLinkParams?.testItem || testItemSelector(state, itemId);
   const hasChildren = testItem?.hasChildren;


### PR DESCRIPTION
## Description

This PR adds support for an optional `isDebugMode` prop in `nameLinkSelector` to allow explicit debug mode override when generating NameLink URLs.

## Problem

When using `NameLink` component in external plugins (like Test Execution Plugin), the URL generation was incorrect. The selector always read the debug mode from Redux global state (`debugModeSelector`), which doesn't reflect the actual `launchMode` of individual test items returned from the API.

This caused all NameLink URLs to generate as `/launches/all/...` even for DEBUG mode launches, which should use `/userdebug/all/...` paths.

## Solution

Modified `nameLinkSelector` to accept an optional `isDebugMode` property in `ownLinkParams`:

```javascript
// Before
const isDebugMode = debugModeSelector(state);

// After
const isDebugMode = ownLinkParams?.isDebugMode ?? debugModeSelector(state);
```

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?


