### PR TITLE
EPMRPP113579 || There is no UI validation message under Organization field on empty state (reopened)

### DIFF
--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   WrappedFieldArrayProps,
@@ -211,6 +211,10 @@ export const InstanceAssignment = ({
    dispatch(untouch(formName, FORM_FIELDS.ORGANIZATION.NAME));
   };
 
+  const handleOrganizationNameFocus = useCallback(() => {
+    dispatch(untouch(formName, FORM_FIELDS.ORGANIZATION.NAME));
+  }, [dispatch, formName]);
+
   useEffect(() => {
     let isActive = true;
 
@@ -368,6 +372,7 @@ export const InstanceAssignment = ({
                 <AsyncAutocompleteV2
                   key={`organization-${invitedUserId}`}
                   inputProps={{
+                    onFocus: handleOrganizationNameFocus,
                     label: formatMessage(messages.organization),
                     clearable: true,
                     onClear: () => {


### PR DESCRIPTION

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
corrected focus handling in organization name autocomplete field by adding onfocus props

https://github.com/user-attachments/assets/f174459f-8570-4ff6-93d3-1f16439dffb6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field behavior for organization input to reset state when focused, enhancing user interaction and form reliability in instance assignment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->