### PR TITLE
EPMRPP-98444 || Fix project/selectors circular dependency

### DIFF
--- a/app/src/controllers/project/selectors.js
+++ b/app/src/controllers/project/selectors.js
@@ -15,7 +15,7 @@
  */
 
 import { createSelector } from 'reselect';
-import { capitalize } from 'common/utils';
+import { capitalize } from 'common/utils/stringUtils';
 import { OWNER } from 'common/constants/permissions';
 import { DEFECT_TYPES_SEQUENCE } from 'common/constants/defectTypes';
 import * as logLevels from 'common/constants/logLevels';


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Cycle 1 (utils ↔ controllers):** In `project/selectors.js`, the `capitalize` import was changed from `common/utils` to `common/utils/stringUtils`. This removes the cycle because `stringUtils` does not depend on `connectRouter` or the controllers chain.

**Cycle 2 (nestedGrid):** Left as is. A possible fix is dependency injection: pass `NestedGridBody` into `NestedGridRow` via props instead of importing it. The cycle is currently hidden in webpack via `exclude: gridBody` in `CircularDependencyPlugin`.

<img width="1075" height="132" alt="Screenshot 2026-02-24 145928" src="https://github.com/user-attachments/assets/0acb6036-bbc1-4e2b-919b-11d636158d9a" />
