### PR TITLE
EPMRPP-106918 || Manage user assignment on instance level. Part 3 (Unassign)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/intl-pluralrules": "1.3.9",
         "@formatjs/intl-relativetimeformat": "4.5.1",
         "@formatjs/intl-utils": "1.6.0",
-        "@reportportal/ui-kit": "^0.0.1-alpha.203",
+        "@reportportal/ui-kit": "^0.0.1-alpha.204",
         "axios": "^1.13.2",
         "c3": "0.7.20",
         "chart.js": "2.9.4",
@@ -4898,9 +4898,9 @@
       "license": "MIT"
     },
     "node_modules/@reportportal/ui-kit": {
-      "version": "0.0.1-alpha.203",
-      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.203.tgz",
-      "integrity": "sha512-8NwSVzs5fQhRFCR5uN8XSzsLEnVOqz3Bd/bimETSm83mJddHpjafAB+IR4OfWJhANYJ6NkFSpMu+ABBf2EpRGQ==",
+      "version": "0.0.1-alpha.204",
+      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.204.tgz",
+      "integrity": "sha512-sfa7i85SnFtynqnXqTM3e0+fjrMULoC5yCF0Rc0nBfVjWBs89C4fZyecyILueQ4z63n/FilODz8BFzDYFc8oxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
@@ -6314,7 +6314,7 @@
       "version": "20.17.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.55.tgz",
       "integrity": "sha512-ESpPDUEtW1a9nueMQtcTq/5iY/7osurPpBpFKH2VAyREKdzoFRRod6Oms0SSTfV7u52CcH7b6dFVnjfPD8fxWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -6374,7 +6374,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -26563,7 +26563,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -26638,7 +26638,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "@formatjs/intl-pluralrules": "1.3.9",
     "@formatjs/intl-relativetimeformat": "4.5.1",
     "@formatjs/intl-utils": "1.6.0",
-    "@reportportal/ui-kit": "^0.0.1-alpha.203",
+    "@reportportal/ui-kit": "^0.0.1-alpha.204",
     "axios": "^1.13.2",
     "c3": "0.7.20",
     "chart.js": "2.9.4",

--- a/app/src/components/main/analytics/events/ga4Events/allUsersPage.ts
+++ b/app/src/components/main/analytics/events/ga4Events/allUsersPage.ts
@@ -113,4 +113,11 @@ export const ALL_USERS_PAGE_EVENTS = {
     link_name: 'documentation',
     place: 'manage_assignment',
   },
+  manageAssignmentsSave: (condition: string) => ({
+    ...BASIC_EVENT_PARAMETERS,
+    place: 'all_users',
+    element_name: 'save',
+    modal: 'manage_assignment',
+    condition,
+  }),
 };

--- a/app/src/pages/inside/common/assignments/hooks.ts
+++ b/app/src/pages/inside/common/assignments/hooks.ts
@@ -1,9 +1,23 @@
 import { useSelector, useDispatch } from 'react-redux';
+import { MessageDescriptor } from 'react-intl';
 import { UserInfo, fetchUserInfoAction, idSelector } from 'controllers/user';
 import { hideModalAction } from 'controllers/modal';
 import { Organization, OrganizationType } from 'controllers/organization';
 import { UPSA } from 'common/constants/accountType';
+import { messages as assignmentMessages } from 'common/constants/localization/assignmentsLocalization';
 import { useUserPermissions } from 'hooks/useUserPermissions';
