### PR TITLE
EPMRPP-104687 editor can add execution comment and change status - fixes after design changes

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
@@ -38,6 +38,12 @@
   width: 480px;
   border-radius: 16px;
   padding: 32px 40px;
+
+  &--simple {
+    .checkbox-section {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .modal-content {
@@ -121,4 +127,28 @@
     width: 16px;
     height: 16px;
   }
+}
+
+.confirmation-text {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 24px;
+}
+
+.confirmation-question {
+  @include modal-text-regular;
+
+  color: var(--rp-ui-base-almost-black);
+
+  strong {
+    font-family: $FONT-ROBOTO-MEDIUM;
+    font-weight: 500;
+    color: var(--rp-ui-base-almost-black);
+  }
+}
+
+.confirmation-hint {
+  @include modal-text-regular;
+
+  color: var(--rp-ui-base-almost-black);
 }

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
@@ -43,17 +43,22 @@
     .checkbox-section {
       margin-bottom: 0;
     }
+
+    .confirmation-text:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 
 .modal-content {
   display: flex;
   flex-direction: column;
-  padding-top: 16px;
 }
 
 .comment-section {
-  margin-bottom: 24px;
+  margin-bottom: 16px;
+  max-height: 170px;
+  overflow: auto;
 
   label {
     @include modal-text-medium;
@@ -87,18 +92,26 @@
 .attachments-section {
   display: flex;
   flex-direction: column;
+  position: relative;
+}
 
-  :global(.file-drop-area__drop-zone) {
-    display: none;
-  }
+.dropzone {
+  width: 400px;
+  height: 54px;
+  border-radius: 4px;
+  border: 2px dashed var(--rp-ui-base-e-200);
+  background: transparent;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .attachment-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
-  width: 100%;
+  position: relative;
+  height: 54px;
   pointer-events: none;
 
   > * {

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -46,6 +46,7 @@ import {
   EXECUTION_STATUS_CONFIRM_FORM_NAME,
   STATUS_CONFIG,
   EXECUTION_STATUS_TO_RUN,
+  EXECUTION_STATUS_FAILED,
 } from '../constants';
 import { messages } from './messages';
 
@@ -80,6 +81,7 @@ const ExecutionStatusConfirmModalComponent: FC<
   const currentStatus = data?.currentStatus;
   const statusLabel = formatMessage(STATUS_CONFIG[status].label);
   const isStatusChange = currentStatus && currentStatus !== EXECUTION_STATUS_TO_RUN;
+  const showPostIssueToBts = status === EXECUTION_STATUS_FAILED;
 
   const onSubmit = (values: ExecutionStatusConfirmFormValues) => {
     if (!executionId) return;
@@ -138,11 +140,13 @@ const ExecutionStatusConfirmModalComponent: FC<
               </div>
             </div>
 
-            <div className={cx('checkbox-section')}>
-              <FieldProvider name="postIssueToBts">
-                <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
-              </FieldProvider>
-            </div>
+            {showPostIssueToBts && (
+              <div className={cx('checkbox-section')}>
+                <FieldProvider name="postIssueToBts">
+                  <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
+                </FieldProvider>
+              </div>
+            )}
           </>
         ) : (
           <>
@@ -159,13 +163,15 @@ const ExecutionStatusConfirmModalComponent: FC<
               </FieldProvider>
             </div>
 
-            <div className={cx('checkbox-section')}>
-              <FieldProvider name="postIssueToBts">
-                <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
-              </FieldProvider>
-            </div>
+            {showPostIssueToBts && (
+              <div className={cx('checkbox-section')}>
+                <FieldProvider name="postIssueToBts">
+                  <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
+                </FieldProvider>
+              </div>
+            )}
 
-            <div className={cx('divider')} />
+            {showPostIssueToBts && <div className={cx('divider')} />}
 
             <div className={cx('attachments-section')}>
               <FileDropArea
@@ -178,6 +184,7 @@ const ExecutionStatusConfirmModalComponent: FC<
                   incorrectFileFormat: formatMessage(messages.incorrectFileFormat),
                 }}
               >
+                <FileDropArea.DropZone className={cx('dropzone')} icon={<div />} />
                 <div className={cx('attachment-header')}>
                   <span className={cx('attachment-title')}>
                     {formatMessage(messages.attachments)}
@@ -203,7 +210,6 @@ const ExecutionStatusConfirmModalComponent: FC<
                     onRemoveFile={handleFileRemove}
                   />
                 )}
-                <FileDropArea.DropZone icon={<div />} />
               </FileDropArea>
             </div>
           </>

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -45,6 +45,7 @@ import {
   EXECUTION_STATUS_CONFIRM_MODAL,
   EXECUTION_STATUS_CONFIRM_FORM_NAME,
   STATUS_CONFIG,
+  EXECUTION_STATUS_TO_RUN,
 } from '../constants';
 import { messages } from './messages';
 
@@ -76,7 +77,9 @@ const ExecutionStatusConfirmModalComponent: FC<
 
   const status = data?.status || 'passed';
   const executionId = data?.executionId;
+  const currentStatus = data?.currentStatus;
   const statusLabel = formatMessage(STATUS_CONFIG[status].label);
+  const isStatusChange = currentStatus && currentStatus !== EXECUTION_STATUS_TO_RUN;
 
   const onSubmit = (values: ExecutionStatusConfirmFormValues) => {
     if (!executionId) return;
@@ -114,70 +117,97 @@ const ExecutionStatusConfirmModalComponent: FC<
       okButton={okButton}
       cancelButton={cancelButton}
       allowCloseOutside={!dirty}
-      className={cx('execution-status-confirm-modal')}
+      className={cx('execution-status-confirm-modal', {
+        'execution-status-confirm-modal--simple': isStatusChange,
+      })}
     >
       <form
         className={cx('modal-content')}
         onSubmit={handleSubmit(onSubmit) as (event: FormEvent) => void}
       >
-        <div className={cx('comment-section')}>
-          <FieldProvider name="comment">
-            <FieldErrorHint>
-              <FieldTextFlex
-                label={formatMessage(messages.executionComment)}
-                placeholder={formatMessage(messages.commentPlaceholder)}
-                value=""
-                minHeight={100}
-              />
-            </FieldErrorHint>
-          </FieldProvider>
-        </div>
-
-        <div className={cx('checkbox-section')}>
-          <FieldProvider name="postIssueToBts">
-            <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
-          </FieldProvider>
-        </div>
-
-        <div className={cx('divider')} />
-
-        <div className={cx('attachments-section')}>
-          <FileDropArea
-            variant="overlay"
-            maxFileSize={MAX_FILE_SIZE}
-            acceptFileMimeTypes={[MIME_TYPES.jpeg, MIME_TYPES.png, MIME_TYPES.pdf]}
-            onFilesAdded={handleFilesAdded}
-            messages={{
-              incorrectFileSize: formatMessage(messages.incorrectFileSize),
-              incorrectFileFormat: formatMessage(messages.incorrectFileFormat),
-            }}
-          >
-            <div className={cx('attachment-header')}>
-              <span className={cx('attachment-title')}>{formatMessage(messages.attachments)}</span>
-              <div className={cx('add-attachment')}>
-                <span className={cx('dropzone-text')}>
-                  <DragAndDropIcon />
-                  {formatMessage(messages.dropFilesHere)}
-                </span>
-                <FileDropArea.BrowseButton icon={<PlusIcon />}>
-                  {formatMessage(messages.add)}
-                </FileDropArea.BrowseButton>
+        {isStatusChange ? (
+          <>
+            <div className={cx('confirmation-text')}>
+              <div className={cx('confirmation-question')}>
+                {formatMessage(messages.confirmStatusChange, {
+                  status: <strong>{statusLabel}</strong>,
+                })}
+              </div>
+              <div className={cx('confirmation-hint')}>
+                {formatMessage(messages.updateCommentIfNeeded)}
               </div>
             </div>
-            {!isEmpty(attachedFiles) && (
-              <FileDropArea.AttachedFilesList
-                files={attachedFiles.map((file, index) => ({
-                  id: `${file.name}-${index}`,
-                  fileName: file.name,
-                  file,
-                  size: file.size,
-                }))}
-                onRemoveFile={handleFileRemove}
-              />
-            )}
-            <FileDropArea.DropZone icon={<div />} />
-          </FileDropArea>
-        </div>
+
+            <div className={cx('checkbox-section')}>
+              <FieldProvider name="postIssueToBts">
+                <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
+              </FieldProvider>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className={cx('comment-section')}>
+              <FieldProvider name="comment">
+                <FieldErrorHint>
+                  <FieldTextFlex
+                    label={formatMessage(messages.executionComment)}
+                    placeholder={formatMessage(messages.commentPlaceholder)}
+                    value=""
+                    minHeight={100}
+                  />
+                </FieldErrorHint>
+              </FieldProvider>
+            </div>
+
+            <div className={cx('checkbox-section')}>
+              <FieldProvider name="postIssueToBts">
+                <InputCheckbox>{formatMessage(messages.postIssueToBts)}</InputCheckbox>
+              </FieldProvider>
+            </div>
+
+            <div className={cx('divider')} />
+
+            <div className={cx('attachments-section')}>
+              <FileDropArea
+                variant="overlay"
+                maxFileSize={MAX_FILE_SIZE}
+                acceptFileMimeTypes={[MIME_TYPES.jpeg, MIME_TYPES.png, MIME_TYPES.pdf]}
+                onFilesAdded={handleFilesAdded}
+                messages={{
+                  incorrectFileSize: formatMessage(messages.incorrectFileSize),
+                  incorrectFileFormat: formatMessage(messages.incorrectFileFormat),
+                }}
+              >
+                <div className={cx('attachment-header')}>
+                  <span className={cx('attachment-title')}>
+                    {formatMessage(messages.attachments)}
+                  </span>
+                  <div className={cx('add-attachment')}>
+                    <span className={cx('dropzone-text')}>
+                      <DragAndDropIcon />
+                      {formatMessage(messages.dropFilesHere)}
+                    </span>
+                    <FileDropArea.BrowseButton icon={<PlusIcon />}>
+                      {formatMessage(messages.add)}
+                    </FileDropArea.BrowseButton>
+                  </div>
+                </div>
+                {!isEmpty(attachedFiles) && (
+                  <FileDropArea.AttachedFilesList
+                    files={attachedFiles.map((file, index) => ({
+                      id: `${file.name}-${index}`,
+                      fileName: file.name,
+                      file,
+                      size: file.size,
+                    }))}
+                    onRemoveFile={handleFileRemove}
+                  />
+                )}
+                <FileDropArea.DropZone icon={<div />} />
+              </FileDropArea>
+            </div>
+          </>
+        )}
       </form>
     </Modal>
   );

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/messages.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/messages.ts
@@ -57,4 +57,12 @@ export const messages = defineMessages({
     id: 'ExecutionStatusConfirmModal.attachmentUploadFailed',
     defaultMessage: 'Failed to upload attachment: {fileName}',
   },
+  confirmStatusChange: {
+    id: 'ExecutionStatusConfirmModal.confirmStatusChange',
+    defaultMessage: 'Are you sure you want to mark test execution as {status}?',
+  },
+  updateCommentIfNeeded: {
+    id: 'ExecutionStatusConfirmModal.updateCommentIfNeeded',
+    defaultMessage: 'Please, update the execution comment if needed.',
+  },
 });

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/useExecutionStatusModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/useExecutionStatusModal.tsx
@@ -22,18 +22,20 @@ import type { ExecutionStatusType } from '../types';
 interface OpenModalParams {
   executionId: number;
   status: ExecutionStatusType;
+  currentStatus?: string;
 }
 
 export const useExecutionStatusModal = () => {
   const dispatch = useDispatch();
 
-  const openModal = ({ executionId, status }: OpenModalParams) => {
+  const openModal = ({ executionId, status, currentStatus }: OpenModalParams) => {
     dispatch(
       showModalAction({
         id: EXECUTION_STATUS_CONFIRM_MODAL,
         data: {
           executionId,
           status,
+          currentStatus,
         },
       }),
     );

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusPopover/executionStatusPopover.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusPopover/executionStatusPopover.tsx
@@ -56,6 +56,7 @@ export const ExecutionStatusPopover: FC<ExecutionStatusPopoverProps> = ({
     openModal({
       executionId,
       status: newStatus as ExecutionStatusType,
+      currentStatus,
     });
     setIsOpened(false);
   };

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/textBasedContent/textBasedContent.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/textBasedContent/textBasedContent.tsx
@@ -19,7 +19,6 @@ import { isEmpty } from 'es-toolkit/compat';
 
 import { createClassnames } from 'common/utils';
 import { CollapsibleSection } from 'components/collapsibleSection';
-import { FieldSection } from 'pages/inside/common/fieldSection';
 import { RequirementsList } from 'pages/inside/common/requirementsList/requirementsList';
 import { AttachmentList, type Attachment } from 'pages/inside/common/attachmentList';
 import { Scenario } from 'pages/inside/common/scenario';
@@ -41,7 +40,6 @@ export const TextBasedContent = ({ execution: { manualScenario } }: ExecutionCon
   const requirements = requirementsToItems(manualScenario.requirements);
   const hasRequirements = !isEmpty(requirements);
   const preconditionValue = manualScenario.preconditions?.value;
-  const hasPreconditionAttachments = !isEmpty(manualScenario.preconditions?.attachments);
   const { instructions, expectedResult, attachments = [] } = manualScenario;
   const hasAttachments = !isEmpty(attachments);
 
@@ -63,28 +61,11 @@ export const TextBasedContent = ({ execution: { manualScenario } }: ExecutionCon
         defaultMessage={hasScenario ? undefined : formatMessage(messages.noDetailsForScenario)}
       >
         {hasScenario && (
-          <div className={cx('scenario-sections')}>
-            {(preconditionValue || instructions || expectedResult) && (
-              <Scenario
-                precondition={preconditionValue}
-                instructions={instructions}
-                expectedResult={expectedResult}
-              />
-            )}
-            {hasPreconditionAttachments && (
-              <FieldSection
-                title={`${formatMessage(commonMessages.attachments)} ${manualScenario.preconditions?.attachments?.length ?? 0}`}
-              >
-                <AttachmentList
-                  attachments={
-                    (manualScenario.preconditions?.attachments ?? []) as unknown as Attachment[]
-                  }
-                  className={cx('attachments-list')}
-                  withPreview
-                />
-              </FieldSection>
-            )}
-          </div>
+          <Scenario
+            precondition={preconditionValue}
+            instructions={instructions}
+            expectedResult={expectedResult}
+          />
         )}
       </CollapsibleSection>
 

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/types.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/types.ts
@@ -47,6 +47,7 @@ export interface ExecutionStatusButtonsProps {
 export interface ExecutionStatusData {
   executionId: number;
   status: ExecutionStatusType;
+  currentStatus?: string;
 }
 
 export type ExecutionStatusConfirmModalData = ExecutionStatusData;


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
**Now 2 types of modal of change status**


https://github.com/user-attachments/assets/9ec52f4a-2c21-4068-b278-427f09f17b0c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a targeted status-change confirmation flow with concise modal layout and specific confirmation/hint text.
  * Modal now adapts content when changing status (shows minimal UI) and conditionally surfaces the issue-posting option for failed executions.
  * Improved attachments area behavior and comment input scrolling limits.

* **Bug Fixes**
  * Removed redundant precondition attachments display from the execution page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->