### PR TITLE
EPMRPP-113567 || Wrong UI validation on empty state at Registration page

### DIFF
--- a/app/src/pages/inside/common/assignments/manageAssignmentsOrganizationModal/manageAssignmentsOrganizationModal.scss
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsOrganizationModal/manageAssignmentsOrganizationModal.scss
@@ -65,3 +65,7 @@
   font-weight: 500;
   line-height: 24px;
 }
+
+.modal-content {
+  padding-bottom: 16px;
+}

--- a/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
+++ b/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
@@ -205,11 +205,25 @@ export const RegistrationForm = connect((state) => ({
           passwordMessage,
         );
 
+        const passwordErrorMessage = password?.trim()
+          ? passwordValidator(password)
+          : 'requiredFieldWithPeriodHint';
+
+        let confirmPasswordErrorMessage: string | undefined;
+        if (!confirmPassword?.trim()) {
+          confirmPasswordErrorMessage = 'requiredFieldWithPeriodHint';
+        } else if (confirmPassword !== password) {
+          confirmPasswordErrorMessage = 'confirmPasswordHint';
+        }
+
+        const nameErrorMessage = name?.trim()
+          ? commonValidators.userName(name)
+          : 'requiredFieldWithPeriodHint';
+
         return {
-          password: passwordValidator(password),
-          confirmPassword:
-            (!confirmPassword || confirmPassword !== password) && 'confirmPasswordHint',
-          name: name?.trim() ? commonValidators.userName(name) : 'requiredFieldWithPeriodHint',
+          password: passwordErrorMessage,
+          confirmPassword: confirmPasswordErrorMessage,
+          name: nameErrorMessage,
         };
       },
     })(RegistrationFormComponent),

--- a/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
+++ b/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
@@ -38,6 +38,11 @@ import styles from './registrationForm.scss';
 
 const cx = createClassnames(styles);
 
+const REGISTRATION_VALIDATION_HINTS = {
+  REQUIRED_FIELD: 'requiredFieldWithPeriodHint',
+  CONFIRM_PASSWORD_MISMATCH: 'confirmPasswordHint',
+} as const;
+
 const messages = defineMessages({
   name: {
     id: 'RegistrationForm.namePlaceholder',
@@ -125,7 +130,10 @@ const RegistrationFormComponent = ({
     >
       <div className={cx('name-field')}>
         <FieldProvider name="name">
-          <FieldErrorHint provideHint={false} errorsWithHint={['requiredFieldWithPeriodHint']}>
+          <FieldErrorHint
+            provideHint={false}
+            errorsWithHint={[REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD]}
+          >
             <InputOutside
               icon={NameIcon}
               maxLength={Number(REGISTRATION_NAME_MAX_LENGTH)}
@@ -207,18 +215,18 @@ export const RegistrationForm = connect((state) => ({
 
         const passwordErrorMessage = password?.trim()
           ? passwordValidator(password)
-          : 'requiredFieldWithPeriodHint';
+          : REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD;
 
         let confirmPasswordErrorMessage: string | undefined;
         if (!confirmPassword?.trim()) {
-          confirmPasswordErrorMessage = 'requiredFieldWithPeriodHint';
+          confirmPasswordErrorMessage = REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD;
         } else if (confirmPassword !== password) {
-          confirmPasswordErrorMessage = 'confirmPasswordHint';
+          confirmPasswordErrorMessage = REGISTRATION_VALIDATION_HINTS.CONFIRM_PASSWORD_MISMATCH;
         }
 
         const nameErrorMessage = name?.trim()
           ? commonValidators.userName(name)
-          : 'requiredFieldWithPeriodHint';
+          : REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD;
 
         return {
           password: passwordErrorMessage,

--- a/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
+++ b/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
@@ -40,7 +40,7 @@ const cx = createClassnames(styles);
 
 const ERROR_MESSAGE_KEYS = {
   REQUIRED_FIELD_WITH_PERIOD: 'requiredFieldWithPeriodHint',
-  CONFIRM_PASSWORD: 'confirmPasswordHint',
+  CONFIRM_PASSWORD_HINT_MESSAGE: 'confirmPasswordHint',
 } as const;
 
 const messages = defineMessages({
@@ -221,7 +221,7 @@ export const RegistrationForm = connect((state) => ({
         if (!confirmPassword?.trim()) {
           confirmPasswordErrorMessage = ERROR_MESSAGE_KEYS.REQUIRED_FIELD_WITH_PERIOD;
         } else if (confirmPassword !== password) {
-          confirmPasswordErrorMessage = ERROR_MESSAGE_KEYS.CONFIRM_PASSWORD;
+          confirmPasswordErrorMessage = ERROR_MESSAGE_KEYS.CONFIRM_PASSWORD_HINT_MESSAGE;
         }
 
         const nameErrorMessage = name?.trim()

--- a/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
+++ b/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
@@ -38,9 +38,9 @@ import styles from './registrationForm.scss';
 
 const cx = createClassnames(styles);
 
-const REGISTRATION_VALIDATION_HINTS = {
-  REQUIRED_FIELD: 'requiredFieldWithPeriodHint',
-  CONFIRM_PASSWORD_MISMATCH: 'confirmPasswordHint',
+const ERROR_MESSAGE_KEYS = {
+  REQUIRED_FIELD_WITH_PERIOD: 'requiredFieldWithPeriodHint',
+  CONFIRM_PASSWORD: 'confirmPasswordHint',
 } as const;
 
 const messages = defineMessages({
@@ -132,7 +132,7 @@ const RegistrationFormComponent = ({
         <FieldProvider name="name">
           <FieldErrorHint
             provideHint={false}
-            errorsWithHint={[REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD]}
+            errorsWithHint={[ERROR_MESSAGE_KEYS.REQUIRED_FIELD_WITH_PERIOD]}
           >
             <InputOutside
               icon={NameIcon}
@@ -215,18 +215,18 @@ export const RegistrationForm = connect((state) => ({
 
         const passwordErrorMessage = password?.trim()
           ? passwordValidator(password)
-          : REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD;
+          : ERROR_MESSAGE_KEYS.REQUIRED_FIELD_WITH_PERIOD;
 
         let confirmPasswordErrorMessage: string | undefined;
         if (!confirmPassword?.trim()) {
-          confirmPasswordErrorMessage = REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD;
+          confirmPasswordErrorMessage = ERROR_MESSAGE_KEYS.REQUIRED_FIELD_WITH_PERIOD;
         } else if (confirmPassword !== password) {
-          confirmPasswordErrorMessage = REGISTRATION_VALIDATION_HINTS.CONFIRM_PASSWORD_MISMATCH;
+          confirmPasswordErrorMessage = ERROR_MESSAGE_KEYS.CONFIRM_PASSWORD;
         }
 
         const nameErrorMessage = name?.trim()
           ? commonValidators.userName(name)
-          : REGISTRATION_VALIDATION_HINTS.REQUIRED_FIELD;
+          : ERROR_MESSAGE_KEYS.REQUIRED_FIELD_WITH_PERIOD;
 
         return {
           password: passwordErrorMessage,


### PR DESCRIPTION

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
separating  not empty and empty state input error messages in registration form , to show correct messages when inputs are focused but empty + did some small design change in manage assignments modal



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted modal dialog spacing to improve visual layout and readability.

* **Refactor**
  * Centralized registration form error messaging to remove inline strings.
  * Updated validation logic to provide clearer, consistent feedback for name, password, and confirmation fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->