+
+export interface AssignmentsUtilsParams {
+  currentUserId: number;
+  userId: number | null | undefined;
+  userType: string | undefined;
+  organizationType: OrganizationType | undefined;
+  ownerId: number | undefined;
+}
+
+export interface AssignmentsUtilsResult {
+  unassignTooltip: MessageDescriptor | null;
+}
 
 export const useCanUnassignOrganization = () => {
   const currentUserId = useSelector(idSelector) as number;
@@ -40,4 +54,41 @@ export const useHandleUnassignSuccess = (user: Pick<UserInfo, 'id'>, onUnassign:
     dispatch(hideModalAction());
     onUnassign?.();
   };
+};
+
+export const useAssignmentsUtils = ({
+  currentUserId,
+  userId,
+  userType,
+  organizationType,
+  ownerId,
+}: AssignmentsUtilsParams): AssignmentsUtilsResult => {
+  const isUpsaUser = userType === UPSA;
+  const isExternalOrg = organizationType === OrganizationType.EXTERNAL;
+  const isPersonalOrg = organizationType === OrganizationType.PERSONAL;
+  const isOrganizationOwner = userId != null && userId === ownerId;
+  const isCurrentUser = currentUserId === userId;
+
+  if (isCurrentUser) {
+    return {
+      unassignTooltip:
+        isPersonalOrg && isOrganizationOwner
+          ? assignmentMessages.unassignPersonalOwnerSelfMessage
+          : assignmentMessages.unassignSelfMessage,
+    };
+  }
+
+  if (isUpsaUser && isExternalOrg) {
+    return {
+      unassignTooltip: assignmentMessages.unassignUpsaMessage,
+    };
+  }
+
+  if (isPersonalOrg && isOrganizationOwner) {
+    return {
+      unassignTooltip: assignmentMessages.unassignPersonalOwnerMessage,
+    };
+  }
+
+  return { unassignTooltip: null };
 };

--- a/app/src/pages/inside/common/assignments/index.ts
+++ b/app/src/pages/inside/common/assignments/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { useCanUnassignOrganization, useHandleUnassignSuccess } from './hooks';
+export { useCanUnassignOrganization, useHandleUnassignSuccess, useAssignmentsUtils } from './hooks';
 export { UnassignOrganizationModal } from './unassignOrganizationModal';
 export { AssignProjectModal } from './assignProjectModal';

--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -123,6 +123,7 @@ export interface InstanceAssignmentProps extends InstanceAssignmentArrayProps<In
   formNamespace?: string;
   isOrganizationRequired: boolean;
   invitedUserId?: number | null;
+  userType?: string;
   excludeUserAssignments?: boolean;
   header?: string;
   addButtonPlacement?: 'header' | 'bottom';
