### PR TITLE
EPMRPP-113513 || Do not add assigned organizations to the autocomplete options list

### DIFF
--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -33,7 +33,7 @@ import {
   Tooltip,
 } from '@reportportal/ui-kit';
 
-import { createClassnames } from 'common/utils';
+import { createClassnames, fetch } from 'common/utils';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import {
@@ -115,6 +115,7 @@ interface InstanceAssignmentProps extends InstanceAssignmentArrayProps<InstanceA
   formName: string;
   formNamespace?: string;
   isOrganizationRequired: boolean;
+  invitedUserId?: number | null;
 }
 
 interface InstanceAssignmentArrayProps<T> extends WrappedFieldArrayProps<T> {
@@ -150,6 +151,7 @@ export const InstanceAssignment = ({
   formName,
   formNamespace,
   isOrganizationRequired = false,
+  invitedUserId = null,
 }: InstanceAssignmentProps) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
@@ -175,12 +177,43 @@ export const InstanceAssignment = ({
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<number | null>(null);
   const [totalProjects, setTotalProjects] = useState(0);
   const [isOpen, setIsOpen] = useState<boolean>(true);
+  const [userOrgIds, setUserOrgIds] = useState<Set<number>>(new Set());
   const allOrganizations = fields.getAll();
 
   useEffect(() => {
     const shouldFormBeOpen = isOpen || allOrganizations?.length === 0;
     dispatch(change(formName, 'isAddingOrganization', shouldFormBeOpen));
   }, [isOpen, allOrganizations?.length, dispatch, formName]);
+
+  useEffect(() => {
+    setSelectedOrganizationId(null);
+    setSelectedProjectId(null);
+    setOrganizationProjects([]);
+    setTotalProjects(0);
+    setNotAssignedOrganizations([]);
+    setAreOrganizationsExhausted(false);
+    dispatch(change(formName, FORM_FIELDS.ORGANIZATION.NAME, null));
+    dispatch(change(formName, FORM_FIELDS.ORGANIZATION.PROJECTS.NAME, null));
+
+    if (!invitedUserId) {
+      setUserOrgIds(new Set());
+      return;
+    }
+
+    fetch(URLS.organizationSearches(), {
+      method: 'post',
+      data: {
+        limit: 300,
+        search_criteria: [{ filter_key: 'org_user_id', operation: 'EQ', value: String(invitedUserId) }],
+      },
+    })
+      .then((response: OrganizationsSearchesResponseData) => {
+        const ids = new Set<number>((response.items ?? []).map((org) => org.id));
+        setUserOrgIds(ids);
+      })
+      .catch(() => setUserOrgIds(new Set()));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [invitedUserId]);
 
   const resetOrganization = () => {
     dispatch(
@@ -200,10 +233,19 @@ export const InstanceAssignment = ({
     };
   };
 
+  const getRequestProjectsParams = (inputValue: string) => {
+    return {
+      method: 'post',
+      data: prepareQueryFilters({ limit: 20, [SEARCH_KEY]: inputValue }),
+    };
+  };
+
   const makeOrganizationsOptions = (response: OrganizationsSearchesResponseData) => {
     if (response.items) {
       const filteredOrganizations = response.items.filter(
-        (organization) => !(allOrganizations || []).some(({ id }) => id === organization.id),
+        (organization) =>
+          !(allOrganizations || []).some(({ id }) => id === organization.id) &&
+          !userOrgIds.has(organization.id),
       );
 
       setNotAssignedOrganizations(filteredOrganizations);
@@ -272,15 +314,16 @@ export const InstanceAssignment = ({
 
   return (
     <div className={cx('forms-wrapper')}>
-      <FieldElement name={ORGANIZATIONS} className={cx('organizations')}>
-        <OrganizationAssignment isMultiple formName={formName} />
-      </FieldElement>
+        <FieldElement name={ORGANIZATIONS} className={cx('organizations')}>
+          <OrganizationAssignment isMultiple formName={formName} invitedUserId={invitedUserId} />
+        </FieldElement>
       {isOpen || allOrganizations?.length === 0 ? (
         <div className={cx('instance-assignment')}>
           <div className={cx('autocomplete-wrapper')}>
             <FieldProvider name={FORM_FIELDS.ORGANIZATION.NAME}>
               <FieldErrorHint provideHint={false}>
                 <AsyncAutocompleteV2
+                  key={`organization-${invitedUserId}`}
                   inputProps={{
                     label: formatMessage(messages.organization),
                     clearable: true,
@@ -334,7 +377,7 @@ export const InstanceAssignment = ({
             <FieldProvider name={FORM_FIELDS.ORGANIZATION.PROJECTS.NAME}>
               <FieldErrorHint provideHint={false}>
                 <AsyncAutocompleteV2
-                  key={`project-${selectedOrganizationId}`}
+                  key={`project-${selectedOrganizationId}-${invitedUserId}`}
                   inputProps={{
                     label: formatMessage(messages.project),
                     clearable: totalProjects > 0 && !!selectedOrganizationId,
@@ -346,7 +389,7 @@ export const InstanceAssignment = ({
                   }}
                   placeholder={formatMessage(invitationMessages.selectSearchProject)}
                   getURI={() => URLS.organizationProjectsSearches(selectedOrganizationId)}
-                  getRequestParams={getRequestOrganizationsParams}
+                  getRequestParams={getRequestProjectsParams}
                   makeOptions={makeProjectsOptions}
                   onChange={handleProjectChange}
                   createWithoutConfirmation

--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -316,9 +316,9 @@ export const InstanceAssignment = ({
 
   return (
     <div className={cx('forms-wrapper')}>
-        <FieldElement name={ORGANIZATIONS} className={cx('organizations')}>
-          <OrganizationAssignment isMultiple formName={formName} isOrganizationFormOpen={isOpen} />
-        </FieldElement>
+      <FieldElement name={ORGANIZATIONS} className={cx('organizations')}>
+        <OrganizationAssignment isMultiple formName={formName} isOrganizationFormOpen={isOpen} />
+      </FieldElement>
       {isOpen || allOrganizations?.length === 0 ? (
         <div className={cx('instance-assignment')}>
           <div className={cx('autocomplete-wrapper')}>

--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -192,6 +192,8 @@ export const InstanceAssignment = ({
     setTotalProjects(0);
     setNotAssignedOrganizations([]);
     setAreOrganizationsExhausted(false);
+    setIsOpen(true);
+    fields.removeAll();
     dispatch(change(formName, FORM_FIELDS.ORGANIZATION.NAME, null));
     dispatch(change(formName, FORM_FIELDS.ORGANIZATION.PROJECTS.NAME, null));
 
@@ -315,7 +317,7 @@ export const InstanceAssignment = ({
   return (
     <div className={cx('forms-wrapper')}>
         <FieldElement name={ORGANIZATIONS} className={cx('organizations')}>
-          <OrganizationAssignment isMultiple formName={formName} invitedUserId={invitedUserId} />
+          <OrganizationAssignment isMultiple formName={formName} isOrganizationFormOpen={isOpen} />
         </FieldElement>
       {isOpen || allOrganizations?.length === 0 ? (
         <div className={cx('instance-assignment')}>

--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -185,6 +185,16 @@ export const InstanceAssignment = ({
     dispatch(change(formName, 'isAddingOrganization', shouldFormBeOpen));
   }, [isOpen, allOrganizations?.length, dispatch, formName]);
 
+  const resetOrganization = () => {
+    dispatch(
+      change(formName, formNamespace, {
+        name: null,
+        role: false,
+        projects: [],
+      }),
+    );
+  };
+
   useEffect(() => {
     setSelectedOrganizationId(null);
     setSelectedProjectId(null);
@@ -194,8 +204,7 @@ export const InstanceAssignment = ({
     setAreOrganizationsExhausted(false);
     setIsOpen(true);
     fields.removeAll();
-    dispatch(change(formName, FORM_FIELDS.ORGANIZATION.NAME, null));
-    dispatch(change(formName, FORM_FIELDS.ORGANIZATION.PROJECTS.NAME, null));
+    resetOrganization();
 
     if (!invitedUserId) {
       setUserOrgIds(new Set());
@@ -216,16 +225,6 @@ export const InstanceAssignment = ({
       .catch(() => setUserOrgIds(new Set()));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [invitedUserId]);
-
-  const resetOrganization = () => {
-    dispatch(
-      change(formName, formNamespace, {
-        name: null,
-        role: false,
-        projects: [],
-      }),
-    );
-  };
 
   const getRequestOrganizationsParams = (inputValue: string) => {
     organizationSearchQueryRef.current = inputValue;

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
@@ -26,6 +26,7 @@ interface OrganizationAssignmentProps {
   isMultiple?: boolean;
   organizationRoleDisabledTooltip?: string | null;
   formName?: string;
+  invitedUserId?: number | null;
 }
 
 export const OrganizationAssignment = ({
@@ -34,6 +35,7 @@ export const OrganizationAssignment = ({
   isMultiple = false,
   organizationRoleDisabledTooltip = null,
   formName,
+  invitedUserId,
 }: OrganizationAssignmentProps) => {
   const dispatch = useDispatch();
   const [openFormOrgId, setOpenFormOrgId] = useState<number | null>(null);
@@ -84,6 +86,7 @@ export const OrganizationAssignment = ({
               onRemove={() => removeItem(index)}
               collapsable
               addProjectDisabled={openFormOrgId !== null && openFormOrgId !== org.id}
+              invitedUserId={invitedUserId}
               onAddProjectFormToggle={handleAddProjectFormToggle}
             />
           </div>
@@ -97,6 +100,7 @@ export const OrganizationAssignment = ({
       value={value as Organization}
       onChange={(updates) => updateItem(updates)}
       organizationRoleDisabledTooltip={organizationRoleDisabledTooltip}
+      invitedUserId={invitedUserId}
       onAddProjectFormToggle={handleAddProjectFormToggle}
     />
   );

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
@@ -26,7 +26,7 @@ interface OrganizationAssignmentProps {
   isMultiple?: boolean;
   organizationRoleDisabledTooltip?: string | null;
   formName?: string;
-  invitedUserId?: number | null;
+  isOrganizationFormOpen?: boolean;
 }
 
 export const OrganizationAssignment = ({
@@ -35,7 +35,7 @@ export const OrganizationAssignment = ({
   isMultiple = false,
   organizationRoleDisabledTooltip = null,
   formName,
-  invitedUserId,
+  isOrganizationFormOpen = false,
 }: OrganizationAssignmentProps) => {
   const dispatch = useDispatch();
   const [openFormOrgId, setOpenFormOrgId] = useState<number | null>(null);
@@ -85,8 +85,7 @@ export const OrganizationAssignment = ({
               onChange={(updates) => updateItem(updates, index)}
               onRemove={() => removeItem(index)}
               collapsable
-              addProjectDisabled={openFormOrgId !== null && openFormOrgId !== org.id}
-              invitedUserId={invitedUserId}
+              addProjectDisabled={(openFormOrgId !== null && openFormOrgId !== org.id) || isOrganizationFormOpen}
               onAddProjectFormToggle={handleAddProjectFormToggle}
             />
           </div>
@@ -100,7 +99,6 @@ export const OrganizationAssignment = ({
       value={value as Organization}
       onChange={(updates) => updateItem(updates)}
       organizationRoleDisabledTooltip={organizationRoleDisabledTooltip}
-      invitedUserId={invitedUserId}
       onAddProjectFormToggle={handleAddProjectFormToggle}
     />
   );

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/addProjectForm/addProjectForm.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/addProjectForm/addProjectForm.tsx
@@ -35,7 +35,6 @@ import {
 } from 'controllers/organization/projects';
 import { getAppliedFilters } from 'controllers/instance/events/utils';
 import { SEARCH_KEY } from 'controllers/organization/projects/constants';
-import { fetch } from 'common/utils';
 import { EDITOR, VIEWER } from 'common/constants/projectRoles';
 import { Project } from '../projectItems';
 import styles from './addProjectForm.scss';
@@ -46,7 +45,6 @@ interface AddProjectFormProps {
   projects: Project[];
   organizationId: number;
   canEditByDefault: boolean;
-  invitedUserId?: number | null;
   onSave: (project: Project) => void;
   onCancel: () => void;
 }
@@ -55,7 +53,6 @@ export const AddProjectForm = ({
   organizationId,
   canEditByDefault,
   projects,
-  invitedUserId,
   onSave,
   onCancel,
 }: AddProjectFormProps) => {
@@ -63,33 +60,10 @@ export const AddProjectForm = ({
   const [canEdit, setCanEdit] = useState(canEditByDefault);
   const [items, setItems] = useState<ProjectsSearchesItem[]>([]);
   const [selectedProject, setSelectedProject] = useState<Pick<Project, 'id' | 'name'>>(null);
-  const [userProjectIds, setUserProjectIds] = useState<Set<number>>(new Set());
-  const [autocompleteKey, setAutocompleteKey] = useState(0);
 
   useEffect(() => {
     setCanEdit(canEditByDefault);
   }, [canEditByDefault]);
-
-  useEffect(() => {
-    if (!invitedUserId) {
-      setUserProjectIds(new Set());
-      return;
-    }
-
-    fetch(URLS.organizationProjectsSearches(organizationId), {
-      method: 'post',
-      data: {
-        limit: 300,
-        search_criteria: [{ filter_key: 'userId', operation: 'EQ', value: String(invitedUserId) }],
-      },
-    })
-      .then((response: ProjectsSearchesResponseData) => {
-        const ids = new Set<number>((response.items ?? []).map((p) => p.id));
-        setUserProjectIds(ids);
-        setAutocompleteKey((k) => k + 1);
-      })
-      .catch(() => setUserProjectIds(new Set()));
-  }, [invitedUserId, organizationId]);
 
   const getRequestParams = (inputValue: string) => {
     return {
@@ -104,9 +78,7 @@ export const AddProjectForm = ({
   const makeOptions = (response: ProjectsSearchesResponseData) => {
     if (response.items) {
       const filtered = response.items.filter(
-        (item) =>
-          !projects.some((project: Project) => project.id === item.id) &&
-          !userProjectIds.has(item.id),
+        (item) => !projects.some((project: Project) => project.id === item.id),
       );
       setItems(filtered);
       return filtered.map((item) => item.name);
@@ -142,7 +114,6 @@ export const AddProjectForm = ({
     <div className={cx('form')}>
       <div className={cx('projects')}>
         <AsyncAutocompleteV2
-          key={autocompleteKey}
           inputProps={{
             clearable: !!selectedProject,
             onClear: () => setSelectedProject(null),

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/addProjectForm/addProjectForm.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/addProjectForm/addProjectForm.tsx
@@ -35,6 +35,7 @@ import {
 } from 'controllers/organization/projects';
 import { getAppliedFilters } from 'controllers/instance/events/utils';
 import { SEARCH_KEY } from 'controllers/organization/projects/constants';
+import { fetch } from 'common/utils';
 import { EDITOR, VIEWER } from 'common/constants/projectRoles';
 import { Project } from '../projectItems';
 import styles from './addProjectForm.scss';
@@ -45,6 +46,7 @@ interface AddProjectFormProps {
   projects: Project[];
   organizationId: number;
   canEditByDefault: boolean;
+  invitedUserId?: number | null;
   onSave: (project: Project) => void;
   onCancel: () => void;
 }
@@ -53,6 +55,7 @@ export const AddProjectForm = ({
   organizationId,
   canEditByDefault,
   projects,
+  invitedUserId,
   onSave,
   onCancel,
 }: AddProjectFormProps) => {
@@ -60,10 +63,33 @@ export const AddProjectForm = ({
   const [canEdit, setCanEdit] = useState(canEditByDefault);
   const [items, setItems] = useState<ProjectsSearchesItem[]>([]);
   const [selectedProject, setSelectedProject] = useState<Pick<Project, 'id' | 'name'>>(null);
+  const [userProjectIds, setUserProjectIds] = useState<Set<number>>(new Set());
+  const [autocompleteKey, setAutocompleteKey] = useState(0);
 
   useEffect(() => {
     setCanEdit(canEditByDefault);
   }, [canEditByDefault]);
+
+  useEffect(() => {
+    if (!invitedUserId) {
+      setUserProjectIds(new Set());
+      return;
+    }
+
+    fetch(URLS.organizationProjectsSearches(organizationId), {
+      method: 'post',
+      data: {
+        limit: 300,
+        search_criteria: [{ filter_key: 'userId', operation: 'EQ', value: String(invitedUserId) }],
+      },
+    })
+      .then((response: ProjectsSearchesResponseData) => {
+        const ids = new Set<number>((response.items ?? []).map((p) => p.id));
+        setUserProjectIds(ids);
+        setAutocompleteKey((k) => k + 1);
+      })
+      .catch(() => setUserProjectIds(new Set()));
+  }, [invitedUserId, organizationId]);
 
   const getRequestParams = (inputValue: string) => {
     return {
@@ -77,11 +103,13 @@ export const AddProjectForm = ({
 
   const makeOptions = (response: ProjectsSearchesResponseData) => {
     if (response.items) {
-      const items = response.items.filter(
-        (item) => !projects.some((project: Project) => project.id === item.id),
+      const filtered = response.items.filter(
+        (item) =>
+          !projects.some((project: Project) => project.id === item.id) &&
+          !userProjectIds.has(item.id),
       );
-      setItems(items);
-      return items.map((item) => item.name);
+      setItems(filtered);
+      return filtered.map((item) => item.name);
     }
 
     return [];
@@ -114,6 +142,7 @@ export const AddProjectForm = ({
     <div className={cx('form')}>
       <div className={cx('projects')}>
         <AsyncAutocompleteV2
+          key={autocompleteKey}
           inputProps={{
             clearable: !!selectedProject,
             onClear: () => setSelectedProject(null),

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
@@ -48,7 +48,6 @@ interface OrganizationItemProps {
   collapsable?: boolean;
   organizationRoleDisabledTooltip?: string | null;
   addProjectDisabled?: boolean;
-  invitedUserId?: number | null;
   onAddProjectFormToggle?: (orgId: number, isOpen: boolean) => void;
 }
 
@@ -59,7 +58,6 @@ export const OrganizationItem = ({
   collapsable,
   organizationRoleDisabledTooltip = null,
   addProjectDisabled = false,
-  invitedUserId,
   onAddProjectFormToggle,
 }: OrganizationItemProps) => {
   const disableOrganizationRole = Boolean(organizationRoleDisabledTooltip);
@@ -211,7 +209,6 @@ export const OrganizationItem = ({
                 projects={projects}
                 organizationId={id}
                 canEditByDefault={role === MANAGER}
-                invitedUserId={invitedUserId}
                 onSave={handleAddProject}
                 onCancel={() => setAddProjectFormOpen(false)}
               />

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
@@ -48,6 +48,7 @@ interface OrganizationItemProps {
   collapsable?: boolean;
   organizationRoleDisabledTooltip?: string | null;
   addProjectDisabled?: boolean;
+  invitedUserId?: number | null;
   onAddProjectFormToggle?: (orgId: number, isOpen: boolean) => void;
 }
 
@@ -58,6 +59,7 @@ export const OrganizationItem = ({
   collapsable,
   organizationRoleDisabledTooltip = null,
   addProjectDisabled = false,
+  invitedUserId,
   onAddProjectFormToggle,
 }: OrganizationItemProps) => {
   const disableOrganizationRole = Boolean(organizationRoleDisabledTooltip);
@@ -209,6 +211,7 @@ export const OrganizationItem = ({
                 projects={projects}
                 organizationId={id}
                 canEditByDefault={role === MANAGER}
+                invitedUserId={invitedUserId}
                 onSave={handleAddProject}
                 onCancel={() => setAddProjectFormOpen(false)}
               />

--- a/app/src/pages/inside/common/invitations/inviteUserModal/InviteUserEmailAutocompleteField.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/InviteUserEmailAutocompleteField.tsx
@@ -145,6 +145,7 @@ const InviteUserEmailAutocompleteFieldContent = ({
   input,
   onFocus,
   onResetTouched,
+  onUserSelect,
   ...rest
 }: {
   inputValueRef: MutableRefObject<string>;
@@ -155,6 +156,7 @@ const InviteUserEmailAutocompleteFieldContent = ({
   };
   onFocus?: () => void;
   onResetTouched?: () => void;
+  onUserSelect?: (userId: number | null) => void;
   [key: string]: unknown;
 }) => {
   const { formatMessage } = useIntl();
@@ -197,6 +199,8 @@ const InviteUserEmailAutocompleteFieldContent = ({
     [formatMessage],
   );
 
+  const { onChange: restOnChange, ...restWithoutOnChange } = rest as { onChange?: (value: unknown) => void; [key: string]: unknown };
+
   return (
     <AsyncAutocompleteV2
       placeholder={placeholder}
@@ -216,17 +220,27 @@ const InviteUserEmailAutocompleteFieldContent = ({
         onClear: () => {
           inputValueRef.current = '';
           input?.onChange(null);
+          onUserSelect?.(null);
         },
         onFocus: handleFocus,
       }}
       isRequired
       useFixedPositioning={false}
-      {...rest}
+      {...restWithoutOnChange}
+      onChange={(selected: EmailOption | null) => {
+        restOnChange?.(selected);
+        const userId = selected && typeof selected.id === 'number' && !selected.isCustom ? selected.id : null;
+        onUserSelect?.(userId);
+      }}
     />
   );
 };
 
-export const InviteUserEmailAutocompleteField = () => {
+interface InviteUserEmailAutocompleteFieldProps {
+  onUserSelect?: (userId: number | null) => void;
+}
+
+export const InviteUserEmailAutocompleteField = ({ onUserSelect }: InviteUserEmailAutocompleteFieldProps) => {
   const inputValueRef = useRef('');
   const dispatch = useDispatch();
 
@@ -237,7 +251,11 @@ export const InviteUserEmailAutocompleteField = () => {
   return (
     <FieldProvider name="email">
       <FieldErrorHint provideHint={false}>
-        <InviteUserEmailAutocompleteFieldContent inputValueRef={inputValueRef} onResetTouched={handleResetTouched} />
+        <InviteUserEmailAutocompleteFieldContent
+          inputValueRef={inputValueRef}
+          onResetTouched={handleResetTouched}
+          onUserSelect={onUserSelect}
+        />
       </FieldErrorHint>
     </FieldProvider>
   );

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserInstanceForm/inviteUserInstanceForm.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserInstanceForm/inviteUserInstanceForm.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useState, useCallback } from 'react';
 import { useIntl } from 'react-intl';
 import { FieldArray } from 'redux-form';
 import { createClassnames } from 'common/utils';
@@ -30,10 +31,15 @@ const cx = createClassnames(styles);
 
 export const InviteUserInstanceForm = () => {
   const { formatMessage } = useIntl();
+  const [invitedUserId, setInvitedUserId] = useState<number | null>(null);
+
+  const handleUserSelect = useCallback((userId: number | null) => {
+    setInvitedUserId(userId);
+  }, []);
 
   return (
     <form className={cx('form')}>
-      <InviteUserEmailAutocompleteField />
+      <InviteUserEmailAutocompleteField onUserSelect={handleUserSelect} />
       <div className={cx('invite-wrapper')}>
         <span className={cx('invite')}>{formatMessage(invitationMessages.organizationsAndProjectsToInvite)}</span>
         <span className={cx('invite-description')}>
@@ -47,6 +53,7 @@ export const InviteUserInstanceForm = () => {
           formName: getFormName(Level.INSTANCE),
           formNamespace: 'organization',
           isOrganizationRequired: true,
+          invitedUserId,
         }}
       />
     </form>


### PR DESCRIPTION
## Description

When inviting an existing user, the organization and project autocomplete fields in the "Invite User" modal now exclude items the user is already assigned to.

Additionally, the "Add Project" buttons in already added organizations are now disabled while the "Add Organization" form is open, enforcing the rule that only one form can be active at a time.

## Changes

### Filter assigned organizations from autocomplete suggestions

When an existing user is selected in the email field, a request is made to fetch all organizations the user already belongs to. These organizations are then excluded from the autocomplete suggestions in the "Add Organization" form.

The invited user's ID is tracked via an `onUserSelect` callback in `InviteUserEmailAutocompleteField`, stored in local state in `InviteUserInstanceForm`, and passed down to `InstanceAssignment` as `invitedUserId`.

When `invitedUserId` changes, the previously added organizations list is cleared and the organization form is reset, preventing stale selections from remaining when switching between users.

Note: backend filtering via `org_user_id NE` was investigated but does not work as expected — the filter operates on a JOIN field and cannot exclude organizations where a user is not a member. Frontend filtering is used instead.

### Disable "Add Project" buttons when "Add Organization" form is open

The `isOrganizationFormOpen` prop is passed from `InstanceAssignment` to `OrganizationAssignment`. When the organization form is open, all "Add Project" buttons in existing organization items are disabled, consistent with the existing behavior that disables "Add Organization" when a project form is open.


## Visuals


https://github.com/user-attachments/assets/8b4425b0-04dd-46ec-bd82-4235a33b3e4c


https://github.com/user-attachments/assets/3232e3a8-e18e-497a-a7cd-8ed918ba8c66





## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete now reports the selected user so the invite form tailors organization and project options.
  * Invitation form resets and refreshes available organizations/projects whenever the selected user changes.
  * Components remount appropriately when invited user or selected organization changes to ensure fresh options.

* **Bug Fixes**
  * Prevents offering organizations already assigned to the invited user.

* **UI**
  * Disables adding projects while an organization form is open to avoid conflicting edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->