### PR TITLE
EPMRPP-111151 || Page is refreshed automatically after clicking on to…

### DIFF
--- a/app/src/components/integrations/elements/bts/btsPropertiesForIssueForm/btsPropertiesForIssueForm.jsx
+++ b/app/src/components/integrations/elements/bts/btsPropertiesForIssueForm/btsPropertiesForIssueForm.jsx
@@ -79,7 +79,13 @@ const ShowWithPopover = ({ formatMessage }) => (
     arrowColor="white"
     content={<div className={cx('popover')}>{formatMessage(messages.tooltip)}</div>}
   >
-    <IconShow />
+    <button
+      type="button"
+      className={cx('show-popover-trigger')}
+      aria-label={formatMessage(messages.tooltip)}
+    >
+      <IconShow />
+    </button>
   </Popover>
 );
 ShowWithPopover.propTypes = {

--- a/app/src/components/integrations/elements/bts/btsPropertiesForIssueForm/btsPropertiesForIssueForm.scss
+++ b/app/src/components/integrations/elements/bts/btsPropertiesForIssueForm/btsPropertiesForIssueForm.scss
@@ -66,6 +66,15 @@
   }
 }
 
+.show-popover-trigger {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
 .checkbox-wrapper {
   position: absolute;
   top: 40px;


### PR DESCRIPTION
…oltip in BTS integration

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

git push --set-upstream origin bugfix/EPMRPP-111151-page_is_refreshed_automatically_after_clicking_on_tooltip_in_bts_integration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility in the issue properties form by adding proper aria-labeling to the popover trigger and converting it from a non-interactive element to a properly interactive button control.

* **Style**
  * Added CSS styling for the popover trigger button that removes default button styling while maintaining flex layout, centered alignment, and appropriate cursor feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->