### PR TITLE
EPMRPP-114082 || "Invite user" option is missing for Member-editor

### DIFF
--- a/app/src/pages/inside/common/assignments/utils.ts
+++ b/app/src/pages/inside/common/assignments/utils.ts
@@ -31,7 +31,7 @@ export function resolveUserRolesForProjectRow(
 ): UserRolesSnapshot {
   return {
     ...base,
-    projectRole:rowProjectRole || base.projectRole,
+    projectRole: rowProjectRole || base.projectRole,
   };
 }
 

--- a/app/src/pages/inside/common/assignments/utils.ts
+++ b/app/src/pages/inside/common/assignments/utils.ts
@@ -1,4 +1,5 @@
 import { EDITOR, VIEWER } from 'common/constants/projectRoles';
+import type { OrganizationRoles, ProjectRoles, UserRoles } from 'types/roles';
 import { OrganizationUserInfo } from 'controllers/user/types';
 import type {
   UpdateUserAssignmentsPayload,
@@ -16,6 +17,22 @@ export function normalizeProjectRole(projectRole: string): string {
   if (projectRole === EDITOR || projectRole === VIEWER) return projectRole;
   const role = (projectRole ?? '').toUpperCase();
   return role === EDITOR || role.includes('EDIT') ? EDITOR : VIEWER;
+}
+
+export type UserRolesSnapshot = {
+  userRole: UserRoles;
+  organizationRole: OrganizationRoles;
+  projectRole: ProjectRoles;
+};
+
+export function resolveUserRolesForProjectRow(
+  base: UserRolesSnapshot,
+  rowProjectRole: ProjectRoles,
+): UserRolesSnapshot {
+  return {
+    ...base,
+    projectRole:rowProjectRole ?? base.projectRole,
+  };
 }
 
 export function mapProjectsFromResponse(

--- a/app/src/pages/inside/common/assignments/utils.ts
+++ b/app/src/pages/inside/common/assignments/utils.ts
@@ -27,11 +27,11 @@ export type UserRolesSnapshot = {
 
 export function resolveUserRolesForProjectRow(
   base: UserRolesSnapshot,
-  rowProjectRole: ProjectRoles,
+  rowProjectRole?: ProjectRoles | '',
 ): UserRolesSnapshot {
   return {
     ...base,
-    projectRole:rowProjectRole ?? base.projectRole,
+    projectRole:rowProjectRole || base.projectRole,
   };
 }
 

--- a/app/src/pages/organization/constants.ts
+++ b/app/src/pages/organization/constants.ts
@@ -1,8 +1,10 @@
+import { ProjectRoles } from 'types/roles';
+
 export interface ProjectDetails {
   projectName: string;
   projectKey: string;
   projectId: number;
   projectSlug: string;
-  projectRole: string;
+  projectRole: ProjectRoles;
   organizationSlug: string;
 }

--- a/app/src/pages/organization/organizationProjectsPage/projectsListTable/projectActionMenu/projectActionMenu.tsx
+++ b/app/src/pages/organization/organizationProjectsPage/projectsListTable/projectActionMenu/projectActionMenu.tsx
@@ -19,6 +19,7 @@ import { FC, useCallback, useMemo } from 'react';
 import { useTracking } from 'react-tracking';
 import { UserInfo, userInfoSelector } from 'controllers/user';
 import { showModalAction } from 'controllers/modal';
+import {canRenameProject as canRenameProjectPermission, canInviteUserToProject as canInviteUserToProjectPermission, canAssignUnassignInternalUser as canAssignUnassignInternalUserPermission } from 'common/utils/permissions';
 import {
   deleteProjectAction,
   fetchFilteredProjectAction,
@@ -33,11 +34,13 @@ import { ActionItem, ActionMenu, LinkItem } from 'components/actionMenu';
 import { UnassignProjectModal } from 'pages/inside/common/assignments/unassignProjectModal';
 import { AssignProjectModal } from 'pages/inside/common/assignments';
 import { ProjectDetails } from 'pages/organization/constants';
-import { useUserPermissions } from 'hooks/useUserPermissions';
 import { ssoUsersOnlySelector } from 'controllers/appInfo';
 import { PROJECTS_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/projectsPageEvents';
 import { InviteUserModal, Level } from 'pages/inside/common/invitations/inviteUserModal';
 import { ORGANIZATION_PAGE_EVENTS } from 'analyticsEvents/organizationsPageEvents';
+import { userRolesSelector } from 'controllers/pages';
+import { resolveUserRolesForProjectRow } from 'pages/inside/common/assignments/utils';
+import { useUserPermissions } from 'hooks/useUserPermissions';
 
 interface ProjectActionMenuProps {
   details: ProjectDetails;
@@ -46,12 +49,23 @@ interface ProjectActionMenuProps {
 export const ProjectActionMenu: FC<ProjectActionMenuProps> = ({ details }) => {
   const { projectName, projectKey, projectId, projectSlug, projectRole, organizationSlug } =
     details;
+  const userRoles = useSelector(userRolesSelector);
   const {
     canRenameProject,
     canInviteUserToProject,
     canDeleteProject,
     canAssignUnassignInternalUser,
   } = useUserPermissions();
+
+  const projectRowPermissions = useMemo(() => {
+    const roles = resolveUserRolesForProjectRow(userRoles, projectRole);
+    return {
+      canRenameProject: canRenameProjectPermission(roles),
+      canInviteUserToProject: canInviteUserToProjectPermission(roles),
+      canAssignUnassignInternalUser: canAssignUnassignInternalUserPermission(roles),
+    };
+  }, [projectRole, userRoles]);
+
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
@@ -163,19 +177,19 @@ export const ProjectActionMenu: FC<ProjectActionMenuProps> = ({ details }) => {
       {
         label: formatMessage(COMMON_LOCALE_KEYS.RENAME),
         onClick: handleRenameProjectClick,
-        hasPermission: canRenameProject,
+        hasPermission: projectRowPermissions.canRenameProject ?? canRenameProject,
       },
       {
         label: formatMessage(messages.actionInviteUser),
         onClick: handleInviteUserClick,
-        hasPermission: canInviteUserToProject,
+        hasPermission: projectRowPermissions.canInviteUserToProject ?? canInviteUserToProject,
       },
       {
         label: isAssigned
           ? formatMessage(COMMON_LOCALE_KEYS.UNASSIGN)
           : formatMessage(COMMON_LOCALE_KEYS.ASSIGN),
         onClick: isAssigned ? handleUnassignClick : handleAssignClick,
-        hasPermission: canAssignUnassignInternalUser,
+        hasPermission: projectRowPermissions.canAssignUnassignInternalUser ?? canAssignUnassignInternalUser,
       },
       {
         label: formatMessage(COMMON_LOCALE_KEYS.DELETE),
@@ -188,8 +202,7 @@ export const ProjectActionMenu: FC<ProjectActionMenuProps> = ({ details }) => {
     projectRole,
     formatMessage,
     handleRenameProjectClick,
-    canRenameProject,
-    canInviteUserToProject,
+    projectRowPermissions,
     handleInviteUserClick,
     handleUnassignClick,
     handleAssignClick,


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
created util function, which will help set the correct permissions depending on project role in organization level where project role is undefined, cause selectors don't know about current project 

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for project role handling across project listings.
  * Added a user-roles snapshot/resolution to consistently derive roles for project rows.
  * Updated project-row permission checks so rename, invite, and assign/unassign actions reflect accurate, per-row access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->