### PR TITLE
EPMRPP-113300 || [UI] Non-Admin user can open some inaccessible pages using direct links

### DIFF
--- a/app/src/store/organizationProjectRouteMiddleware.js
+++ b/app/src/store/organizationProjectRouteMiddleware.js
@@ -19,8 +19,11 @@ import { userInfoSelector, activeProjectSelector, setActiveProjectAction } from 
 import { isAuthorizedSelector } from 'controllers/auth';
 import {
   ORGANIZATION_USERS_PAGE,
+  ORGANIZATIONS_PAGE,
+  adminPageNames,
   userAssignedSelector,
   userRolesSelector,
+  PLUGIN_UI_EXTENSION_ADMIN_PAGE,
 } from 'controllers/pages';
 import { prepareActiveProjectAction } from 'controllers/project';
 import {
@@ -29,7 +32,11 @@ import {
 } from 'controllers/organization';
 import { getRedirectRoute, ROUTE_ACTION_TYPES } from 'routes/routesMap';
 import { stringEqual } from 'common/utils/stringUtils';
-import { canSeeOrganizationMembers } from 'common/utils/permissions';
+import {
+  canSeeOrganizationMembers,
+  canSeeSidebarOptions,
+  canSeeInstanceLevelPluginsPages,
+} from 'common/utils/permissions';
 
 /**
  * Organization/project route middleware: access check, sync of active org/project from URL, redirect on no access.
@@ -47,6 +54,20 @@ export const organizationProjectRouteMiddleware = (store) => (next) => (action) 
   } = action.payload || {};
 
   const authorized = isAuthorizedSelector(getState());
+  const isAdminPage = action.type in adminPageNames;
+
+  if (authorized && isAdminPage) {
+    const hasInstanceLevelAccess =
+      action.type === PLUGIN_UI_EXTENSION_ADMIN_PAGE
+        ? canSeeInstanceLevelPluginsPages(userRolesSelector(getState()))
+        : canSeeSidebarOptions(userRolesSelector(getState()));
+
+    if (!hasInstanceLevelAccess) {
+      dispatch(redirect({ type: ORGANIZATIONS_PAGE }));
+      return;
+    }
+  }
+
   const isOrganizationPage = !!hashOrganizationSlug;
   const isOrganizationUsersPage = action.type === ORGANIZATION_USERS_PAGE;
 


### PR DESCRIPTION
… using direct links

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
<img width="689" height="359" alt="image" src="https://github.com/user-attachments/assets/a14f5a0b-7b6d-4a18-af0e-fc6285187b60" />


<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened admin-page access checks to verify instance-level permissions and redirect unauthorized users to the organizations page, preventing further navigation.
  * Preserved existing organization/project permission flows for non-admin routes and when instance-level access is granted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->