### PR TITLE
EPMRPP-113915 || EPMRPP-113917 || EPMRPP-113965 || Fix role dropdown visibility, add org type icon, sort the org list

### DIFF
--- a/app/src/controllers/instance/organizations/types.ts
+++ b/app/src/controllers/instance/organizations/types.ts
@@ -32,7 +32,7 @@ interface OrganizationRelationships {
   };
 }
 
-export interface OrganizationSearchesItem extends Omit<Organization, 'owner_id'> {
+export interface OrganizationSearchesItem extends Organization {
   relationships: OrganizationRelationships;
   created_at: string;
   updated_at: string;

--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -54,6 +54,7 @@ import {
   ProjectsSearchesItem,
 } from 'controllers/organization/projects';
 import { SEARCH_KEY } from 'controllers/organization/projects/constants';
+import { OrganizationType } from 'controllers/organization';
 import { prepareQueryFilters } from 'components/filterEntities/utils';
 import { URLS } from 'common/urls';
 import { AddItemButton } from '../organizationAssignment/organizationItem/addItemButton';
@@ -110,6 +111,9 @@ const messages = defineMessages({
 interface InstanceAssignmentItem {
   id?: number;
   name: string;
+  type?: OrganizationType;
+  owner_id?: number;
+  isNew?: boolean;
   role: string;
   projects: Project[];
 }
@@ -119,6 +123,7 @@ export interface InstanceAssignmentProps extends InstanceAssignmentArrayProps<In
   formNamespace?: string;
   isOrganizationRequired: boolean;
   invitedUserId?: number | null;
+  excludeUserAssignments?: boolean;
   header?: string;
   addButtonPlacement?: 'header' | 'bottom';
   addFormPlacement?: 'top' | 'bottom';
@@ -161,6 +166,7 @@ export const InstanceAssignment = ({
   formNamespace,
   isOrganizationRequired = false,
   invitedUserId = null,
+  excludeUserAssignments = false,
   header,
   addButtonPlacement = 'bottom',
   addFormPlacement = 'bottom',
@@ -209,10 +215,12 @@ export const InstanceAssignment = ({
 
   useEffect(() => {
     const allOrganizationsIds = new Set((allOrganizations || []).map(({ id }) => id));
-    const totalAddedIds = new Set([...allOrganizationsIds, ...userOrgIds]);
+    const totalAddedIds = excludeUserAssignments
+      ? new Set([...allOrganizationsIds, ...userOrgIds])
+      : allOrganizationsIds;
     const totalAvailableToAdd = totalOrganizationsInSystem - totalAddedIds.size;
     setAreOrganizationsExhausted(totalOrganizationsInSystem > 0 && totalAvailableToAdd <= 0);
-  }, [allOrganizations, totalOrganizationsInSystem, userOrgIds]);
+  }, [allOrganizations, totalOrganizationsInSystem, userOrgIds, excludeUserAssignments]);
 
   useEffect(() => {
     if (isOpen && formContainerRef.current) {
@@ -312,7 +320,7 @@ export const InstanceAssignment = ({
       const filteredOrganizations = response.items.filter(
         (organization) =>
           !(allOrganizations || []).some(({ id }) => id === organization.id) &&
-          !userOrgIds.has(organization.id),
+          (!excludeUserAssignments || !userOrgIds.has(organization.id)),
       );
 
       setNotAssignedOrganizations(filteredOrganizations);
@@ -346,6 +354,7 @@ export const InstanceAssignment = ({
 
   const handleSubmit = () => {
     const { name, role, projects } = organization as InstanceAssignmentItem;
+    const selectedOrg = notAssignedOrganizations.find((org) => org.id === selectedOrganizationId);
 
     setIsOpen(false);
     setOrganizationProjects([]);
@@ -356,6 +365,9 @@ export const InstanceAssignment = ({
     fields.push({
       id: selectedOrganizationId,
       name,
+      type: selectedOrg?.type,
+      owner_id: selectedOrg?.owner_id,
+      isNew: !userOrgIds.has(selectedOrganizationId),
       role: role ? MANAGER : MEMBER,
       projects:
         projects?.length > 0 && selectedProjectId
@@ -559,6 +571,7 @@ export const InstanceAssignment = ({
           isMultiple
           formName={formName}
           invitedUserId={invitedUserId}
+          excludeUserAssignments={excludeUserAssignments}
           isOrganizationFormOpen={isOpen}
           onExpandOrganization={onExpandOrganization}
         />

--- a/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.scss
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.scss
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+.modal-content {
+  position: relative;
+}
+
 .admin-info {
   margin-bottom: 24px;
 }

--- a/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.tsx
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.tsx
@@ -54,7 +54,10 @@ import {
 } from '../utils';
 import { OrganizationType } from 'controllers/organization';
 import { UserOrganizationProjectsResponse } from 'controllers/organization/users/types';
-import { OrganizationsSearchesResponseData } from 'controllers/instance/organizations';
+import {
+  type OrganizationSearchesItem,
+  type OrganizationsSearchesResponseData,
+} from 'controllers/instance/organizations';
 import { ALL_USERS_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/allUsersPage';
 import { ApiError } from 'types/api';
 
@@ -119,61 +122,74 @@ const ManageAssignmentsInstanceModalView = ({
   const isInlineAssignmentFormOpen = isAddingOrganization || isAddingProject;
   const isAdmin = user.instanceRole === ADMINISTRATOR;
 
+  const mergeOrganizationSearchItemsIntoOrgs = useCallback(
+    (orgs: OrganizationValue[], items: OrganizationSearchesItem[]) =>
+      orgs.map((org, orgIndex) => {
+        const nextOrg = items.find((item) => item.id === org.id);
+        const orgField = `${ORGANIZATIONS}[${orgIndex}]`;
+        if (nextOrg?.type) {
+          dispatch(change(MANAGE_ASSIGNMENTS_FORM, `${orgField}.type`, nextOrg.type));
+        }
+        if (nextOrg?.owner_id) {
+          dispatch(change(MANAGE_ASSIGNMENTS_FORM, `${orgField}.owner_id`, nextOrg.owner_id));
+        }
+        return { ...org, type: nextOrg?.type, owner_id: nextOrg?.owner_id };
+      }),
+    [dispatch],
+  );
+
   // Store initial organizations for dirty checking
   useEffect(() => {
-    const initializeForm = () => {
-      if (user?.organizations?.length > 0) {
-        let orgs: OrganizationValue[] = user.organizations
-          .map((org) => ({
-            id: org.id,
-            name: org.name,
-            type: org.type,
-            owner_id: org.owner_id,
-            role: org.org_role,
-            projects: [],
-            isProjectsLoaded: false,
-            isExpanded: false,
-          }))
-          .sort((first, second) => first.name.localeCompare(second.name));
+    let isActive = true;
 
-        initialize({ [ORGANIZATIONS]: orgs });
+    if (!user?.organizations?.length) {
+      return;
+    }
+
+    let orgs: OrganizationValue[] = user.organizations
+      .map((org) => ({
+        id: org.id,
+        name: org.name,
+        type: org.type,
+        owner_id: org.owner_id,
+        role: org.org_role,
+        projects: [],
+        isProjectsLoaded: false,
+        isExpanded: false,
+      }))
+      .sort((first, second) => first.name.localeCompare(second.name));
+
+    initialize({ [ORGANIZATIONS]: orgs });
+    initialOrganizationsRef.current = orgs;
+
+    setOrganizationsLoading(true);
+
+    fetch(URLS.organizationSearches(), {
+      method: 'post',
+      data: {
+        limit: 300,
+        search_criteria: [{ filter_key: 'org_user_id', operation: 'EQ', value: String(user.id) }],
+      },
+    })
+      .then((response: OrganizationsSearchesResponseData) => {
+        if (!isActive) {
+          return;
+        }
+        const items = response.items ?? [];
+        orgs = mergeOrganizationSearchItemsIntoOrgs(orgs, items);
         initialOrganizationsRef.current = orgs;
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (isActive) {
+          setOrganizationsLoading(false);
+        }
+      });
 
-        setOrganizationsLoading(true);
-
-        fetch(URLS.organizationSearches(), {
-          method: 'post',
-          data: {
-            limit: 300,
-            search_criteria: [
-              { filter_key: 'org_user_id', operation: 'EQ', value: String(user.id) },
-            ],
-          },
-        })
-          .then((response: OrganizationsSearchesResponseData) => {
-            const items = response.items ?? [];
-            orgs = orgs.map((org, orgIndex) => {
-              const nextOrg = items.find((item) => item.id === org.id);
-              const orgField = `${ORGANIZATIONS}[${orgIndex}]`;
-              if (nextOrg?.type) {
-                dispatch(change(MANAGE_ASSIGNMENTS_FORM, `${orgField}.type`, nextOrg.type));
-              }
-              if (nextOrg?.owner_id) {
-                dispatch(change(MANAGE_ASSIGNMENTS_FORM, `${orgField}.owner_id`, nextOrg.owner_id));
-              }
-              return { ...org, type: nextOrg?.type, owner_id: nextOrg?.owner_id };
-            });
-            initialOrganizationsRef.current = orgs;
-          })
-          .catch(() => {})
-          .finally(() => {
-            setOrganizationsLoading(false);
-          });
-      }
+    return () => {
+      isActive = false;
     };
-
-    initializeForm();
-  }, [user, initialize, dispatch]);
+  }, [user, initialize, dispatch, mergeOrganizationSearchItemsIntoOrgs]);
 
   // Fetch projects for organization when expanded
   const handleExpandOrganization = useCallback(
@@ -343,33 +359,31 @@ const ManageAssignmentsInstanceModalView = ({
     >
       <div className={cx('modal-content')}>
         <ModalLoadingOverlay isVisible={organizationsLoading} />
-        <>
-          {isAdmin && (
-            <div className={cx('admin-info')}>
-              <SystemMessage mode="info">
-                {formatMessage(messages.manageAssignmentsAdminInfo)}
-              </SystemMessage>
-            </div>
-          )}
-          <FieldArray
-            name={ORGANIZATIONS}
-            component={InstanceAssignment}
-            props={
-              {
-                formName: MANAGE_ASSIGNMENTS_FORM,
-                formNamespace: ORGANIZATION,
-                invitedUserId: user.id,
-                isOrganizationRequired: false,
-                header: formatMessage(messages.assignedTo),
-                addButtonPlacement: 'header',
-                addFormPlacement: 'top',
-                withEmptyState: true,
-                emptyStateText: formatMessage(messages.noAssignmentsYet),
-                onExpandOrganization: handleExpandOrganization,
-              } as InstanceAssignmentProps
-            }
-          />
-        </>
+        {isAdmin && (
+          <div className={cx('admin-info')}>
+            <SystemMessage mode="info">
+              {formatMessage(messages.manageAssignmentsAdminInfo)}
+            </SystemMessage>
+          </div>
+        )}
+        <FieldArray
+          name={ORGANIZATIONS}
+          component={InstanceAssignment}
+          props={
+            {
+              formName: MANAGE_ASSIGNMENTS_FORM,
+              formNamespace: ORGANIZATION,
+              invitedUserId: user.id,
+              isOrganizationRequired: false,
+              header: formatMessage(messages.assignedTo),
+              addButtonPlacement: 'header',
+              addFormPlacement: 'top',
+              withEmptyState: true,
+              emptyStateText: formatMessage(messages.noAssignmentsYet),
+              onExpandOrganization: handleExpandOrganization,
+            } as InstanceAssignmentProps
+          }
+        />
       </div>
     </Modal>
   );

--- a/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.tsx
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.tsx
@@ -52,7 +52,9 @@ import {
   getManageAssignmentsInstanceChangeSet,
   mapProjectsFromResponse,
 } from '../utils';
+import { OrganizationType } from 'controllers/organization';
 import { UserOrganizationProjectsResponse } from 'controllers/organization/users/types';
+import { OrganizationsSearchesResponseData } from 'controllers/instance/organizations';
 import { ALL_USERS_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/allUsersPage';
 import { ApiError } from 'types/api';
 
@@ -71,6 +73,8 @@ interface InstanceUser {
     org_role: string;
     name: string;
     slug: string;
+    type?: OrganizationType;
+    owner_id?: number;
   }>;
 }
 
@@ -99,6 +103,7 @@ const ManageAssignmentsInstanceModalView = ({
   const dispatch = useDispatch();
 
   const [isSavingAssignments, setIsSavingAssignments] = useState(false);
+  const [organizationsLoading, setOrganizationsLoading] = useState(false);
   const initialOrganizationsRef = useRef<OrganizationValue[]>([]);
 
   const formSelector = formValueSelector(MANAGE_ASSIGNMENTS_FORM);
@@ -118,21 +123,57 @@ const ManageAssignmentsInstanceModalView = ({
   useEffect(() => {
     const initializeForm = () => {
       if (user?.organizations?.length > 0) {
-        const orgs: OrganizationValue[] = user.organizations.map((org) => ({
-          id: org.id,
-          name: org.name,
-          role: org.org_role,
-          projects: [],
-          isProjectsLoaded: false,
-          isExpanded: false,
-        }));
+        let orgs: OrganizationValue[] = user.organizations
+          .map((org) => ({
+            id: org.id,
+            name: org.name,
+            type: org.type,
+            owner_id: org.owner_id,
+            role: org.org_role,
+            projects: [],
+            isProjectsLoaded: false,
+            isExpanded: false,
+          }))
+          .sort((first, second) => first.name.localeCompare(second.name));
+
         initialize({ [ORGANIZATIONS]: orgs });
         initialOrganizationsRef.current = orgs;
+
+        setOrganizationsLoading(true);
+
+        fetch(URLS.organizationSearches(), {
+          method: 'post',
+          data: {
+            limit: 300,
+            search_criteria: [
+              { filter_key: 'org_user_id', operation: 'EQ', value: String(user.id) },
+            ],
+          },
+        })
+          .then((response: OrganizationsSearchesResponseData) => {
+            const items = response.items ?? [];
+            orgs = orgs.map((org, orgIndex) => {
+              const nextOrg = items.find((item) => item.id === org.id);
+              const orgField = `${ORGANIZATIONS}[${orgIndex}]`;
+              if (nextOrg?.type) {
+                dispatch(change(MANAGE_ASSIGNMENTS_FORM, `${orgField}.type`, nextOrg.type));
+              }
+              if (nextOrg?.owner_id) {
+                dispatch(change(MANAGE_ASSIGNMENTS_FORM, `${orgField}.owner_id`, nextOrg.owner_id));
+              }
+              return { ...org, type: nextOrg?.type, owner_id: nextOrg?.owner_id };
+            });
+            initialOrganizationsRef.current = orgs;
+          })
+          .catch(() => {})
+          .finally(() => {
+            setOrganizationsLoading(false);
+          });
       }
     };
 
     initializeForm();
-  }, [user, initialize]);
+  }, [user, initialize, dispatch]);
 
   // Fetch projects for organization when expanded
   const handleExpandOrganization = useCallback(
@@ -256,16 +297,19 @@ const ManageAssignmentsInstanceModalView = ({
     dispatch(hideModalAction());
   }, [dispatch]);
 
-  const renderDocumentationLink = useCallback((chunks: ReactNode) => (
-    <ExternalLink
-      href={referenceDictionary.rpDoc}
-      variant="compact"
-      isColoredIcon={false}
-      onClick={() => trackEvent(ALL_USERS_PAGE_EVENTS.MANAGE_ASSIGNMENTS_DOCUMENTATION)}
-    >
-      {chunks}
-    </ExternalLink>
-  ), [trackEvent]);
+  const renderDocumentationLink = useCallback(
+    (chunks: ReactNode) => (
+      <ExternalLink
+        href={referenceDictionary.rpDoc}
+        variant="compact"
+        isColoredIcon={false}
+        onClick={() => trackEvent(ALL_USERS_PAGE_EVENTS.MANAGE_ASSIGNMENTS_DOCUMENTATION)}
+      >
+        {chunks}
+      </ExternalLink>
+    ),
+    [trackEvent],
+  );
 
   const description = useMemo(
     () =>
@@ -289,37 +333,43 @@ const ManageAssignmentsInstanceModalView = ({
       okButton={{
         children: formatMessage(COMMON_LOCALE_KEYS.SAVE),
         disabled:
-          !isDirty || isAnyProjectsLoading || isSavingAssignments || isInlineAssignmentFormOpen,
+          !isDirty ||
+          organizationsLoading ||
+          isAnyProjectsLoading ||
+          isSavingAssignments ||
+          isInlineAssignmentFormOpen,
         onClick: handleSubmit(handleSave) as () => void,
       }}
     >
-      <div>
-        <ModalLoadingOverlay isVisible={isSavingAssignments} />
-        {isAdmin && (
-          <div className={cx('admin-info')}>
-            <SystemMessage mode="info">
-              {formatMessage(messages.manageAssignmentsAdminInfo)}
-            </SystemMessage>
-          </div>
-        )}
-        <FieldArray
-          name={ORGANIZATIONS}
-          component={InstanceAssignment}
-          props={
-            {
-              formName: MANAGE_ASSIGNMENTS_FORM,
-              formNamespace: ORGANIZATION,
-              invitedUserId: user.id,
-              isOrganizationRequired: false,
-              header: formatMessage(messages.assignedTo),
-              addButtonPlacement: 'header',
-              addFormPlacement: 'top',
-              withEmptyState: true,
-              emptyStateText: formatMessage(messages.noAssignmentsYet),
-              onExpandOrganization: handleExpandOrganization,
-            } as InstanceAssignmentProps
-          }
-        />
+      <div className={cx('modal-content')}>
+        <ModalLoadingOverlay isVisible={organizationsLoading} />
+        <>
+          {isAdmin && (
+            <div className={cx('admin-info')}>
+              <SystemMessage mode="info">
+                {formatMessage(messages.manageAssignmentsAdminInfo)}
+              </SystemMessage>
+            </div>
+          )}
+          <FieldArray
+            name={ORGANIZATIONS}
+            component={InstanceAssignment}
+            props={
+              {
+                formName: MANAGE_ASSIGNMENTS_FORM,
+                formNamespace: ORGANIZATION,
+                invitedUserId: user.id,
+                isOrganizationRequired: false,
+                header: formatMessage(messages.assignedTo),
+                addButtonPlacement: 'header',
+                addFormPlacement: 'top',
+                withEmptyState: true,
+                emptyStateText: formatMessage(messages.noAssignmentsYet),
+                onExpandOrganization: handleExpandOrganization,
+              } as InstanceAssignmentProps
+            }
+          />
+        </>
       </div>
     </Modal>
   );

--- a/app/src/pages/inside/common/assignments/manageAssignmentsOrganizationModal/manageAssignmentsOrganizationModal.tsx
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsOrganizationModal/manageAssignmentsOrganizationModal.tsx
@@ -95,14 +95,6 @@ const ManageAssignmentsOrganizationModalView = ({
   const [initialOrganization, setInitialOrganization] = useState<OrganizationValue | null>(null);
   const handleUnassignSuccess = useHandleUnassignSuccess(user, onUnassign);
   const isCurrentUser = currentUserId === user?.id;
-  const tooltipMessage = formatMessage(
-    isCurrentUser
-      ? messages.organizationRoleDisabledOwnAccount
-      : messages.organizationRoleDisabledOwner,
-  );
-  const isOrganizationOwner = user?.id === organization?.owner_id;
-  const organizationRoleDisabledTooltip =
-    isCurrentUser || isOrganizationOwner ? tooltipMessage : null;
   const isDirty = isAssignmentDirty(currentOrganization, initialOrganization);
   const isBusy = assignmentsLoading || assignmentsUpdateLoading || !currentOrganization;
 
@@ -302,7 +294,7 @@ const ManageAssignmentsOrganizationModalView = ({
             isMultiple={false}
             value={currentOrganization}
             onChange={handleOrganizationChange}
-            organizationRoleDisabledTooltip={organizationRoleDisabledTooltip}
+            invitedUserId={user.id}
           />
         )}
       </div>

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
@@ -24,9 +24,9 @@ interface OrganizationAssignmentProps {
   onChange?: (value: Organization | Organization[]) => void;
   value?: Organization | Organization[];
   isMultiple?: boolean;
-  organizationRoleDisabledTooltip?: string | null;
   formName?: string;
   invitedUserId?: number | null;
+  excludeUserAssignments?: boolean;
   isOrganizationFormOpen?: boolean;
   onExpandOrganization?: (orgId: number) => void;
 }
@@ -35,9 +35,9 @@ export const OrganizationAssignment = ({
   value,
   onChange,
   isMultiple = false,
-  organizationRoleDisabledTooltip = null,
   formName,
   invitedUserId,
+  excludeUserAssignments = false,
   isOrganizationFormOpen = false,
   onExpandOrganization,
 }: OrganizationAssignmentProps) => {
@@ -90,6 +90,7 @@ export const OrganizationAssignment = ({
               onRemove={() => removeItem(index)}
               collapsable
               invitedUserId={invitedUserId}
+              excludeUserAssignments={excludeUserAssignments}
               addProjectDisabled={(openFormOrgId !== null && openFormOrgId !== org.id) || isOrganizationFormOpen}
               onAddProjectFormToggle={handleAddProjectFormToggle}
               onExpandOrganization={onExpandOrganization}
@@ -104,8 +105,8 @@ export const OrganizationAssignment = ({
     <OrganizationItem
       value={value as Organization}
       onChange={(updates) => updateItem(updates)}
-      organizationRoleDisabledTooltip={organizationRoleDisabledTooltip}
       invitedUserId={invitedUserId}
+      excludeUserAssignments={excludeUserAssignments}
       onAddProjectFormToggle={handleAddProjectFormToggle}
       onExpandOrganization={onExpandOrganization}
     />

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/addProjectForm/addProjectForm.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/addProjectForm/addProjectForm.tsx
@@ -46,6 +46,7 @@ interface AddProjectFormProps {
   organizationId: number;
   canEditByDefault: boolean;
   invitedUserId?: number | null;
+  excludeUserAssignments?: boolean;
   onSave: (project: Project) => void;
   onCancel: () => void;
 }
@@ -54,6 +55,7 @@ export const AddProjectForm = ({
   organizationId,
   canEditByDefault,
   invitedUserId,
+  excludeUserAssignments = false,
   projects,
   onSave,
   onCancel,
@@ -76,7 +78,7 @@ export const AddProjectForm = ({
     setUserProjectIds(new Set());
     setAutocompleteKey((k) => k + 1);
 
-    if (!invitedUserId) {
+    if (!invitedUserId || !excludeUserAssignments) {
       return undefined;
     }
 
@@ -100,7 +102,7 @@ export const AddProjectForm = ({
     return () => {
       active = false;
     };
-  }, [invitedUserId, organizationId]);
+  }, [invitedUserId, organizationId, excludeUserAssignments]);
 
   const getRequestParams = (inputValue: string) => {
     return {

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.scss
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.scss
@@ -28,11 +28,23 @@
 .name {
   flex: 1;
   font-weight: var(--rp-ui-base-fw-medium);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+
+.name-label {
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.type-icons {
+  flex-shrink: 0;
   display: flex;
-  gap: 8px;
+  align-items: center;
 }
 
 .pointer {

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
+import { useSelector } from 'react-redux';
 import {
   BaseIconButton,
   CloseIcon,
@@ -28,9 +29,13 @@ import {
 import { createClassnames, fetch } from 'common/utils';
 import { EDITOR, MANAGER, MEMBER } from 'common/constants/projectRoles';
 import { messages } from 'common/constants/localization/invitationsLocalization';
+import { messages as assignmentMessages } from 'common/constants/localization/assignmentsLocalization';
 import { getOrgRoleTitle } from 'common/utils/permissions';
 import { URLS } from 'common/urls';
 import { ProjectsSearchesResponseData } from 'controllers/organization/projects';
+import { OrganizationType } from 'controllers/organization';
+import { idSelector } from 'controllers/user';
+import { IconsBlock } from 'pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock';
 
 import { PROJECTS_LIMIT } from './constants';
 import { AddItemButton } from './addItemButton';
@@ -44,6 +49,9 @@ const cx = createClassnames(styles);
 export interface Organization {
   id: number;
   name: string;
+  type?: OrganizationType;
+  owner_id?: number;
+  isNew?: boolean,
   role: string;
   projects: Project[];
   isProjectsLoaded?: boolean;
@@ -56,9 +64,9 @@ interface OrganizationItemProps {
   onChange: (updates: Partial<Organization>) => void;
   onRemove?: () => void;
   collapsable?: boolean;
-  organizationRoleDisabledTooltip?: string | null;
   addProjectDisabled?: boolean;
   invitedUserId?: number | null;
+  excludeUserAssignments?: boolean;
   onAddProjectFormToggle?: (orgId: number, isOpen: boolean) => void;
   onExpandOrganization?: (orgId: number) => void;
 }
@@ -68,15 +76,43 @@ export const OrganizationItem = ({
   onChange,
   onRemove,
   collapsable,
-  organizationRoleDisabledTooltip = null,
   addProjectDisabled = false,
   invitedUserId,
+  excludeUserAssignments = false,
   onAddProjectFormToggle,
   onExpandOrganization,
 }: OrganizationItemProps) => {
-  const disableOrganizationRole = Boolean(organizationRoleDisabledTooltip);
   const { formatMessage } = useIntl();
-  const { id, name, role, projects, isExpanded = true, isProjectsLoading } = value;
+  const currentUserId = useSelector(idSelector) as number;
+  const {
+    id,
+    name,
+    type,
+    owner_id: ownerId,
+    isNew,
+    role,
+    projects,
+    isExpanded = true,
+    isProjectsLoading,
+  } = value;
+
+  const organizationRoleDisabledTooltip = useMemo(() => {
+    if (invitedUserId == null || isNew) {
+      return null;
+    }
+    const isOwnAccount = currentUserId === invitedUserId;
+    const isAssignedUserOrgOwner = ownerId != null && invitedUserId === ownerId;
+    if (!isOwnAccount && !isAssignedUserOrgOwner) {
+      return null;
+    }
+    return formatMessage(
+      isOwnAccount
+        ? assignmentMessages.organizationRoleDisabledOwnAccount
+        : assignmentMessages.organizationRoleDisabledOwner,
+    );
+  }, [invitedUserId, isNew, currentUserId, ownerId, formatMessage]);
+
+  const disableOrganizationRole = Boolean(organizationRoleDisabledTooltip);
   const [totalProjects, setTotalProjects] = useState(0);
   const [addProjectFormOpen, setAddProjectFormOpen] = useState(false);
   const [isOpen, setIsOpen] = useState(isExpanded);
@@ -177,7 +213,8 @@ export const OrganizationItem = ({
               <DropdownIcon />
             </div>
           )}
-          {name}
+          <span className={cx('name-label')}>{name}</span>
+          {!!type && <IconsBlock organizationType={type} />}
         </div>
         <div className={cx('controls')}>
           <div className={cx('role-slot')}>
@@ -236,6 +273,7 @@ export const OrganizationItem = ({
                     organizationId={id}
                     canEditByDefault={role === MANAGER}
                     invitedUserId={invitedUserId}
+                    excludeUserAssignments={excludeUserAssignments}
                     onSave={handleAddProject}
                     onCancel={() => setAddProjectFormOpen(false)}
                   />

--- a/app/src/pages/inside/common/assignments/utils.ts
+++ b/app/src/pages/inside/common/assignments/utils.ts
@@ -49,6 +49,8 @@ export function getCurrentOrganizationAssignment(
   return {
     id: organization.id,
     name: organization.name,
+    type: organization.type,
+    owner_id: organization.owner_id,
     role: orgRole,
     projects,
   };

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserInstanceForm/inviteUserInstanceForm.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserInstanceForm/inviteUserInstanceForm.tsx
@@ -67,6 +67,7 @@ export const InviteUserInstanceForm = () => {
           formNamespace: ORGANIZATION,
           isOrganizationRequired: true,
           invitedUserId,
+          excludeUserAssignments: true,
         }}
       />
     </form>

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
@@ -33,10 +33,7 @@ import { InviteUserProjectForm } from './inviteUserProjectForm';
 import { InviteUserOrganizationForm } from './inviteUserOrganizationForm/inviteUserOrganizationForm';
 import { InviteUserInstanceForm } from './inviteUserInstanceForm';
 import { MEMBER } from 'common/constants/projectRoles';
-import {
-  activeOrganizationIdSelector,
-  activeOrganizationNameSelector,
-} from 'controllers/organization';
+import { activeOrganizationSelector } from 'controllers/organization';
 import { messages } from 'common/constants/localization/invitationsLocalization';
 import { fetchUserInfoAction, UserInfo, userInfoSelector } from 'controllers/user';
 import { InvitationStatus, Level } from './constants';
@@ -229,13 +226,12 @@ const FORM_CONTENT = {
 } as const;
 
 export const InviteUserModal = <L extends keyof FormDataMap>(props: ModalProps<L>) => {
-  const id = useSelector(activeOrganizationIdSelector) as number;
-  const name = useSelector(activeOrganizationNameSelector) as string;
+  const { id, name, type } = useSelector(activeOrganizationSelector) as Organization;
   const level = props.level;
 
   let initialValues: Record<string, unknown> = {};
   if (level === Level.ORGANIZATION) {
-    const organization: Organization = { id, name, role: MEMBER, projects: [] };
+    const organization: Organization = { id, name, type, role: MEMBER, projects: [] };
     initialValues = { organization };
   }
 

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserOrganizationForm/inviteUserOrganizationForm.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserOrganizationForm/inviteUserOrganizationForm.tsx
@@ -34,7 +34,7 @@ export const InviteUserOrganizationForm = () => {
         onUserSelect={handleUserSelect}
       />
       <FieldElement name="organization">
-        <OrganizationAssignment invitedUserId={invitedUserId} />
+        <OrganizationAssignment invitedUserId={invitedUserId} excludeUserAssignments />
       </FieldElement>
     </form>
   );

--- a/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersActionMenu/allUsersActionMenu.tsx
+++ b/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersActionMenu/allUsersActionMenu.tsx
@@ -31,6 +31,7 @@ import { messages as assignmentMessages } from 'common/constants/localization/as
 import { ALL_USERS_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/allUsersPage';
 import { createClassnames } from 'common/utils';
 import { useUserPermissions } from 'hooks/useUserPermissions';
+import { OrganizationType } from 'controllers/organization';
 import { ManageAssignmentsInstanceModal } from 'pages/inside/common/assignments/manageAssignmentsInstanceModal';
 import styles from './allUsersActionMenu.scss';
 
@@ -46,6 +47,8 @@ interface User {
     org_role: string;
     name: string;
     slug: string;
+    type?: OrganizationType;
+    owner_id?: number;
   }>;
 }
 

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock.jsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock.jsx
@@ -45,7 +45,7 @@ export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) 
           <i className={cx('icon')}>{Parser(SynchedIcon)}</i>
         </Tooltip>
       ) : (
-        organizationType !== OrganizationType.INTERNAL && (
+        organizationType === OrganizationType.PERSONAL && (
           <Tooltip
             content={formatMessage(messages.personalOrganization)}
             placement={'top'}

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock.jsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock.jsx
@@ -36,26 +36,25 @@ export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) 
 
   return (
     <>
-      {hasPermission &&
-        (organizationType === OrganizationType.EXTERNAL ? (
+      {organizationType === OrganizationType.EXTERNAL ? (
+        <Tooltip
+          content={formatMessage(messages.synchedOrganization)}
+          placement={'top'}
+          wrapperClassName={cx('tooltip-wrapper')}
+        >
+          <i className={cx('icon')}>{Parser(SynchedIcon)}</i>
+        </Tooltip>
+      ) : (
+        organizationType !== OrganizationType.INTERNAL && (
           <Tooltip
-            content={formatMessage(messages.synchedOrganization)}
+            content={formatMessage(messages.personalOrganization)}
             placement={'top'}
             wrapperClassName={cx('tooltip-wrapper')}
           >
-            <i className={cx('icon')}>{Parser(SynchedIcon)}</i>
+            <i className={cx('icon')}>{Parser(PersonalIcon)}</i>
           </Tooltip>
-        ) : (
-          organizationType !== OrganizationType.INTERNAL && (
-            <Tooltip
-              content={formatMessage(messages.personalOrganization)}
-              placement={'top'}
-              wrapperClassName={cx('tooltip-wrapper')}
-            >
-              <i className={cx('icon')}>{Parser(PersonalIcon)}</i>
-            </Tooltip>
-          )
-        ))}
+        )
+      )}
       {hasPermission && isOutdated && (
         <Tooltip
           content={formatMessage(messages.lastLaunch)}


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Links
[EPMRPP-113915: Instance Manage assignments. Role dropdown for current user](https://jiraeu.epam.com/browse/EPMRPP-113915)
[EPMRPP-113917: Org type icons are missed](https://jiraeu.epam.com/browse/EPMRPP-113917)
[EPMRPP-113965: Instance Manage assignments. Organizations list in a random order](https://jiraeu.epam.com/browse/EPMRPP-113965)

## Summary of changes

### Organization metadata (`type`, `owner_id`, `isNew`)
- **Types:** `OrganizationSearchesItem` now extends the full `Organization` type (so `owner_id` is included). User/org interfaces in **allUsersActionMenu** and assignment code include optional `type` and `owner_id`.
- **Data flow:** When adding an org in **instanceAssignment**, `type`, `owner_id`, and `isNew` are stored on the row. **utils** and **inviteUserModal** propagate `type` (via `activeOrganizationSelector` instead of separate id/name selectors).
- **UI:** **organizationItem** shows the org name with ellipsis and **`IconsBlock`** for the org type. **organizationItem.scss** adjusts layout (flex, `name-label`, `type-icons`).

### `Manage assignments` instance modal
- Orgs are **sorted by name** on init.
- A **POST `organizationSearches`** call loads full org details (`type`, `owner_id`) for the edited user’s orgs; the form is updated via **redux-form `change`**. **`organizationsLoading`** drives a **ModalLoadingOverlay** and **disables Save** until that load finishes.
- **manageAssignmentsInstanceModal.scss:** `.modal-content { position: relative }` for correct overlay positioning.

### `excludeUserAssignments`
- New flag on **instanceAssignment**, **organizationAssignment**, **organizationItem**, **addProjectForm**.
- **`true`** on **invite** flows (instance + organization invite forms): do **not** count the invitee’s existing org memberships when deciding “how many orgs are left to add” or when filtering the org picker; **addProjectForm** only loads “user’s project IDs” when both `invitedUserId` **and** `excludeUserAssignments` are set (invite scenario).
- **`false`** by default for normal manage-assignments, preserving the previous behavior.

### Organization role disable tooltip
- Removed **`organizationRoleDisabledTooltip`** from parents; **organizationItem** computes it internally with **`useMemo`**: uses **`invitedUserId`**, **`owner_id`**, **`isNew`**, and **current user id** so the “own account” / “org owner” messages apply in the right cases. **ManageAssignmentsOrganizationModal** passes **`invitedUserId={user.id}`** instead of a precomputed tooltip.

### **IconsBlock** (`iconsBlock.jsx`)
- **External** (synced) and **personal** org icons are shown **without** requiring `hasPermission`. The **outdated launch** icon stays behind **`hasPermission`**.

---

**Overall purpose:** Enrich assignment and invite UIs with **org type/owner** for correct icons and role restrictions, **async-load** that metadata in the instance “manage assignments” modal, separate **invite** vs **manage-user** behavior with **`excludeUserAssignments`**, and show **type icons** even when the user lacks the permission that previously hid all type icons.

## Visuals
**_Instance level:_**

https://github.com/user-attachments/assets/9367cdca-c313-4c22-9fd3-7d23c14075e6

**_Organization level:_**

https://github.com/user-attachments/assets/fe265423-976a-402b-a8d2-fe8a69113403



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to exclude a user’s existing assignments when selecting organizations during invites/assignments.

* **Improvements**
  * Assignment workflows now surface richer organization metadata (type, owner) and merge it into forms.
  * Modal save/loading behavior improved to reflect background metadata loading.
  * Role-disabled tooltips now compute reliably based on context.

* **UI Updates**
  * Improved name layout and icon alignment.
  * Icons refined for external/personal organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->