### PR TITLE
EPMRPP-113579 ||  There is no UI validation message under "Organization" field on empty state

### DIFF
--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -20,6 +20,7 @@ import {
   WrappedFieldArrayProps,
   formValueSelector,
   change,
+  untouch,
   getFormSyncErrors,
   getFormMeta,
 } from 'redux-form';
@@ -193,6 +194,7 @@ export const InstanceAssignment = ({
         projects: [],
       }),
     );
+   dispatch(untouch(formName, FORM_FIELDS.ORGANIZATION.NAME));
   };
 
   useEffect(() => {

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModalValidate.ts
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModalValidate.ts
@@ -42,9 +42,11 @@ export function validateInstance(formData: InviteUserInstanceFormData): InviteUs
   }
 
   const orgName = formData.organization?.name;
+    const shouldValidateOrganizationName =
+    formData.isAddingOrganization || formData.isAddingProject || organizations.length === 0;
   const isOrganizationNameEmpty =
     !orgName || (typeof orgName === 'string' && !orgName.trim());
-  if (isOrganizationNameEmpty) {
+  if (shouldValidateOrganizationName && isOrganizationNameEmpty) {
     errors.organization = {
       name: commonValidators.requiredField(orgName),
     };

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModalValidate.ts
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModalValidate.ts
@@ -33,20 +33,22 @@ export function validateInstance(formData: InviteUserInstanceFormData): InviteUs
     email: emailValidator(emailStr.trim()),
   };
 
+  const organizations = formData.organizations ?? [];
+
   if (formData.isAddingOrganization || formData.isAddingProject) {
     errors.organizations = 'Form is being edited';
-    return errors;
+  } else if (organizations.length === 0) {
+    errors.organizations = commonValidators.requiredField(organizations);
   }
 
-  const organizations = formData.organizations ?? [];
-  if (organizations.length === 0) {
-    errors.organizations = commonValidators.requiredField(organizations);
-    const orgName = formData.organization?.name;
-    if (!orgName) {
-      errors.organization = {
-        name: commonValidators.requiredField(orgName),
-      };
-    }
+  const orgName = formData.organization?.name;
+  const isOrganizationNameEmpty =
+    !orgName || (typeof orgName === 'string' && !orgName.trim());
+  if (isOrganizationNameEmpty) {
+    errors.organization = {
+      name: commonValidators.requiredField(orgName),
+    };
   }
+
   return errors;
 }

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModalValidate.ts
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModalValidate.ts
@@ -42,10 +42,9 @@ export function validateInstance(formData: InviteUserInstanceFormData): InviteUs
   }
 
   const orgName = formData.organization?.name;
-    const shouldValidateOrganizationName =
+  const shouldValidateOrganizationName =
     formData.isAddingOrganization || formData.isAddingProject || organizations.length === 0;
-  const isOrganizationNameEmpty =
-    !orgName || (typeof orgName === 'string' && !orgName.trim());
+  const isOrganizationNameEmpty = !orgName || (typeof orgName === 'string' && !orgName.trim());
   if (shouldValidateOrganizationName && isOrganizationNameEmpty) {
     errors.organization = {
       name: commonValidators.requiredField(orgName),


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description

changed inviterUserModal instance assignment validation , so now after unfocus in organization name field 'field is required' validation message appears

## Visuals

https://github.com/user-attachments/assets/8f4c4289-a4b8-40b8-9256-142de1b4fc72





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting assignment forms now also clears the touched state for the organization name so validation and UI reflect the cleared field.
  * Invitation form validation now accumulates and reports all relevant errors and applies organization-name checks conditionally, improving feedback when adding organizations or projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->