### PR TITLE
 EPMRPP-108531 || Invite/Assign user to a project from Projects page

### DIFF
--- a/app/src/pages/inside/common/invitations/inviteUserModal/hooks.ts
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/hooks.ts
@@ -35,13 +35,21 @@ import { InviteUserOrganizationFormData } from './inviteUserOrganizationForm';
 import { Organization } from '../../assignments/organizationAssignment';
 import { ERROR_CODES, Level, settingsLink, settingsLinkName } from './constants';
 
-export const useInviteUser = <L extends keyof FormDataMap>(level: L) => {
+interface UseInviteUserOverrides {
+  projectId?: number;
+  projectName?: string;
+}
+
+export const useInviteUser = <L extends keyof FormDataMap>(level: L, overrides?: UseInviteUserOverrides) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const projectName = useSelector(projectNameSelector);
+  const projectNameFromStore = useSelector(projectNameSelector);
   const ssoUsersOnly = useSelector(ssoUsersOnlySelector);
   const organizationId = useSelector(activeOrganizationIdSelector) as number;
-  const projectId = useSelector(projectInfoIdSelector);
+  const projectIdFromStore = useSelector(projectInfoIdSelector);
+
+  const projectName = overrides?.projectName ?? projectNameFromStore;
+  const projectId = overrides?.projectId ?? projectIdFromStore;
 
   const okButtonTitle = formatMessage(
     ssoUsersOnly ? COMMON_LOCALE_KEYS.ASSIGN : COMMON_LOCALE_KEYS.INVITE,

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
@@ -129,10 +129,15 @@ export const InviteUser = <L extends keyof FormDataMap>({
   handleSubmit,
   dirty,
   invalid,
+  projectId,
+  projectName,
 }: InviteUserProps<L>) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const { header, okButtonTitle, buildUserData, handleError } = useInviteUser(level);
+  const { header, okButtonTitle, buildUserData, handleError } = useInviteUser(level, {
+    projectId,
+    projectName,
+  });
   const currentUser = useSelector(userInfoSelector) as UserInfo;
 
   const inviteUser = async (userData: InvitationRequestData, condition: InviteProjectCondition) => {

--- a/app/src/pages/inside/common/invitations/inviteUserModal/types.ts
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/types.ts
@@ -44,6 +44,8 @@ export type InviteProjectCondition = 'with_project' | 'without_project' | 'with_
 export type ModalProps<L extends keyof FormDataMap> = {
   level: L;
   onInvite: (condition: InviteProjectCondition) => void;
+  projectId?: number;
+  projectName?: string;
 };
 
 export type InviteUserProps<L extends keyof FormDataMap> = InjectedFormProps<FormDataMap[L]> &

--- a/app/src/pages/organization/organizationProjectsPage/projectsListTable/projectActionMenu/projectActionMenu.tsx
+++ b/app/src/pages/organization/organizationProjectsPage/projectsListTable/projectActionMenu/projectActionMenu.tsx
@@ -15,7 +15,6 @@
  */
 
 import { useDispatch, useSelector } from 'react-redux';
-import { noop } from 'es-toolkit';
 import { FC, useCallback, useMemo } from 'react';
 import { useTracking } from 'react-tracking';
 import { UserInfo, userInfoSelector } from 'controllers/user';
@@ -36,6 +35,7 @@ import { AssignProjectModal } from 'pages/inside/common/assignments';
 import { ProjectDetails } from 'pages/organization/constants';
 import { useUserPermissions } from 'hooks/useUserPermissions';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
+import { InviteUserModal, Level } from 'pages/inside/common/invitations/inviteUserModal';
 
 interface ProjectActionMenuProps {
   details: ProjectDetails;
@@ -102,6 +102,25 @@ export const ProjectActionMenu: FC<ProjectActionMenuProps> = ({ details }) => {
     );
   }, [details, dispatch, user]);
 
+  const handleInviteUserClick = useCallback(() => {
+    const onInvite = () => {
+      dispatch(fetchFilteredProjectAction());
+    };
+
+    dispatch(
+      showModalAction({
+        component: (
+          <InviteUserModal
+            level={Level.PROJECT}
+            onInvite={onInvite}
+            projectId={projectId}
+            projectName={projectName}
+          />
+        ),
+      }),
+    );
+  }, [dispatch, projectId, projectName]);
+
   const links = useMemo(
     (): LinkItem[] => [
       {
@@ -133,7 +152,7 @@ export const ProjectActionMenu: FC<ProjectActionMenuProps> = ({ details }) => {
       },
       {
         label: formatMessage(messages.actionInviteUser),
-        onClick: noop,
+        onClick: handleInviteUserClick,
         hasPermission: canInviteUserToProject,
       },
       {
@@ -156,6 +175,7 @@ export const ProjectActionMenu: FC<ProjectActionMenuProps> = ({ details }) => {
     handleRenameProjectClick,
     canRenameProject,
     canInviteUserToProject,
+    handleInviteUserClick,
     handleUnassignClick,
     handleAssignClick,
     canAssignUnassignInternalUser,


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
added functionality of invite/assign user modal from projects page (that's in organization level), so user can click on action menu in projects page then invite/assign user
Technical changes
projectActionMenu.tsx

Removed unused noop import
Added handleInviteUserClick that opens <InviteUserModal level={Level.PROJECT} projectId={...} projectName={...} /> with the row's explicit data, and refreshes the projects list on success
Replaced onClick: noop with onClick: handleInviteUserClick
types.ts

Added optional projectId? and projectName? to ModalProps — these are only meaningful at Level.PROJECT and are ignored by org/instance flows since they're optional
hooks.ts

Added UseInviteUserOverrides interface
useInviteUser now accepts an optional overrides? second argument — when projectId/projectName are provided they take precedence over the Redux store selectors. This is necessary because on the projects list page there is no active project context in the store (unlike the project team page where you navigate inside a project)
inviteUserModal.tsx

InviteUser destructures projectId and projectName from props and forwards them to useInviteUser as overrides
InviteUserModal spreads {...props} so the new fields flow through automatically with no extra wiring
## Visuals

https://github.com/user-attachments/assets/fdfffca7-d6c4-4eb5-923a-3dc7616ceaef



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Invite user" action in the project menu is now fully functional, allowing users to invite team members to specific projects directly from the project actions menu. The project list automatically refreshes after each invitation is sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->