### PR TITLE
EPMRPP-111076 || Wrong 'place' parameter value for opening 'Make Decision' by clicking pencil icon on Unique Errors

### DIFF
--- a/app/src/pages/inside/stepPage/stepGrid/defectType/defectType.jsx
+++ b/app/src/pages/inside/stepPage/stepGrid/defectType/defectType.jsx
@@ -73,9 +73,9 @@ PALabel.propTypes = {
 export const DefectType = ({ issue, hideEdit, onEdit, onRemove, patternTemplates, events }) => {
   const { trackEvent } = useTracking();
   const eventData = issue.issueType.startsWith(TO_INVESTIGATE_LOCATOR_PREFIX);
-  const onClickEdit = (event) => {
+  const onClickEdit = (event, actionPlace = '') => {
     event && trackEvent(event);
-    onEdit();
+    onEdit(actionPlace);
   };
 
   const onClickIssue = (pluginName) => {
@@ -99,7 +99,7 @@ export const DefectType = ({ issue, hideEdit, onEdit, onRemove, patternTemplates
         {!hideEdit && (
           <div
             className={cx('edit-icon')}
-            onClick={() => onClickEdit(events.onEditEvent?.(eventData, 'edit'))}
+            onClick={() => onClickEdit(events.onEditEvent?.(eventData, 'edit'), 'edit')}
           >
             {Parser(PencilIcon)}
           </div>

--- a/app/src/pages/inside/stepPage/stepGrid/stepGrid.jsx
+++ b/app/src/pages/inside/stepPage/stepGrid/stepGrid.jsx
@@ -164,7 +164,7 @@ const DefectTypeColumn = ({
         issue={value.issue}
         patternTemplates={value.patternTemplates}
         hideEdit={hideEdit}
-        onEdit={() => onEdit(value)}
+        onEdit={(actionPlace) => onEdit(value, actionPlace)}
         onRemove={onUnlinkSingleTicket(value)}
         events={events}
       />
@@ -374,9 +374,7 @@ export class StepGrid extends Component {
         component: DefectTypeColumn,
         customProps: {
           hideEdit: isTestSearchView,
-          onEdit: (data) => {
-            onEditDefect(data);
-          },
+          onEdit: (data, actionPlace) => onEditDefect(data, actionPlace),
           onUnlinkSingleTicket,
           events: {
             onEditEvent: events.MAKE_DECISION_MODAL_EVENTS?.getOpenModalEvent,

--- a/app/src/pages/inside/uniqueErrorsPage/uniqueErrorsPage.jsx
+++ b/app/src/pages/inside/uniqueErrorsPage/uniqueErrorsPage.jsx
@@ -201,7 +201,7 @@ export class UniqueErrorsPage extends Component {
     });
     this.props.tracking.trackEvent(UNIQUE_ERRORS_PAGE_EVENTS.EDIT_ITEMS_ACTION);
   };
-  handleEditDefects = (eventData) => {
+  handleEditDefects = (eventData, actionPlace = '') => {
     const { selectedItems, tracking } = this.props;
     const items = eventData?.id ? [eventData] : selectedItems;
 
@@ -210,7 +210,7 @@ export class UniqueErrorsPage extends Component {
         items.length === 1
           ? items[0].issue.issueType.startsWith(TO_INVESTIGATE_LOCATOR_PREFIX)
           : undefined,
-        eventData?.id ? '' : 'actions',
+        eventData?.id ? actionPlace : 'actions',
       ),
     );
     this.props.editDefectsAction(items, {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Problem:** On Unique Errors we needed three analytics places for opening the Make Decision modal: defect-type click (`unique_errors`), edit-icon click (`unique_errors#edit`), and toolbar (`unique_errors#actions`). We could only tell “from grid” (eventsData.id) vs “from toolbar”, not defect-type vs edit icon.

**Cause:** Unique Errors passes `events` without `MAKE_DECISION_MODAL_EVENTS` (omit), so all tracking is in `handleEditDefects`, which only gets `eventData`, not the click source.

**Change:** DefectType passes an optional second argument to the edit callback (nothing for defect-type, `'edit'` for the pencil). StepGrid forwards it as `onEditDefect(data, actionPlace)`. `handleEditDefects(eventData, actionPlace = '')` uses it to set `openModalPlace` and send one event with the correct place.

**Why:** Keeps omit and single place of tracking, reuses the existing “second argument = place” idea, minimal change (one optional param, default `''`).

## Links
[EPMRPP-111076](https://jiraeu.epam.com/browse/EPMRPP-111076)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced defect edit action tracking to capture the source and context of all edit operations, improving data logging accuracy across the application.

* **Refactor**
  * Optimized internal event handling for edit actions to better propagate action context through the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->