### PR TITLE
EPMRPP-113295 || "Project Team" and "Filters" menu items are not displayed in sidebar for Member-viewer

### DIFF
--- a/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
+++ b/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
@@ -63,32 +63,31 @@ export const OrganizationSidebar = ({ onClickNavBtn }) => {
         icon: ProjectsIcon,
         message: formatMessage(messages.projects),
       },
+      {
+        onClick: (isSidebarCollapsed) =>
+          onClickButton({ itemName: messages.users.defaultMessage, isSidebarCollapsed }),
+        link: {
+          type: ORGANIZATION_USERS_PAGE,
+          payload: { organizationSlug },
+        },
+        icon: MembersIcon,
+        message: formatMessage(messages.users),
+      },
+      {
+        onClick: (isSidebarCollapsed) =>
+          onClickButton({
+            itemName: messages.organizationSettings.defaultMessage,
+            isSidebarCollapsed,
+          }),
+        link: {
+          type: ORGANIZATION_SETTINGS_PAGE,
+          payload: { organizationSlug },
+        },
+        icon: SettingsIcon,
+        message: formatMessage(messages.organizationSettings),
+      }
     ];
 
-    sidebarItems.push({
-      onClick: (isSidebarCollapsed) =>
-        onClickButton({ itemName: messages.users.defaultMessage, isSidebarCollapsed }),
-      link: {
-        type: ORGANIZATION_USERS_PAGE,
-        payload: { organizationSlug },
-      },
-      icon: MembersIcon,
-      message: formatMessage(messages.users),
-    });
-
-    sidebarItems.push({
-      onClick: (isSidebarCollapsed) =>
-        onClickButton({
-          itemName: messages.organizationSettings.defaultMessage,
-          isSidebarCollapsed,
-        }),
-      link: {
-        type: ORGANIZATION_SETTINGS_PAGE,
-        payload: { organizationSlug },
-      },
-      icon: SettingsIcon,
-      message: formatMessage(messages.organizationSettings),
-    });
 
     sidebarExtensions.forEach((extension) => {
       const itemName = extension.payload?.iconName;

--- a/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
+++ b/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
@@ -18,9 +18,7 @@ import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useTracking } from 'react-tracking';
-import { userRolesSelector } from 'controllers/pages';
 import { useIntl } from 'react-intl';
-import { canSeeMembers } from 'common/utils/permissions';
 import {
   ORGANIZATION_PROJECTS_PAGE,
   ORGANIZATION_USERS_PAGE,
@@ -41,15 +39,11 @@ import {
 import { SIDEBAR_EVENTS } from 'components/main/analytics/events';
 import { OrganizationsControlWithPopover } from '../../organizationsControl';
 import { messages } from '../../messages';
-import { useUserPermissions } from 'hooks/useUserPermissions';
-
 const ORGANIZATION_CONTROL = 'Organization control';
 
 export const OrganizationSidebar = ({ onClickNavBtn }) => {
   const { trackEvent } = useTracking();
   const { formatMessage } = useIntl();
-  const { canSeeMembers } = useUserPermissions();
-  const userRoles = useSelector(userRolesSelector);
   const sidebarExtensions = useSelector(uiExtensionOrganizationSidebarComponentsSelector);
   const organizationSlug = useSelector(activeOrganizationSelector)?.slug;
   const organizationName = useSelector(activeOrganizationNameSelector);
@@ -71,18 +65,16 @@ export const OrganizationSidebar = ({ onClickNavBtn }) => {
       },
     ];
 
-    if (canSeeMembers) {
-      sidebarItems.push({
-        onClick: (isSidebarCollapsed) =>
-          onClickButton({ itemName: messages.users.defaultMessage, isSidebarCollapsed }),
-        link: {
-          type: ORGANIZATION_USERS_PAGE,
-          payload: { organizationSlug },
-        },
-        icon: MembersIcon,
-        message: formatMessage(messages.users),
-      });
-    }
+    sidebarItems.push({
+      onClick: (isSidebarCollapsed) =>
+        onClickButton({ itemName: messages.users.defaultMessage, isSidebarCollapsed }),
+      link: {
+        type: ORGANIZATION_USERS_PAGE,
+        payload: { organizationSlug },
+      },
+      icon: MembersIcon,
+      message: formatMessage(messages.users),
+    });
 
     sidebarItems.push({
       onClick: (isSidebarCollapsed) =>

--- a/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
+++ b/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
@@ -57,7 +57,6 @@ import { projectNameSelector } from 'controllers/project';
 import { activeOrganizationNameSelector } from 'controllers/organization';
 import { OrganizationsControlWithPopover } from '../../organizationsControl';
 import { messages } from '../../messages';
-import { useUserPermissions } from 'hooks/useUserPermissions';
 import { useTmsEnabled } from 'hooks/useTmsEnabled';
 import { useTmsMilestonesEnabled } from 'hooks/useTmsMilestonesEnabled';
 
@@ -66,7 +65,6 @@ const ORGANIZATION_CONTROL = 'Organization control';
 export const ProjectSidebar = ({ onClickNavBtn }) => {
   const { trackEvent } = useTracking();
   const { formatMessage } = useIntl();
-  const { canSeeMembers, canWorkWithFilters } = useUserPermissions();
   const isTmsEnabled = useTmsEnabled();
   const isTmsMilestonesEnabled = useTmsMilestonesEnabled();
   const sidebarExtensions = useSelector(uiExtensionSidebarComponentsSelector);
@@ -136,21 +134,15 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
         message: formatMessage(messages.debugMode),
         menuOrder: (menuCounter += menuStep),
       },
-    ];
-
-    if (canWorkWithFilters) {
-      sidebarItems.push({
+      {
         onClick: (isSidebarCollapsed) =>
           onClickButton({ itemName: messages.filters.defaultMessage, isSidebarCollapsed }),
         link: { type: PROJECT_FILTERS_PAGE, payload: { organizationSlug, projectSlug } },
         icon: FiltersIcon,
         message: formatMessage(messages.filters),
         menuOrder: (menuCounter += menuStep),
-      });
-    }
-
-    if (canSeeMembers) {
-      sidebarItems.push({
+      },
+      {
         onClick: (isSidebarCollapsed) =>
           onClickButton({ itemName: messages.projectTeam.defaultMessage, isSidebarCollapsed }),
         link: {
@@ -160,8 +152,9 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
         icon: MembersIcon,
         message: formatMessage(messages.projectTeam),
         menuOrder: (menuCounter += menuStep),
-      });
-    }
+      }
+    ];
+
 
     if (isTmsEnabled) {
       sidebarItems.push(

--- a/app/src/pages/organization/organizationUsersPage/organizationUsersPage.jsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersPage.jsx
@@ -93,7 +93,7 @@ const OrganizationUsersPageComponent = ({
       <EmptyUsersPageState
         isLoading={isUsersLoading}
         isNotEmpty={!isEmptyUsers}
-        hasPermission
+        hasPermission={canInviteUserToOrganization}
         showInviteUserModal={showInviteUserModal}
       />
     ) : (


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description

removed conditions where filters and project team should be visible in sidebar with viewer permissions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Organization sidebar now always shows the Users navigation option.
  * Project sidebar now always shows the Filters and Team (Members) navigation options.
  * Organization users page empty state now receives explicit permission wiring for invite-related controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->