### PR TITLE
EPMRPP-108398 || Organization retention settings adjustments

### DIFF
--- a/app/src/controllers/organization/sagas.js
+++ b/app/src/controllers/organization/sagas.js
@@ -100,7 +100,7 @@ function* prepareActiveOrganizationSettings({ payload: { organizationSlug } }) {
   });
 }
 
-function* updateOrganizationSettings({ payload: { organizationId, retentionPolicy } }) {
+function* updateOrganizationSettings({ payload: { organizationId, retentionPolicy, onComplete } }) {
   try {
     yield call(fetch, URLS.organizationSettings(organizationId), {
       method: 'put',
@@ -112,6 +112,8 @@ function* updateOrganizationSettings({ payload: { organizationId, retentionPolic
     yield put(showSuccessNotification({ messageId: 'updateOrganizationSettingsSuccess' }));
   } catch ({ message }) {
     yield put(showDefaultErrorNotification({ message }));
+  } finally {
+    onComplete?.();
   }
 }
 

--- a/app/src/pages/inside/projectSettingsPageContainer/generalTab/generalTab.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/generalTab/generalTab.jsx
@@ -226,9 +226,9 @@ export class GeneralTab extends Component {
     const { attachments, launches, logs } = this.props.organizationSettings;
 
     return {
-      keepLaunches: launches?.period ? daysToSeconds(launches.period) : null,
-      keepLogs: logs?.period ? daysToSeconds(logs.period) : null,
-      keepScreenshots: attachments?.period ? daysToSeconds(attachments.period) : null,
+      keepLaunches: launches?.period ?? null,
+      keepLogs: logs?.period ?? null,
+      keepScreenshots: attachments?.period ?? null,
     };
   };
 

--- a/app/src/pages/organization/organizationSettingsPage/content/generalTab/generalTab.jsx
+++ b/app/src/pages/organization/organizationSettingsPage/content/generalTab/generalTab.jsx
@@ -18,7 +18,7 @@ import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTracking } from 'react-tracking';
 import PropTypes from 'prop-types';
-import { BubblesLoader, Button, FieldText, SystemMessage, Dropdown } from '@reportportal/ui-kit';
+import { Button, FieldText, SystemMessage, Dropdown } from '@reportportal/ui-kit';
 import classNames from 'classnames/bind';
 import { useIntl } from 'react-intl';
 import { FieldElement } from 'pages/inside/projectSettingsPageContainer/content/elements';
@@ -61,7 +61,7 @@ const GeneralTabForm = ({ initialize, handleSubmit, retention = null }) => {
     formValues,
     retention,
   );
-  const isDisabled = !canUpdateOrganizationSettings || processingData;
+  const isDisabled = !canUpdateOrganizationSettings;
 
   useEffect(() => {
     if (organizationName) {
@@ -136,17 +136,9 @@ const GeneralTabForm = ({ initialize, handleSubmit, retention = null }) => {
           <Dropdown className={cx('dropdown')} options={getScreenshotsOptions()} mobileDisabled />
         </FieldElement>
         <div className={cx('submit-block')}>
-          <Button type="submit" disabled={isDisabled}>
+          <Button type="submit" disabled={isDisabled || processingData}>
             {formatMessage(COMMON_LOCALE_KEYS.SUBMIT)}
           </Button>
-          {processingData && (
-            <div className={cx('preloader-block')}>
-              <BubblesLoader className={cx('preloader')} />
-              <span className={cx('preloader-text')}>
-                {formatMessage(COMMON_LOCALE_KEYS.processData)}
-              </span>
-            </div>
-          )}
         </div>
       </form>
     </div>

--- a/app/src/pages/organization/organizationSettingsPage/content/generalTab/generalTab.jsx
+++ b/app/src/pages/organization/organizationSettingsPage/content/generalTab/generalTab.jsx
@@ -30,7 +30,6 @@ import {
   activeOrganizationSettingsSelector,
 } from 'controllers/organization';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
-import { SpinningPreloader } from 'components/preloaders/spinningPreloader';
 import { settingsMessages } from 'common/constants/localization/settingsLocalization';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
 import { useUserPermissions } from 'hooks/useUserPermissions';
@@ -43,7 +42,10 @@ const cx = classNames.bind(styles);
 
 const selector = formValueSelector(GENERAL_TAB_FORM);
 
-const GeneralTabForm = ({ initialize, handleSubmit }) => {
+const getMinRetentionValue = (value, retention) =>
+  retention === null || retention > value || retention === 0 ? value : retention;
+
+const GeneralTabForm = ({ initialize, handleSubmit, retention = null }) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const { trackEvent } = useTracking();
@@ -51,27 +53,29 @@ const GeneralTabForm = ({ initialize, handleSubmit }) => {
   const organizationName = useSelector(activeOrganizationNameSelector);
   const { attachments, launches, logs } = useSelector(activeOrganizationSettingsSelector);
   const { canUpdateOrganizationSettings } = useUserPermissions();
-  const [processingData] = useState(false);
-  const [isLoading] = useState(false);
+  const [processingData, setProcessingData] = useState(false);
   const formValues = useSelector((state) =>
     selector(state, 'keepLaunches', 'keepLogs', 'keepScreenshots'),
   );
-  const { getLaunchesOptions, getLogOptions, getScreenshotsOptions } =
-    useRetentionUtils(formValues);
+  const { getLaunchesOptions, getLogOptions, getScreenshotsOptions } = useRetentionUtils(
+    formValues,
+    retention,
+  );
   const isDisabled = !canUpdateOrganizationSettings || processingData;
 
   useEffect(() => {
     if (organizationName) {
       initialize({
         name: organizationName,
-        keepLaunches: launches?.period || 0,
-        keepLogs: logs?.period || 0,
-        keepScreenshots: attachments?.period || 0,
+        keepLaunches: getMinRetentionValue(launches?.period ?? 0, retention),
+        keepLogs: getMinRetentionValue(logs?.period ?? 0, retention),
+        keepScreenshots: getMinRetentionValue(attachments?.period ?? 0, retention),
       });
     }
-  }, [attachments, initialize, launches, logs, organizationName]);
+  }, [attachments, initialize, launches, logs, organizationName, retention]);
 
   const onFormSubmit = (formData) => {
+    setProcessingData(true);
     const { keepLaunches, keepLogs, keepScreenshots } = formData;
 
     const retentionPolicy = {
@@ -80,13 +84,17 @@ const GeneralTabForm = ({ initialize, handleSubmit }) => {
       attachments: { ...attachments, period: keepScreenshots },
     };
 
-    dispatch(updateOrganizationSettingsAction({ organizationId, retentionPolicy }));
+    dispatch(
+      updateOrganizationSettingsAction({
+        organizationId,
+        retentionPolicy,
+        onComplete: () => setProcessingData(false),
+      }),
+    );
     trackEvent(ORGANIZATION_PAGE_EVENTS.updateOrganizationSettings(formData));
   };
 
-  return isLoading ? (
-    <SpinningPreloader />
-  ) : (
+  return (
     <div className={cx('general-tab')}>
       <form className={cx('form')} onSubmit={handleSubmit(onFormSubmit)}>
         <SystemMessage header={formatMessage(messages.informationTitle)}>
@@ -148,6 +156,7 @@ const GeneralTabForm = ({ initialize, handleSubmit }) => {
 GeneralTabForm.propTypes = {
   initialize: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  retention: PropTypes.number,
 };
 
 export const GeneralTab = reduxForm({

--- a/app/src/pages/organization/organizationSettingsPage/content/generalTab/hooks.js
+++ b/app/src/pages/organization/organizationSettingsPage/content/generalTab/hooks.js
@@ -14,22 +14,41 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import { settingsMessages } from 'common/constants/localization/settingsLocalization';
-import { humanizeDays } from 'common/utils';
+import { daysToSeconds, secondsToDays } from 'common/utils';
 import { useIntl } from 'react-intl';
 
-export const useRetentionUtils = (formValues) => {
+export const useRetentionUtils = (formValues, retention) => {
   const { locale, formatMessage } = useIntl();
 
-  const baseOptions = [
-    { label: formatMessage(settingsMessages.week1), value: 7 },
-    { label: formatMessage(settingsMessages.week2), value: 14 },
-    { label: formatMessage(settingsMessages.week3), value: 21 },
-    { label: formatMessage(settingsMessages.month1), value: 30 },
-    { label: formatMessage(settingsMessages.month3), value: 90 },
-    { label: formatMessage(settingsMessages.month6), value: 180 },
-    { label: formatMessage(settingsMessages.forever), value: 0 },
-  ];
+  const baseOptions = useMemo(() => {
+    const retentionOptions = [
+      { label: formatMessage(settingsMessages.week1), value: daysToSeconds(7) },
+      { label: formatMessage(settingsMessages.week2), value: daysToSeconds(14) },
+      { label: formatMessage(settingsMessages.week3), value: daysToSeconds(21) },
+      { label: formatMessage(settingsMessages.month1), value: daysToSeconds(30) },
+      { label: formatMessage(settingsMessages.month3), value: daysToSeconds(90) },
+      { label: formatMessage(settingsMessages.month6), value: daysToSeconds(180) },
+      { label: formatMessage(settingsMessages.forever), value: 0 },
+    ];
+
+    if (!retention || retention === 0) {
+      return retentionOptions;
+    }
+
+    const options = retentionOptions.filter(
+      (option) => option.value <= retention && option.value !== 0,
+    );
+    if ((options.length && options[options.length - 1].value !== retention) || !options.length) {
+      options.push({
+        label: secondsToDays(retention, locale),
+        value: retention,
+      });
+    }
+
+    return options;
+  }, [formatMessage, retention, locale]);
 
   const sortValues = (a, b) => {
     if (a.value === 0) {
@@ -47,7 +66,9 @@ export const useRetentionUtils = (formValues) => {
     const options = [...baseOptions];
 
     if (!options.some((elem) => elem.value === value)) {
-      options.push({ label: humanizeDays(value, locale), value });
+      const label =
+        value === 0 ? formatMessage(settingsMessages.forever) : secondsToDays(value, locale);
+      options.push({ label, value });
       options.sort(sortValues);
     }
 


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Project settings — General tab (`projectSettingsPageContainer/generalTab`)**  
Organization-level limits used for project retention dropdowns are read from `organizationSettings` (`launches`, `logs`, `attachments` → `period`). Previously those values were passed through `daysToSeconds()`, which incorrectly assumed **days** and effectively **doubled** the conversion when the API already returned **seconds**. That extra conversion was **removed**: limits are now used **as returned by the API** (seconds).

**Organization settings — General tab (`organizationSettingsPage/content/generalTab`)**  
- Form initialization uses `period` from the loaded organization retention policy **in seconds**, combined with an optional **`retention`** cap (plan limit, also in seconds): `getMinRetentionValue` clamps stored values to the plan when the plan is stricter.  
- The tab accepts an optional **`retention`** prop (from the billing plugin) for that cap.  
- **Loading UX**: the tab no longer shows a standalone full-page `SpinningPreloader` here; loading of plan data is handled by the plugin wrapper.
- **Submit UX**: `processingData` is set while the update request runs; the saga is given an **`onComplete`** callback so the UI can clear that state when the request finishes (success or error).

**Organization General — retention hooks (`hooks.js`)**  
- Dropdown **values** for presets use **`daysToSeconds(...)`** so stored/submitted values stay in **seconds**.  
- Labels use **`secondsToDays`** (and “Forever” for `0`) instead of treating raw numbers as days (`humanizeDays`).  
- When a **plan retention** is provided and non-zero, the base option list is **filtered** to options not above the plan, and a synthetic option is added for the exact plan limit when needed—matching the same pattern as project settings when organization limits apply.

**NOTE:** The logic is similar to the current RP version: [GeneralTab (feature/upcoming)](https://github.com/reportportal/service-ui/blob/feature/upcoming/app/src/pages/inside/projectSettingsPageContainer/generalTab/generalTab.jsx)

**Organization sagas (`controllers/organization/sagas.js`)**  
- **`updateOrganizationSettings`** accepts an optional **`onComplete`** in the action payload and invokes it in a **`finally`** block so the UI can always reset loading/submit state after the PUT completes.

## Links
[EPMRPP-108398](https://jiraeu.epam.com/browse/EPMRPP-108398)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed retention limit calculation to properly preserve zero and falsy values instead of converting them to null

* **Improvements**
  * Refactored organization settings form to use disabled button states instead of loading overlays for cleaner UX
  * Updated retention configuration options to dynamically reflect organization limits
  * Enhanced form submission handling with improved callback mechanism for post-completion actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->