### PR TITLE
EPMRPP-113914 || [UI] "Organization users" menu item is displayed in sidebar for Member user

### DIFF
--- a/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
+++ b/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
@@ -39,10 +39,12 @@ import {
 import { SIDEBAR_EVENTS } from 'components/main/analytics/events';
 import { OrganizationsControlWithPopover } from '../../organizationsControl';
 import { messages } from '../../messages';
+import { useUserPermissions } from 'hooks/useUserPermissions';
 const ORGANIZATION_CONTROL = 'Organization control';
 
 export const OrganizationSidebar = ({ onClickNavBtn }) => {
   const { trackEvent } = useTracking();
+  const { canSeeOrganizationMembers } = useUserPermissions();
   const { formatMessage } = useIntl();
   const sidebarExtensions = useSelector(uiExtensionOrganizationSidebarComponentsSelector);
   const organizationSlug = useSelector(activeOrganizationSelector)?.slug;
@@ -63,16 +65,20 @@ export const OrganizationSidebar = ({ onClickNavBtn }) => {
         icon: ProjectsIcon,
         message: formatMessage(messages.projects),
       },
-      {
-        onClick: (isSidebarCollapsed) =>
-          onClickButton({ itemName: messages.users.defaultMessage, isSidebarCollapsed }),
-        link: {
-          type: ORGANIZATION_USERS_PAGE,
-          payload: { organizationSlug },
-        },
-        icon: MembersIcon,
-        message: formatMessage(messages.users),
-      },
+      ...(canSeeOrganizationMembers
+        ? [
+            {
+              onClick: (isSidebarCollapsed) =>
+                onClickButton({ itemName: messages.users.defaultMessage, isSidebarCollapsed }),
+              link: {
+                type: ORGANIZATION_USERS_PAGE,
+                payload: { organizationSlug },
+              },
+              icon: MembersIcon,
+              message: formatMessage(messages.users),
+            },
+          ]
+        : []),
       {
         onClick: (isSidebarCollapsed) =>
           onClickButton({
@@ -85,9 +91,8 @@ export const OrganizationSidebar = ({ onClickNavBtn }) => {
         },
         icon: SettingsIcon,
         message: formatMessage(messages.organizationSettings),
-      }
+      },
     ];
-
 
     sidebarExtensions.forEach((extension) => {
       const itemName = extension.payload?.iconName;

--- a/app/src/store/organizationProjectRouteMiddleware.js
+++ b/app/src/store/organizationProjectRouteMiddleware.js
@@ -17,7 +17,11 @@
 import { redirect } from 'redux-first-router';
 import { userInfoSelector, activeProjectSelector, setActiveProjectAction } from 'controllers/user';
 import { isAuthorizedSelector } from 'controllers/auth';
-import { userAssignedSelector } from 'controllers/pages';
+import {
+  ORGANIZATION_USERS_PAGE,
+  userAssignedSelector,
+  userRolesSelector,
+} from 'controllers/pages';
 import { prepareActiveProjectAction } from 'controllers/project';
 import {
   fetchOrganizationBySlugAction,
@@ -25,6 +29,7 @@ import {
 } from 'controllers/organization';
 import { getRedirectRoute, ROUTE_ACTION_TYPES } from 'routes/routesMap';
 import { stringEqual } from 'common/utils/stringUtils';
+import { canSeeOrganizationMembers } from 'common/utils/permissions';
 
 /**
  * Organization/project route middleware: access check, sync of active org/project from URL, redirect on no access.
@@ -43,6 +48,7 @@ export const organizationProjectRouteMiddleware = (store) => (next) => (action) 
 
   const authorized = isAuthorizedSelector(getState());
   const isOrganizationPage = !!hashOrganizationSlug;
+  const isOrganizationUsersPage = action.type === ORGANIZATION_USERS_PAGE;
 
   if (!authorized || !isOrganizationPage) return next(action);
 
@@ -54,8 +60,15 @@ export const organizationProjectRouteMiddleware = (store) => (next) => (action) 
 
   const isProjectPage = !!hashProjectSlug;
 
+  const hasPermissionOrganizationUsers = canSeeOrganizationMembers(userRolesSelector(getState()));
+
   // For project pages check project-level permission, for org pages — org-level
-  const hasPageAccess = isProjectPage ? hasPermission : hasPermissionOrganization;
+  const hasOrganizationPageAccess =
+    hasPermissionOrganization && isOrganizationUsersPage
+      ? hasPermissionOrganizationUsers
+      : hasPermissionOrganization;
+
+  const hasPageAccess = isProjectPage ? hasPermission : hasOrganizationPageAccess;
 
   // No access — redirect to a guaranteed accessible route
   if (!hasPageAccess) {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
<img width="1045" height="415" alt="image" src="https://github.com/user-attachments/assets/f13e6e84-ac8d-4065-a341-fce8dd295f5e" />
<img width="400" height="864" alt="image" src="https://github.com/user-attachments/assets/1e0008fa-1086-4d52-8be0-464b2d464cbe" />

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based access control for organization members. The members menu item and page are now only visible to users with appropriate permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->