### PR TITLE
EPMRPP-114050 || Fix overall widget preview

### DIFF
--- a/app/src/common/constants/colors.js
+++ b/app/src/common/constants/colors.js
@@ -41,4 +41,4 @@ export const COLOR_CHERRY = '#be0a0a';
 export const COLOR_DEEP_RED = '#ee0d0d';
 export const COLOR_DULL_RED = '#f56e6e';
 export const COLOR_DULL_GREEN = '#add8a2';
-export const COLOR_INTERRUPTED = '#a94442';
+export const COLOR_INTERRUPTED = '#ffc64a';

--- a/app/src/common/css/variables/colors.scss
+++ b/app/src/common/css/variables/colors.scss
@@ -49,7 +49,7 @@ $COLOR--tomato: #ed5a43;
 $COLOR--dark-pastel-green: #5cb755;
 $COLOR--violet: #c5cae9;
 $COLOR--azure: #03a9f4;
-$COLOR--blush: #f0baa9;
+$COLOR--blush: #ffc64a;
 $COLOR--silver: #d2d7da;
 $COLOR--light-yellow: #f5f9ec;
 $COLOR--orangish: #fb7848;

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetInfoBlock/widgetInfoBlock.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetInfoBlock/widgetInfoBlock.jsx
@@ -68,6 +68,14 @@ export class WidgetInfoBlock extends PureComponent {
       return;
     }
 
+    const prevSeparateInterrupted =
+      prevProps.widgetSettings.contentParameters?.widgetOptions?.separateInterrupted;
+    const nextSeparateInterrupted = contentParameters.widgetOptions?.separateInterrupted;
+    const isPanelView = contentParameters.widgetOptions?.viewMode === 'panel';
+    if (isPanelView && prevSeparateInterrupted !== nextSeparateInterrupted) {
+      this.setState({ widgetData: null, loading: true });
+    }
+
     const prevData = {
       filterIds: prevProps.widgetSettings.filterIds,
       contentParameters: prevProps.widgetSettings.contentParameters,
@@ -129,9 +137,11 @@ export class WidgetInfoBlock extends PureComponent {
       dashboardId,
     } = this.props;
     const { loading, widgetData } = this.state;
+    const widgetOptions = this.props.widgetSettings.contentParameters?.widgetOptions;
     const isSeparateInterrupted =
       activeWidget.id === OVERALL_STATISTICS &&
-      this.props.widgetSettings.contentParameters?.widgetOptions?.separateInterrupted;
+      widgetOptions?.viewMode === 'panel' &&
+      widgetOptions?.separateInterrupted;
     const isExpanded = isSeparateInterrupted && (loading || !!widgetData);
 
     return (

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetInfoBlock/widgetInfoBlock.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetInfoBlock/widgetInfoBlock.jsx
@@ -28,6 +28,7 @@ import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import ExternalLinkIcon from 'common/img/open-in-rounded-inline.svg';
 import { LinkComponent } from 'pages/inside/projectSettingsPageContainer/content/notifications/LinkComponent';
 import { injectIntl } from 'react-intl';
+import { OVERALL_STATISTICS } from 'common/constants/widgetTypes';
 import { WIDGETS_STATIC_PREVIEWS } from '../widgets';
 import { WidgetPreview } from '../widgetPreview';
 import styles from './widgetInfoBlock.scss';
@@ -128,6 +129,10 @@ export class WidgetInfoBlock extends PureComponent {
       dashboardId,
     } = this.props;
     const { loading, widgetData } = this.state;
+    const isSeparateInterrupted =
+      activeWidget.id === OVERALL_STATISTICS &&
+      this.props.widgetSettings.contentParameters?.widgetOptions?.separateInterrupted;
+    const isExpanded = isSeparateInterrupted && (loading || !!widgetData);
 
     return (
       <div className={cx('edit-widget-info-section')}>
@@ -153,6 +158,7 @@ export class WidgetInfoBlock extends PureComponent {
           loading={loading}
           widgetType={activeWidget.id}
           data={widgetData}
+          className={cx({ expanded: isExpanded })}
         />
       </div>
     );

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetPreview/widgetPreview.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetPreview/widgetPreview.jsx
@@ -31,6 +31,7 @@ export class WidgetPreview extends PureComponent {
     data: PropTypes.object,
     loading: PropTypes.bool,
     defaultPreview: PropTypes.any,
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ export class WidgetPreview extends PureComponent {
     defaultPreview: null,
     data: null,
     loading: false,
+    className: '',
   };
 
   constructor(props) {
@@ -85,7 +87,7 @@ export class WidgetPreview extends PureComponent {
   render = () => (
     <div
       ref={this.widgetContainerRef}
-      className={cx('widget-preview', { table: !!this.getWidgetStaticPreview() })}
+      className={cx('widget-preview', { table: !!this.getWidgetStaticPreview() }, this.props.className)}
     >
       {this.getWidgetContent()}
     </div>

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetPreview/widgetPreview.scss
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetPreview/widgetPreview.scss
@@ -31,4 +31,13 @@
       height: 125px;
     }
   }
+
+  &.expanded {
+    height: 190px;
+
+    svg {
+      height: 190px;
+      max-height: 190px;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

* Fixed color of `Interrupted` according to the Figma mockup
* Fixed height of Overall widget preview for checked "Show the "Interrupted" status independently from "Failed" items"

## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<img width="996" height="835" alt="image" src="https://github.com/user-attachments/assets/6a1c88ba-3246-4a0e-9185-4c620be827e2" />

<img width="995" height="827" alt="image" src="https://github.com/user-attachments/assets/e2470b05-a666-4bc3-8a34-c03070a41ed2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widget previews now support expanded view mode for Overall Statistics widgets in panel view

* **Style**
  * Updated interrupted state color to gold throughout the application
  * Enhanced widget preview sizing in expanded mode with increased height for improved visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->