@@ -166,6 +167,7 @@ export const InstanceAssignment = ({
   formNamespace,
   isOrganizationRequired = false,
   invitedUserId = null,
+  userType,
   excludeUserAssignments = false,
   header,
   addButtonPlacement = 'bottom',
@@ -571,6 +573,7 @@ export const InstanceAssignment = ({
           isMultiple
           formName={formName}
           invitedUserId={invitedUserId}
+          userType={userType}
           excludeUserAssignments={excludeUserAssignments}
           isOrganizationFormOpen={isOpen}
           onExpandOrganization={onExpandOrganization}

--- a/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.tsx
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsInstanceModal/manageAssignmentsInstanceModal.tsx
@@ -50,6 +50,7 @@ import { ORGANIZATIONS } from 'pages/instance/allUsersPage/allUsersHeader/create
 import {
   buildUpdateAssignmentsPayload,
   getManageAssignmentsInstanceChangeSet,
+  getManageAssignmentsInstanceSaveCondition,
   mapProjectsFromResponse,
 } from '../utils';
 import { OrganizationType } from 'controllers/organization';
@@ -71,6 +72,7 @@ interface InstanceUser {
   id: number;
   fullName: string;
   instanceRole?: string;
+  accountType?: string;
   organizations: Array<{
     id: number;
     org_role: string;
@@ -241,37 +243,59 @@ const ManageAssignmentsInstanceModalView = ({
   }, [organizations]);
 
   const handleSave = async () => {
-    const { modified } = getManageAssignmentsInstanceChangeSet(
+    const { modified, removed } = getManageAssignmentsInstanceChangeSet(
       initialOrganizationsRef.current,
       organizations,
     );
+    const saveCondition = getManageAssignmentsInstanceSaveCondition(
+      initialOrganizationsRef.current,
+      organizations,
+    );
+    if (saveCondition) {
+      trackEvent(ALL_USERS_PAGE_EVENTS.manageAssignmentsSave(saveCondition));
+    }
 
     setIsSavingAssignments(true);
 
     try {
-      const updatePromises = modified.map(async (org) => {
-        let orgToSave = org;
-        if (org.isProjectsLoaded === false) {
-          const response: UserOrganizationProjectsResponse = await fetch(
-            URLS.organizationUserProjects(org.id, user.id),
-          );
-          orgToSave = {
-            ...org,
-            projects: mapProjectsFromResponse(response),
-            isProjectsLoaded: true,
-          };
-        }
-        return fetch(URLS.organizationUserAssignments(org.id, user.id), {
-          method: 'PUT',
-          data: buildUpdateAssignmentsPayload(orgToSave),
-        });
-      });
-      const results = await Promise.allSettled(updatePromises);
+      const removeOperations = removed.map((org) => ({
+        name: org.name,
+        promise: fetch(URLS.organizationUserById({ organizationId: org.id, userId: user.id }), {
+          method: 'DELETE',
+        }),
+      }));
+
+      const updateOperations = modified.map((org) => ({
+        name: org.name,
+        promise: (async () => {
+          let orgToSave = org;
+
+          if (org.isProjectsLoaded === false) {
+            const response: UserOrganizationProjectsResponse = await fetch(
+              URLS.organizationUserProjects(org.id, user.id),
+            );
+
+            orgToSave = {
+              ...org,
+              projects: mapProjectsFromResponse(response),
+              isProjectsLoaded: true,
+            };
+          }
+
+          return fetch(URLS.organizationUserAssignments(org.id, user.id), {
+            method: 'PUT',
+            data: buildUpdateAssignmentsPayload(orgToSave),
+          });
+        })(),
+      }));
+
+      const operations = [...removeOperations, ...updateOperations];
+      const results = await Promise.allSettled(operations.map((op) => op.promise));
       const failedNames = results
-        .map((res, i) => (res.status === 'rejected' ? modified[i]?.name : null))
+        .map((res, i) => (res.status === 'rejected' ? operations[i].name : null))
         .filter(Boolean);
 
-      const allFailed = failedNames.length === modified.length;
+      const allFailed = failedNames.length === operations.length;
       const someFailed = failedNames.length > 0 && !allFailed;
 
       if (allFailed) {
@@ -374,6 +398,7 @@ const ManageAssignmentsInstanceModalView = ({
               formName: MANAGE_ASSIGNMENTS_FORM,
               formNamespace: ORGANIZATION,
               invitedUserId: user.id,
+              userType: user.accountType,
               isOrganizationRequired: false,
               header: formatMessage(messages.assignedTo),
               addButtonPlacement: 'header',

--- a/app/src/pages/inside/common/assignments/manageAssignmentsOrganizationModal/manageAssignmentsOrganizationModal.tsx
+++ b/app/src/pages/inside/common/assignments/manageAssignmentsOrganizationModal/manageAssignmentsOrganizationModal.tsx
@@ -39,14 +39,13 @@ import {
   userAssignmentsUpdateLoadingSelector,
 } from 'controllers/organization/users';
 import type { UserOrganizationProjectsResponse } from 'controllers/organization/users/types';
-import { Organization, OrganizationType } from 'controllers/organization';
+import { Organization } from 'controllers/organization';
 import { messages } from 'common/constants/localization/assignmentsLocalization';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
-import { UPSA } from 'common/constants/accountType';
 import { hideModalAction } from 'controllers/modal';
 import { ModalLoadingOverlay } from 'components/modalLoadingOverlay';
 
-import { useHandleUnassignSuccess } from '..';
+import { useHandleUnassignSuccess, useAssignmentsUtils } from '..';
 import {
   type Organization as OrganizationValue,
   OrganizationAssignment,
@@ -99,6 +98,13 @@ const ManageAssignmentsOrganizationModalView = ({
   const isCurrentUser = currentUserId === user?.id;
   const isDirty = isAssignmentDirty(currentOrganization, initialOrganization);
   const isBusy = assignmentsLoading || assignmentsUpdateLoading || !currentOrganization;
+  const { unassignTooltip } = useAssignmentsUtils({
+    currentUserId,
+    userId: user.id,
+    userType: user.accountType,
+    organizationType: organization.type,
+    ownerId: organization.owner_id,
+  });
 
   const initialSnapshotTakenRef = useRef(false);
   const wasLoadingRef = useRef(false);
@@ -169,41 +175,17 @@ const ManageAssignmentsOrganizationModalView = ({
   };
 
   const renderUnassignButton = () => {
-    const { id: userId, accountType: userType } = user;
-    const { owner_id: ownerId, type: organizationType } = organization;
-    const isUpsaUser = userType === UPSA;
-    const isExternalOrg = organizationType === OrganizationType.EXTERNAL;
-    const isPersonalOrg = organizationType === OrganizationType.PERSONAL;
-    const isOrganizationOwner = userId === ownerId;
-    const isCurrentUser = currentUserId === userId;
-
-    let isDisabled = isBusy;
-    let tooltipMessage: MessageDescriptor = null;
-
-    if (isCurrentUser) {
-      isDisabled = true;
-      tooltipMessage =
-        isPersonalOrg && isOrganizationOwner
-          ? messages.unassignPersonalOwnerSelfMessage
-          : messages.unassignSelfMessage;
-    } else if (isUpsaUser && isExternalOrg) {
-      isDisabled = true;
-      tooltipMessage = messages.unassignUpsaMessage;
-    } else if (isPersonalOrg && isOrganizationOwner) {
-      isDisabled = true;
-      tooltipMessage = messages.unassignPersonalOwnerMessage;
-    }
-
+    const isDisabled = isBusy || !!unassignTooltip;
     const button = (
       <Button variant="text-danger" onClick={handleUnassignClick} disabled={isDisabled}>
         {formatMessage(messages.unassignFromOrganization)}
       </Button>
     );
 
-    return tooltipMessage ? (
+    return unassignTooltip ? (
       <Tooltip
         placement="top"
-        content={formatMessage(tooltipMessage)}
+        content={formatMessage(unassignTooltip)}
         tooltipClassName={cx('custom-tooltip')}
         wrapperClassName={cx('tooltip-wrapper')}
       >
@@ -298,6 +280,7 @@ const ManageAssignmentsOrganizationModalView = ({
             onChange={handleOrganizationChange}
             invitedUserId={user.id}
             formName={MANAGE_ASSIGNMENTS_FORM}
+            userType={user.accountType}
           />
         )}
       </div>

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationAssignment.tsx
@@ -26,6 +26,7 @@ interface OrganizationAssignmentProps {
   isMultiple?: boolean;
   formName?: string;
   invitedUserId?: number | null;
+  userType?: string;
   excludeUserAssignments?: boolean;
   isOrganizationFormOpen?: boolean;
   onExpandOrganization?: (orgId: number) => void;
@@ -37,6 +38,7 @@ export const OrganizationAssignment = ({
   isMultiple = false,
   formName,
   invitedUserId,
+  userType,
   excludeUserAssignments = false,
   isOrganizationFormOpen = false,
   onExpandOrganization,
@@ -90,8 +92,9 @@ export const OrganizationAssignment = ({
               onRemove={() => removeItem(index)}
               collapsable
               invitedUserId={invitedUserId}
+              userType={userType}
               excludeUserAssignments={excludeUserAssignments}
-              addProjectDisabled={(openFormOrgId !== null && openFormOrgId !== org.id) || isOrganizationFormOpen}
+              disabled={(openFormOrgId !== null && openFormOrgId !== org.id) || isOrganizationFormOpen}
               onAddProjectFormToggle={handleAddProjectFormToggle}
               onExpandOrganization={onExpandOrganization}
             />
@@ -106,6 +109,7 @@ export const OrganizationAssignment = ({
       value={value as Organization}
       onChange={(updates) => updateItem(updates)}
       invitedUserId={invitedUserId}
+      userType={userType}
       excludeUserAssignments={excludeUserAssignments}
       onAddProjectFormToggle={handleAddProjectFormToggle}
       onExpandOrganization={onExpandOrganization}

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.scss
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.scss
@@ -110,3 +110,7 @@
 .tooltip-wrapper {
   width: fit-content;
 }
+
+.custom-tooltip {
+  width: 248px;
+}

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/organizationItem.tsx
@@ -26,7 +26,7 @@ import {
   Tooltip,
 } from '@reportportal/ui-kit';
 
-import { createClassnames, fetch } from 'common/utils';
+import { capitalize, createClassnames, fetch } from 'common/utils';
 import { EDITOR, MANAGER, MEMBER } from 'common/constants/projectRoles';
 import { messages } from 'common/constants/localization/invitationsLocalization';
 import { messages as assignmentMessages } from 'common/constants/localization/assignmentsLocalization';
@@ -36,6 +36,7 @@ import { ProjectsSearchesResponseData } from 'controllers/organization/projects'
 import { OrganizationType } from 'controllers/organization';
 import { idSelector } from 'controllers/user';
 import { IconsBlock } from 'pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock';
+import { useAssignmentsUtils } from 'pages/inside/common/assignments/hooks';
 
 import { PROJECTS_LIMIT } from './constants';
 import { AddItemButton } from './addItemButton';
@@ -51,7 +52,7 @@ export interface Organization {
   name: string;
   type?: OrganizationType;
   owner_id?: number;
-  isNew?: boolean,
+  isNew?: boolean;
   role: string;
   projects: Project[];
   isProjectsLoaded?: boolean;
@@ -64,8 +65,9 @@ interface OrganizationItemProps {
   onChange: (updates: Partial<Organization>) => void;
   onRemove?: () => void;
   collapsable?: boolean;
-  addProjectDisabled?: boolean;
+  disabled?: boolean;
   invitedUserId?: number | null;
+  userType?: string;
   excludeUserAssignments?: boolean;
   onAddProjectFormToggle?: (orgId: number, isOpen: boolean) => void;
   onExpandOrganization?: (orgId: number) => void;
@@ -76,8 +78,9 @@ export const OrganizationItem = ({
   onChange,
   onRemove,
   collapsable,
-  addProjectDisabled = false,
+  disabled = false,
   invitedUserId,
+  userType,
   excludeUserAssignments = false,
   onAddProjectFormToggle,
   onExpandOrganization,
@@ -193,11 +196,51 @@ export const OrganizationItem = ({
     onChange({ projects: updatedProjects });
   };
 
-  const collapseDisabled = collapsable && addProjectFormOpen;
+  const itemDisabled = disabled || addProjectFormOpen;
+  const collapseDisabled = collapsable && itemDisabled;
 
   const handleCollapsable = () => {
     if (collapseDisabled) return;
     setIsOpen(!isOpen);
+  };
+
+  const { unassignTooltip } = useAssignmentsUtils({
+    currentUserId,
+    userId: invitedUserId,
+    userType,
+    organizationType: type,
+    ownerId,
+  });
+
+  const renderRemoveButton = () => {
+    if (!onRemove) return null;
+
+    const commonTooltipMessage = assignmentMessages.unassignOrganizationUser;
+
+    const button = (
+      <BaseIconButton
+        className={cx('remove-button')}
+        onClick={onRemove}
+        disabled={!!unassignTooltip || itemDisabled}
+      >
+        <CloseIcon />
+      </BaseIconButton>
+    );
+
+    return (
+      <Tooltip
+        placement="top"
+        content={
+          unassignTooltip
+            ? `${formatMessage(unassignTooltip)}`
+            : `${capitalize(formatMessage(commonTooltipMessage))}`
+        }
+        tooltipClassName={cx('custom-tooltip')}
+        wrapperClassName={cx('tooltip-wrapper')}
+      >
+        {button}
+      </Tooltip>
+    );
   };
 
   return (
@@ -213,8 +256,10 @@ export const OrganizationItem = ({
               <DropdownIcon />
             </div>
           )}
-          <span className={cx('name-label')}>{name}</span>
-          {!!type && <IconsBlock organizationType={type} />}
+          <span className={cx('name-label', { disabled: itemDisabled })}>{name}</span>
+          {!!type && (
+            <IconsBlock organizationType={type} iconClassName={cx({ disabled: itemDisabled })} />
+          )}
         </div>
         <div className={cx('controls')}>
           <div className={cx('role-slot')}>
@@ -235,7 +280,7 @@ export const OrganizationItem = ({
               </Tooltip>
             ) : (
               <Dropdown
-                disabled={disableOrganizationRole}
+                disabled={disableOrganizationRole || itemDisabled}
                 className={cx('role')}
                 value={role}
                 options={roleOptions}
@@ -244,11 +289,7 @@ export const OrganizationItem = ({
               />
             )}
           </div>
-          {onRemove && (
-            <BaseIconButton className={cx('remove-button')} onClick={onRemove}>
-              <CloseIcon />
-            </BaseIconButton>
-          )}
+          {renderRemoveButton()}
         </div>
       </div>
       {isOpen && (
@@ -262,6 +303,7 @@ export const OrganizationItem = ({
               <ProjectItems
                 projects={projects}
                 canEditByDefault={role === MANAGER}
+                disabled={itemDisabled}
                 onChange={handleProjectChange}
                 onRemove={handleProjectRemove}
               />
@@ -282,7 +324,7 @@ export const OrganizationItem = ({
                     tooltipClassname={cx('tooltip-wrapper')}
                     onClick={() => setAddProjectFormOpen(true)}
                     tooltipContent={noProjects ? messages.noProjects : messages.allProjectsAdded}
-                    disabled={noProjects || allProjectsAdded || addProjectDisabled}
+                    disabled={noProjects || allProjectsAdded || disabled}
                     text={formatMessage(messages.addProject)}
                   />
                 )}

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/projectItems/projectItems.scss
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/projectItems/projectItems.scss
@@ -46,3 +46,7 @@
     height: 10px;
   }
 }
+
+.disabled {
+  opacity: 0.3;
+}

--- a/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/projectItems/projectItems.tsx
+++ b/app/src/pages/inside/common/assignments/organizationAssignment/organizationItem/projectItems/projectItems.tsx
@@ -35,6 +35,7 @@ export interface Project {
 interface ProjectItemsProps {
   projects: Project[];
   canEditByDefault: boolean;
+  disabled?: boolean;
   onChange: (id: number, updates: Partial<Project>) => void;
   onRemove: (id: number) => void;
 }
@@ -42,6 +43,7 @@ interface ProjectItemsProps {
 export const ProjectItems = ({
   projects = [],
   canEditByDefault,
+  disabled,
   onChange,
   onRemove,
 }: ProjectItemsProps) => {
@@ -62,13 +64,13 @@ export const ProjectItems = ({
       options={roleOptions}
       onChange={handleRoleChange(project.id)}
       variant="ghost"
-      disabled={canEditByDefault}
+      disabled={canEditByDefault || disabled}
     />
   );
 
   return projects.map((project) => (
     <div className={cx('project')} key={project.id}>
-      <div className={cx('name')}>{project.name}</div>
+      <div className={cx('name', { disabled })}>{project.name}</div>
       <div className={cx('controls')}>
         {canEditByDefault ? (
           <Tooltip
@@ -81,7 +83,11 @@ export const ProjectItems = ({
         ) : (
           renderRole(project)
         )}
-        <BaseIconButton className={cx('remove-button')} onClick={() => onRemove(project.id)}>
+        <BaseIconButton
+          className={cx('remove-button')}
+          onClick={() => onRemove(project.id)}
+          disabled={disabled}
+        >
           <CloseIcon />
         </BaseIconButton>
       </div>

--- a/app/src/pages/inside/common/assignments/utils.ts
+++ b/app/src/pages/inside/common/assignments/utils.ts
@@ -125,3 +125,37 @@ export function getManageAssignmentsInstanceChangeSet(
 
   return { removed, modified, added };
 }
+
+/** Maps org-level save condition parts to instance GA labels */
+const ORG_SAVE_CONDITION_TO_INSTANCE: Record<string, string> = {
+  [MANAGE_ASSIGNMENTS_CONDITIONS.CHANGE_ROLE]: 'change org role',
+  [MANAGE_ASSIGNMENTS_CONDITIONS.CHANGE_PERMISSION]: 'change project role',
+};
+
+function mergeOrgSaveConditionIntoSet(orgCondition: string, target: Set<string>): void {
+  if (!orgCondition) return;
+  orgCondition.split('#').forEach((part) => {
+    target.add(ORG_SAVE_CONDITION_TO_INSTANCE[part] || part);
+  });
+}
+
+export function getManageAssignmentsInstanceSaveCondition(
+  initial: OrganizationValue[],
+  current: OrganizationValue[],
+): string {
+  const { removed, added, modified } = getManageAssignmentsInstanceChangeSet(initial, current);
+  const parts = new Set<string>();
+  if (removed.length > 0) {
+    parts.add('remove organization');
+  }
+  if (added.length > 0) {
+    parts.add('add organization');
+  }
+  modified.forEach((org) => {
+    const initialOrg = initial.find((io) => io.id === org.id);
+    if (initialOrg) {
+      mergeOrgSaveConditionIntoSet(getManageAssignmentsSaveCondition(initialOrg, org), parts);
+    }
+  });
+  return [...parts].join('#');
+}

--- a/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersActionMenu/allUsersActionMenu.tsx
+++ b/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersActionMenu/allUsersActionMenu.tsx
@@ -42,6 +42,7 @@ interface User {
   email: string;
   fullName: string;
   instanceRole: string;
+  accountType: string;
   organizations: Array<{
     id: number;
     org_role: string;

--- a/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersListTable.jsx
+++ b/app/src/pages/instance/allUsersPage/allUsersListTable/allUsersListTable.jsx
@@ -88,6 +88,7 @@ export const AllUsersListTable = ({
             email: user.email,
             fullName: user.full_name,
             instanceRole: user.instance_role,
+            accountType: user.account_type,
             id: user.id,
             organizations: user.organizations,
           },

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock.jsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/iconsBlock/iconsBlock.jsx
@@ -29,7 +29,12 @@ import styles from './iconsBlock.scss';
 const cx = classNames.bind(styles);
 const THREE_MONTHS_IN_MS = 1000 * 60 * 60 * 24 * 30 * 3;
 
-export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) => {
+export const IconsBlock = ({
+  lastLaunchDate,
+  hasPermission,
+  organizationType,
+  iconClassName,
+}) => {
   const { formatMessage } = useIntl();
   const isOutdated =
     lastLaunchDate && Date.now() - new Date(lastLaunchDate).getTime() > THREE_MONTHS_IN_MS;
@@ -42,7 +47,7 @@ export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) 
           placement={'top'}
           wrapperClassName={cx('tooltip-wrapper')}
         >
-          <i className={cx('icon')}>{Parser(SynchedIcon)}</i>
+          <i className={cx('icon', iconClassName)}>{Parser(SynchedIcon)}</i>
         </Tooltip>
       ) : (
         organizationType === OrganizationType.PERSONAL && (
@@ -51,7 +56,7 @@ export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) 
             placement={'top'}
             wrapperClassName={cx('tooltip-wrapper')}
           >
-            <i className={cx('icon')}>{Parser(PersonalIcon)}</i>
+            <i className={cx('icon', iconClassName)}>{Parser(PersonalIcon)}</i>
           </Tooltip>
         )
       )}
@@ -61,7 +66,7 @@ export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) 
           placement={'top'}
           wrapperClassName={cx('tooltip-wrapper')}
         >
-          <i className={cx('icon')}>{Parser(OutdatedIcon)}</i>
+          <i className={cx('icon', iconClassName)}>{Parser(OutdatedIcon)}</i>
         </Tooltip>
       )}
     </>
@@ -70,6 +75,7 @@ export const IconsBlock = ({ lastLaunchDate, hasPermission, organizationType }) 
 
 IconsBlock.propTypes = {
   organizationType: PropTypes.string.isRequired,
-  lastLaunchDate: PropTypes.string.isRequired,
-  hasPermission: PropTypes.bool.isRequired,
+  lastLaunchDate: PropTypes.string,
+  hasPermission: PropTypes.bool,
+  iconClassName: PropTypes.string,
 };


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Links
[EPMRPP-106918](https://jiraeu.epam.com/browse/EPMRPP-106918)

## Changes

**1. Assignments UX & rules**
- Introduced **`useAssignmentsUtils`**: shared rules for when unassign/remove is blocked and which **tooltip** to show (self, UPSA + external org, personal org owner).
- **`userType` / `accountType`** is passed from **All Users** into modals and assignment components so those rules work in **Manage assignments (instance)** and **organization** flows.

**2. Disabled state while editing another row**
- Renamed **`addProjectDisabled` → `disabled`** on org rows; when another org’s form is open, the inactive row is **fully** disabled (role dropdown, projects, remove, labels).
- **`ProjectItems`** accepts **`disabled`** to match parent state.
- **`IconsBlock`** supports optional **`iconClassName`** (e.g. disabled styling); **`lastLaunchDate` / `hasPermission`** are optional in propTypes where only org type icons are shown.

**3. Manage assignments (instance) — save behavior**
- Save now runs **DELETE** for **removed** org memberships and **PUT** for **modified** ones (not only updates).
- **`getManageAssignmentsInstanceSaveCondition`** builds a **condition string** for analytics from adds/removes/role changes.

**4. Analytics**
- New GA4 helper **`manageAssignmentsSave(condition)`** on the all-users page events; fired on save when a condition is present.

## Visuals

https://github.com/user-attachments/assets/39910ba3-0fe0-4208-b33f-90b3b2a4c9c6

Disabled actions while `Add project` | `Add organization` is active:
<img width="487" height="494" alt="Screenshot 2026-03-30 161615" src="https://github.com/user-attachments/assets/b9586367-d3f2-485c-923b-eda186bef945" />
<img width="488" height="443" alt="Screenshot 2026-03-30 161602" src="https://github.com/user-attachments/assets/57bbce26-459c-4457-abb1-ce282ade3b16" />
<img width="486" height="540" alt="Screenshot 2026-03-30 162132" src="https://github.com/user-attachments/assets/6120292f-986b-4698-9629-1eeb2c332a58" />
<img width="485" height="295" alt="Screenshot 2026-03-30 162057" src="https://github.com/user-attachments/assets/6e0cfae2-0161-42f1-964e-1bc026b9419e" />
<img width="485" height="295" alt="Screenshot 2026-03-30 162031" src="https://github.com/user-attachments/assets/dc92dfed-ca01-4ac6-9dfb-3d9cd3672a78" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-aware tooltips for assignment management explaining restrictions on unassigning users.

* **Improvements**
  * Enhanced assignment management save process to handle both adding and removing user access.
  * Improved visual feedback for disabled assignment actions with updated styling.
  * Refined unassignment button behavior based on user permissions and organization context.

* **Dependencies**
  * Updated UI kit dependency to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->