### PR TITLE
correct logic for disabling add to launch button for different test case type

### DIFF
--- a/app/src/pages/inside/common/testCaseList/testCaseSidePanel/testCaseSidePanel.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseSidePanel/testCaseSidePanel.tsx
@@ -328,7 +328,7 @@ export const TestCaseSidePanel = memo(
           </Button>
           {canAddTestCaseToLaunch && (
             <AddToLaunchButton
-              isButtonDisabled={isEmpty(testCase?.manualScenario?.preconditions?.value)}
+              manualScenario={testCase?.manualScenario}
               testCaseName={testCase.name}
             />
           )}

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/testCaseDetailsHeader/testCaseDetailsHeader.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/testCaseDetailsHeader/testCaseDetailsHeader.tsx
@@ -18,7 +18,6 @@ import { useIntl } from 'react-intl';
 import Parser from 'html-react-parser';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
-import { isEmpty } from 'es-toolkit/compat';
 import { BreadcrumbsTreeIcon, Button, MeatballMenuIcon } from '@reportportal/ui-kit';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
@@ -190,7 +189,7 @@ export const TestCaseDetailsHeader = ({
           </PopoverControl>
           {canAddTestCaseToLaunch && (
             <AddToLaunchButton
-              isButtonDisabled={isEmpty(testCase?.manualScenario?.preconditions?.value)}
+              manualScenario={testCase?.manualScenario}
               testCaseName={testCase.name}
             />
           )}


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for test case operations button to derive behavior directly from test data rather than precomputed flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->