### PR TITLE
EPMRPP-91263 || "Request professional service" modal — do not close on overlay click when form has unsaved edits

### DIFF
--- a/app/src/layouts/common/appSidebar/helpAndService/modals/requestSupportModal/requestSupportModal.jsx
+++ b/app/src/layouts/common/appSidebar/helpAndService/modals/requestSupportModal/requestSupportModal.jsx
@@ -40,14 +40,17 @@ import styles from './requestSupportModal.scss';
 const cx = classNames.bind(styles);
 
 const REQUEST_FORM_ID = 'requestFormId';
+const DEFAULT_IS_CONSENT_CHECKED = false;
 
-const RequestSupport = ({ handleSubmit, initialize, invalid }) => {
+const RequestSupport = ({ handleSubmit, initialize, invalid, dirty }) => {
   const dispatch = useDispatch();
   const { trackEvent } = useTracking();
   const { formatMessage } = useIntl();
   const email = useSelector(userEmailSelector);
   const [iframe, setIframe] = useState(null);
-  const [isConsentChecked, setIsConsentChecked] = useState(false);
+  const [isConsentChecked, setIsConsentChecked] = useState(DEFAULT_IS_CONSENT_CHECKED);
+
+  const allowCloseOutside = !dirty && isConsentChecked === DEFAULT_IS_CONSENT_CHECKED;
 
   useEffect(() => {
     const dummyframe = document.createElement('iframe');
@@ -57,7 +60,7 @@ const RequestSupport = ({ handleSubmit, initialize, invalid }) => {
     document.body.appendChild(dummyframe);
 
     setIframe(dummyframe);
-    initialize({ email });
+    initialize({ email, wouldLikeToReceiveAds__c: false });
 
     return () => {
       dummyframe.parentNode.removeChild(dummyframe);
@@ -116,7 +119,7 @@ const RequestSupport = ({ handleSubmit, initialize, invalid }) => {
       }}
       cancelButton={{ children: formatMessage(COMMON_LOCALE_KEYS.CANCEL) }}
       onClose={hideModal}
-      allowCloseOutside={false}
+      allowCloseOutside={allowCloseOutside}
     >
       <form
         action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8"
@@ -175,7 +178,7 @@ const RequestSupport = ({ handleSubmit, initialize, invalid }) => {
           </FieldProvider>
 
           <FieldProvider name="wouldLikeToReceiveAds__c" format={Boolean}>
-            <Checkbox className={cx('check-item')}>
+            <Checkbox className={cx('check-item')} >
               {formatMessage(messages.subscribeToNews)}
             </Checkbox>
           </FieldProvider>
@@ -192,6 +195,7 @@ RequestSupport.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   initialize: PropTypes.func.isRequired,
   invalid: PropTypes.bool.isRequired,
+  dirty: PropTypes.bool.isRequired,
 };
 
 export const RequestSupportModal = withModal('requestSupportModal')(

--- a/app/src/layouts/common/appSidebar/helpAndService/modals/requestSupportModal/requestSupportModal.jsx
+++ b/app/src/layouts/common/appSidebar/helpAndService/modals/requestSupportModal/requestSupportModal.jsx
@@ -116,6 +116,7 @@ const RequestSupport = ({ handleSubmit, initialize, invalid }) => {
       }}
       cancelButton={{ children: formatMessage(COMMON_LOCALE_KEYS.CANCEL) }}
       onClose={hideModal}
+      allowCloseOutside={false}
     >
       <form
         action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8"

--- a/app/src/layouts/common/appSidebar/helpAndService/modals/requestSupportModal/requestSupportModal.jsx
+++ b/app/src/layouts/common/appSidebar/helpAndService/modals/requestSupportModal/requestSupportModal.jsx
@@ -178,7 +178,7 @@ const RequestSupport = ({ handleSubmit, initialize, invalid, dirty }) => {
           </FieldProvider>
 
           <FieldProvider name="wouldLikeToReceiveAds__c" format={Boolean}>
-            <Checkbox className={cx('check-item')} >
+            <Checkbox className={cx('check-item')}>
               {formatMessage(messages.subscribeToNews)}
             </Checkbox>
           </FieldProvider>


### PR DESCRIPTION
[EPMRPP-91263 || "Request professional service" modal — do not close on overlay click when form has unsaved edits
](https://jiraeu.epam.com/browse/EPMRPP-91263)
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

[DEMO](https://epam-my.sharepoint.com/:v:/p/aliaksei_rudak/IQBkLHWCaPVtSYn4qtjMDsC9AfVVSeza748twsJYxhWeA9s?e=wSPFKZ&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request Support modal no longer closes from outside clicks once the form has been modified — users must use close or cancel to avoid losing input.

* **New Features**
  * Outside-click dismissal is allowed only when the form is untouched and the consent checkbox is at its default state.

* **Behavior**
  * The "receive ads" preference now defaults to off when submitting the support form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->