### PR TITLE
EPMRPP-111994 ||  Add support for custom plugin disable message

### DIFF
--- a/app/src/components/integrations/containers/integrationInfoContainer/infoSection/infoSection.jsx
+++ b/app/src/components/integrations/containers/integrationInfoContainer/infoSection/infoSection.jsx
@@ -110,7 +110,7 @@ export class InfoSection extends Component {
     } = this.props;
     const { isEnabled } = this.state;
 
-    showToggleConfirmationModal(isEnabled, title || name, this.toggleActiveHandler, pluginLocation);
+    showToggleConfirmationModal(isEnabled, title || name, this.toggleActiveHandler, pluginLocation, name);
   };
 
   render() {

--- a/app/src/controllers/plugins/uiExtensions/constants.js
+++ b/app/src/controllers/plugins/uiExtensions/constants.js
@@ -59,3 +59,7 @@ export const UPDATE_EXTENSION_MANIFEST = 'updateExtensionManifest';
 export const PLUGIN_TYPE_REMOTE = 'REMOTE';
 export const PLUGIN_TYPE_EXTENSION = 'EXTENSION';
 export const PLUGIN_TYPE_BUILTIN = 'BUILTIN';
+
+// manifest overrides
+export const MANIFEST_OVERRIDES_KEY = 'overrides';
+export const MANIFEST_OVERRIDE_DISABLE_POPUP_CONTENT_KEY = 'disablePluginPopupContent';

--- a/app/src/controllers/plugins/uiExtensions/index.js
+++ b/app/src/controllers/plugins/uiExtensions/index.js
@@ -18,5 +18,7 @@ export {
   logStackTraceAddonSelector,
   testItemDetailsAddonSelector,
   uiExtensionProjectPagesSelector,
+  extensionManifestSelector,
+  disablePluginPopupContentSelector,
 } from './selectors';
 export { uiExtensionsReducer } from './reducer';

--- a/app/src/controllers/plugins/uiExtensions/selectors.js
+++ b/app/src/controllers/plugins/uiExtensions/selectors.js
@@ -41,6 +41,8 @@ import {
   PLUGIN_TYPE_REMOTE,
   PLUGIN_TYPE_EXTENSION,
   REMOTE_EXTENSION_POINT_PROJECT_PAGE,
+  MANIFEST_OVERRIDES_KEY,
+  MANIFEST_OVERRIDE_DISABLE_POPUP_CONTENT_KEY,
 } from './constants';
 import {
   domainSelector,
@@ -147,3 +149,14 @@ export const logStackTraceAddonSelector = createExtensionSelectorByExtensionPoin
 export const testItemDetailsAddonSelector = createExtensionSelectorByExtensionPoints([
   EXTENSION_TYPE_TEST_ITEM_DETAILS_ADDON,
 ]);
+
+export const extensionManifestSelector = (state, pluginName) => {
+  const extensionManifests = domainSelector(state).uiExtensions?.extensionManifests || [];
+  return extensionManifests.find((item) => item.pluginName === pluginName) || null;
+};
+
+export const disablePluginPopupContentSelector = (state, pluginName) => {
+  const manifest = extensionManifestSelector(state, pluginName);
+  return manifest?.[MANIFEST_OVERRIDES_KEY]?.[MANIFEST_OVERRIDE_DISABLE_POPUP_CONTENT_KEY] || null;
+};
+

--- a/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
+++ b/app/src/pages/admin/pluginsPage/pluginsListItems/pluginsItem/pluginsItem.jsx
@@ -94,7 +94,7 @@ export class PluginsItem extends Component {
     } = this.props;
     const displayName = detailsName || name;
 
-    showToggleConfirmationModal(enabled, displayName, this.toggleActiveHandler, pluginLocation);
+    showToggleConfirmationModal(enabled, displayName, this.toggleActiveHandler, pluginLocation, name);
   };
 
   render() {


### PR DESCRIPTION
## Description

This PR adds support for custom "disable plugin" confirmation messages defined in each plugin's `metadata.json`. This allows plugin developers to provide context-specific disable confirmations without requiring changes to service-ui.

### Changes Made

#### 1. **New Redux Selectors** (`service-ui/app/src/controllers/plugins/uiExtensions/selectors.js`)
- `extensionManifestSelector(state, pluginName)` — Universal selector to retrieve entire plugin manifest from Redux state
- `disablePluginPopupContentSelector(state, pluginName)` — Extracts custom disable message from `manifest.overrides.disablePluginPopupContent`

Both selectors are exported from `uiExtensions/index.js` for use throughout the application.

#### 2. **Updated installedTab Component** (`service-ui/app/src/pages/admin/pluginsPage/pluginsTabs/installedTab/`)
- Connected component to Redux with `disablePluginPopupContentSelector`
- Modified `showDisablePluginModal` method to:
  - Accept optional `pluginId` parameter (5th parameter) for manifest lookup
  - Support both object (with translations) and string formats for custom messages
  - Automatically select appropriate language based on user locale (`intl.locale`)
  - Fall back to en if current locale not available
  - Use default message if no custom message provided

#### 3. **Updated Plugin Item Components**
- `infoSection.jsx` — Updated to pass technical plugin name as `pluginId` (5th parameter)
- `pluginsItem.jsx` — Updated to pass technical plugin name as `pluginId` (5th parameter)

#### 4. **Plugin Metadata** (for example  `plugin-test-execution/ui/src/metadata.json`)
- Added `overrides` section with multi-language support
- Example structure:
  ```json
  "overrides": {
    "disablePluginPopupContent": {
      "en": "Are you sure...",
      "ru": "....",
      "be": "....",
      "uk": "...."
    }
  }
  ```

### Key Features

**Plugin Independence** — Each plugin defines its own disable messages, no sync with service-ui needed

**Multi-language Support** — Plugins can provide messages in multiple languages using object format:
```json
"disablePluginPopupContent": { "en": "...", "ru": "...", "de": "..." }
```

**Flexible Structure** — `overrides` can be extended for other plugin customizations in the future
**User Locale Aware** — Automatically selects message language based on `intl.locale` with fallback to English

## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<img width="1252" height="651" alt="image" src="https://github.com/user-attachments/assets/450cc9f7-1cd0-4630-a355-88c33a928d6f" />

<img width="1229" height="549" alt="image" src="https://github.com/user-attachments/assets/bc28a958-5eb5-456a-bd2c-b60a6227760b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom confirmation messages in plugin management. Plugins can now define per-plugin messages displayed when being disabled or toggled, providing context-specific feedback that improves the overall management experience and helps users make informed decisions regarding plugin configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->