### PR TITLE
EPMRPP-112498 view test executions within a folder in selected manual launch

### DIFF
--- a/app/src/controllers/manualLaunch/constants.ts
+++ b/app/src/controllers/manualLaunch/constants.ts
@@ -33,6 +33,8 @@ export const ACTIVE_MANUAL_LAUNCH_EXECUTION_NAMESPACE = 'activeManualLaunchExecu
 export const MANUAL_SCENARIO_TYPE_TEXT = 'TEXT' as const;
 export const MANUAL_SCENARIO_TYPE_STEPS = 'STEPS' as const;
 
+export const TEST_FOLDER_ID_FILTER_KEY = 'filter.eq.testFolderId' as const;
+
 export const defaultManualLaunchesQueryParams = {
   limit: 20,
   offset: 0,

--- a/app/src/controllers/manualLaunch/sagas.ts
+++ b/app/src/controllers/manualLaunch/sagas.ts
@@ -17,7 +17,7 @@
 import { Action } from 'redux';
 import { takeLatest, call, select, all, put } from 'redux-saga/effects';
 import { isString } from 'es-toolkit';
-import { isEmpty } from 'es-toolkit/compat';
+import { isEmpty, isNil } from 'es-toolkit/compat';
 
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
@@ -49,6 +49,7 @@ import {
   MANUAL_LAUNCH_FOLDERS_NAMESPACE,
   MANUAL_LAUNCH_TEST_CASE_EXECUTIONS_NAMESPACE,
   ACTIVE_MANUAL_LAUNCH_EXECUTION_NAMESPACE,
+  TEST_FOLDER_ID_FILTER_KEY,
   defaultManualLaunchesQueryParams,
 } from './constants';
 import {
@@ -216,7 +217,7 @@ function* getManualLaunchTestCaseExecutions(
 ): Generator {
   try {
     const projectKey = (yield select(projectKeySelector)) as string;
-    const { launchId, offset, limit } = action.payload;
+    const { launchId, offset, limit, folderId } = action.payload;
 
     yield put({
       type: FETCH_START,
@@ -225,7 +226,12 @@ function* getManualLaunchTestCaseExecutions(
     });
 
     const typedURLS = URLS as UrlsHelper;
-    const params = { offset, limit };
+    const params: Record<string, string | number> = { offset, limit };
+
+    if (!isNil(folderId)) {
+      params[TEST_FOLDER_ID_FILTER_KEY as string] = folderId;
+    }
+
     const data = (yield call(
       fetch,
       typedURLS.manualLaunchTestCaseExecutions(projectKey, launchId, params),

--- a/app/src/controllers/manualLaunch/selectors.ts
+++ b/app/src/controllers/manualLaunch/selectors.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isString } from 'es-toolkit/compat';
 import { Page } from 'types/common';
 import { AppState } from 'types/store';
 
@@ -105,3 +106,14 @@ export const activeManualLaunchExecutionSelector = (state: AppState): TestCaseEx
 
 export const isLoadingActiveManualLaunchExecutionSelector = (state: AppState): boolean =>
   Boolean(activeManualLaunchExecutionStateSelector(state)?.isLoading);
+
+export const urlManualLaunchFolderIdSelector = (state: AppState): string => {
+  const payload = state.location?.payload;
+  const manualLaunchPageRoute = payload?.manualLaunchPageRoute;
+
+  if (manualLaunchPageRoute && isString(manualLaunchPageRoute)) {
+    return manualLaunchPageRoute.split('/')[1] || '';
+  }
+
+  return '';
+};

--- a/app/src/controllers/manualLaunch/types.ts
+++ b/app/src/controllers/manualLaunch/types.ts
@@ -44,6 +44,7 @@ export interface GetManualLaunchTestCaseExecutionsParams {
   launchId: string | number;
   offset?: string | number;
   limit?: string | number;
+  folderId?: string | number;
 }
 
 export interface GetManualLaunchExecutionParams {

--- a/app/src/controllers/manualLaunch/types.ts
+++ b/app/src/controllers/manualLaunch/types.ts
@@ -62,7 +62,6 @@ export interface UpdateManualLaunchExecutionStatusParams {
   attachments?: File[];
 }
 
-// State types
 export interface ManualLaunchState {
   data: {
     content: Launch[] | null;
@@ -154,6 +153,7 @@ export interface ExecutionComment {
 
 export interface TestFolder {
   id: number;
+  name?: string;
   testItemId?: number; // Reference to link folder with test case executions
 }
 

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchFolders/manualLaunchFolders.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchFolders/manualLaunchFolders.tsx
@@ -15,7 +15,8 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { isNil } from 'es-toolkit/compat';
 
 import {
   manualLaunchFoldersSelector,
@@ -23,13 +24,18 @@ import {
   manualLaunchTestCaseExecutionsPageSelector,
   isLoadingManualLaunchFoldersSelector,
   isLoadingManualLaunchTestCaseExecutionsSelector,
+  getManualLaunchTestCaseExecutionsAction,
+  defaultManualLaunchesQueryParams,
 } from 'controllers/manualLaunch';
+import { useManualLaunchId } from 'hooks/useTypedSelector';
 import { TMS_INSTANCE_KEY } from 'pages/inside/common/constants';
 import { transformFoldersToDisplay } from 'common/utils/folderUtils';
 import { ExpandedOptions } from '../../../common/expandedOptions';
 import { ManualLaunchExecutions } from '../manualLaunchExecutions';
 
 export const ManualLaunchFolders = () => {
+  const dispatch = useDispatch();
+  const launchId = useManualLaunchId();
   const folders = useSelector(manualLaunchFoldersSelector);
   const executions = useSelector(manualLaunchTestCaseExecutionsSelector);
   const pageInfo = useSelector(manualLaunchTestCaseExecutionsPageSelector);
@@ -40,14 +46,34 @@ export const ManualLaunchFolders = () => {
 
   const transformedFolders = useMemo(() => transformFoldersToDisplay(folders), [folders]);
 
-  const handleFolderClick = useCallback((folderId: number) => {
-    setActiveFolderId(folderId);
-    // TODO: Fetch executions for specific folder from backend
-  }, []);
+  const fetchExecutions = useCallback(
+    (folderId?: number) => {
+      if (!launchId) return;
+
+      dispatch(
+        getManualLaunchTestCaseExecutionsAction({
+          launchId,
+          ...(!isNil(folderId) && { folderId }),
+          offset: defaultManualLaunchesQueryParams.offset,
+          limit: defaultManualLaunchesQueryParams.limit,
+        }),
+      );
+    },
+    [dispatch, launchId],
+  );
+
+  const handleFolderClick = useCallback(
+    (folderId: number) => {
+      setActiveFolderId(folderId);
+      fetchExecutions(folderId);
+    },
+    [fetchExecutions],
+  );
 
   const handleAllExecutionsClick = useCallback(() => {
     setActiveFolderId(null);
-  }, []);
+    fetchExecutions();
+  }, [fetchExecutions]);
 
   return (
     <ExpandedOptions

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchFolders/manualLaunchFolders.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchFolders/manualLaunchFolders.tsx
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { isNil } from 'es-toolkit/compat';
 
 import {
   manualLaunchFoldersSelector,
@@ -24,10 +23,10 @@ import {
   manualLaunchTestCaseExecutionsPageSelector,
   isLoadingManualLaunchFoldersSelector,
   isLoadingManualLaunchTestCaseExecutionsSelector,
-  getManualLaunchTestCaseExecutionsAction,
-  defaultManualLaunchesQueryParams,
+  urlManualLaunchFolderIdSelector,
 } from 'controllers/manualLaunch';
-import { useManualLaunchId } from 'hooks/useTypedSelector';
+import { MANUAL_LAUNCH_DETAILS_PAGE } from 'controllers/pages';
+import { useManualLaunchId, useProjectDetails } from 'hooks/useTypedSelector';
 import { TMS_INSTANCE_KEY } from 'pages/inside/common/constants';
 import { transformFoldersToDisplay } from 'common/utils/folderUtils';
 import { ExpandedOptions } from '../../../common/expandedOptions';
@@ -36,48 +35,47 @@ import { ManualLaunchExecutions } from '../manualLaunchExecutions';
 export const ManualLaunchFolders = () => {
   const dispatch = useDispatch();
   const launchId = useManualLaunchId();
+  const { organizationSlug, projectSlug } = useProjectDetails();
   const folders = useSelector(manualLaunchFoldersSelector);
   const executions = useSelector(manualLaunchTestCaseExecutionsSelector);
   const pageInfo = useSelector(manualLaunchTestCaseExecutionsPageSelector);
   const isLoadingFolders = useSelector(isLoadingManualLaunchFoldersSelector);
   const isLoadingExecutions = useSelector(isLoadingManualLaunchTestCaseExecutionsSelector);
 
-  const [activeFolderId, setActiveFolderId] = useState<number | null>(null);
+  const urlFolderId = useSelector(urlManualLaunchFolderIdSelector);
+  const urlFolderIdNumber = urlFolderId ? Number(urlFolderId) : null;
 
   const transformedFolders = useMemo(() => transformFoldersToDisplay(folders), [folders]);
 
-  const fetchExecutions = useCallback(
+  const navigateToFolder = useCallback(
     (folderId?: number) => {
-      if (!launchId) return;
-
-      dispatch(
-        getManualLaunchTestCaseExecutionsAction({
+      dispatch({
+        type: MANUAL_LAUNCH_DETAILS_PAGE,
+        payload: {
+          organizationSlug,
+          projectSlug,
           launchId,
-          ...(!isNil(folderId) && { folderId }),
-          offset: defaultManualLaunchesQueryParams.offset,
-          limit: defaultManualLaunchesQueryParams.limit,
-        }),
-      );
+          ...(folderId && { manualLaunchPageRoute: `folder/${folderId}` }),
+        },
+      });
     },
-    [dispatch, launchId],
+    [dispatch, organizationSlug, projectSlug, launchId],
   );
 
   const handleFolderClick = useCallback(
     (folderId: number) => {
-      setActiveFolderId(folderId);
-      fetchExecutions(folderId);
+      navigateToFolder(folderId);
     },
-    [fetchExecutions],
+    [navigateToFolder],
   );
 
   const handleAllExecutionsClick = useCallback(() => {
-    setActiveFolderId(null);
-    fetchExecutions();
-  }, [fetchExecutions]);
+    navigateToFolder();
+  }, [navigateToFolder]);
 
   return (
     <ExpandedOptions
-      activeFolderId={activeFolderId}
+      activeFolderId={urlFolderIdNumber}
       folders={transformedFolders}
       instanceKey={TMS_INSTANCE_KEY.MANUAL_LAUNCH}
       setAllTestCases={handleAllExecutionsClick}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusButtons/executionStatusButtons.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusButtons/executionStatusButtons.tsx
@@ -15,15 +15,12 @@
  */
 
 import { useIntl } from 'react-intl';
-import { useDispatch, useSelector } from 'react-redux';
 
 import { createClassnames } from 'common/utils';
-import { useManualLaunchId } from 'hooks/useTypedSelector';
-import { updateManualLaunchExecutionStatusAction } from 'controllers/manualLaunch';
-import { projectKeySelector } from 'controllers/project';
 
 import { STATUS_BUTTONS } from '../constants';
-import type { ExecutionStatusButtonsProps } from '../types';
+import type { ExecutionStatusButtonsProps, ExecutionStatusType } from '../types';
+import { useExecutionStatusModal } from '../executionStatusConfirmModal';
 
 import styles from './executionStatusButtons.scss';
 
@@ -31,19 +28,13 @@ const cx = createClassnames(styles);
 
 export const ExecutionStatusButtons = ({ executionId }: ExecutionStatusButtonsProps) => {
   const { formatMessage } = useIntl();
-  const dispatch = useDispatch();
-  const projectKey = useSelector(projectKeySelector);
-  const launchId = useManualLaunchId();
+  const { openModal } = useExecutionStatusModal();
 
   const handleStatusClick = (status: string) => {
-    dispatch(
-      updateManualLaunchExecutionStatusAction({
-        projectKey,
-        launchId,
-        executionId,
-        status: status.toUpperCase(),
-      }),
-    );
+    openModal({
+      executionId,
+      status: status as ExecutionStatusType,
+    });
   };
 
   return (

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
@@ -65,8 +65,13 @@ export const ManualLaunchExecutionPage = () => {
   const [showStatusButtons, setShowStatusButtons] = useState(false);
 
   const launchName = launch?.name ?? '';
-  const folder = folders.find((f) => f.id === execution?.testFolder?.id);
-  const folderName = folder?.name ?? '';
+
+  const folderName =
+    execution?.testFolder?.name ||
+    folders.find((f) => f.id === execution?.testFolder?.testItemId)?.name ||
+    '';
+
+  const folderId = execution?.testFolder?.testItemId;
 
   const breadcrumbDescriptors = [
     {
@@ -87,11 +92,15 @@ export const ManualLaunchExecutionPage = () => {
           }
         : undefined,
     },
-    ...(folderName
+    ...(folderName && folderId
       ? [
           {
             id: 'folder',
             title: folderName,
+            link: {
+              type: MANUAL_LAUNCH_DETAILS_PAGE,
+              payload: { organizationSlug, projectSlug, launchId, folderId },
+            },
           },
         ]
       : []),

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
@@ -99,7 +99,12 @@ export const ManualLaunchExecutionPage = () => {
             title: folderName,
             link: {
               type: MANUAL_LAUNCH_DETAILS_PAGE,
-              payload: { organizationSlug, projectSlug, launchId, folderId },
+              payload: {
+                organizationSlug,
+                projectSlug,
+                launchId,
+                manualLaunchPageRoute: `folder/${folderId}`,
+              },
             },
           },
         ]

--- a/app/src/routes/routesMap.js
+++ b/app/src/routes/routesMap.js
@@ -387,10 +387,11 @@ const routesMap = {
     },
   },
   [MANUAL_LAUNCH_DETAILS_PAGE]: {
-    path: '/organizations/:organizationSlug/projects/:projectSlug/manualLaunches/:launchId',
+    path: '/organizations/:organizationSlug/projects/:projectSlug/manualLaunches/:launchId/:manualLaunchPageRoute*',
     thunk: (dispatch, getState) => {
       const state = getState();
-      const launchId = state.location?.payload?.launchId;
+      const { launchId, manualLaunchPageRoute } = state.location?.payload || {};
+      const folderId = manualLaunchPageRoute?.split('/')[1];
 
       if (launchId) {
         dispatch(getManualLaunchAction({ launchId }));
@@ -400,7 +401,7 @@ const routesMap = {
           getManualLaunchFoldersAction({
             launchId,
             offset: 0,
-            limit: 100, // TODO do we need to implement folder click and fetch test executions for certain folder?
+            limit: 100,
           }),
         );
 
@@ -414,6 +415,7 @@ const routesMap = {
         dispatch(
           getManualLaunchTestCaseExecutionsAction({
             launchId,
+            ...(folderId && { folderId }),
             offset,
             limit,
           }),

--- a/app/src/types/store.ts
+++ b/app/src/types/store.ts
@@ -33,6 +33,7 @@ export interface BaseAppState {
       testPlanId?: string;
       testCaseId?: string;
       launchId?: string;
+      manualLaunchPageRoute?: string;
     };
     prev?: {
       payload?: ProjectDetails;


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

**Fixes:**
Show test for certain folder;
Adding folder breadcrumb to execution page;
Show modal initially when choose status(previously was onChange status)

## Visuals

https://github.com/user-attachments/assets/ce353fea-10cb-4213-b070-25eb288731b8




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL-driven folder navigation for manual launches—click a folder to view its test cases; folder selection is reflected in the URL and app state
  * Folder-aware loading of executions so views can be filtered by folder
  * Breadcrumbs now include a folder link when folder details are available

* **UI/UX Improvements**
  * Execution status updates now open a modal for confirmation and follow-up instead of firing immediate background actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->