### PR TITLE
EPMRPP-114326 || Wrong filter is applied when clicking on Defect type chart in "Cumulative trend chart" widget

### DIFF
--- a/app/src/components/widgets/multiLevelWidgets/cumulativeTrendChart/cumulativeTrendChart.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/cumulativeTrendChart/cumulativeTrendChart.jsx
@@ -376,6 +376,7 @@ export class CumulativeTrendChart extends PureComponent {
       });
     } else {
       link = getStatisticsLink({
+        ...(selectedDefectLocators?.length && { defects: selectedDefectLocators }),
         statuses: selectedStatus ? [selectedStatus] : [PASSED, FAILED, SKIPPED, INTERRUPTED],
         levelAttribute: activeAttributes.map(formatAttribute).join(','),
         launchesLimit: widget.contentParameters.itemsCount,

--- a/app/src/controllers/testItem/selectors.js
+++ b/app/src/controllers/testItem/selectors.js
@@ -320,6 +320,7 @@ export const statisticsLinkSelector = createSelector(
       baselineLaunchId,
       launchId,
       statuses,
+      defects,
       startTime,
       types,
     } = ownProps;
@@ -349,6 +350,9 @@ export const statisticsLinkSelector = createSelector(
     };
     if (statuses) {
       params['filter.in.status'] = statuses.join(',');
+    }
+    if (defects?.length) {
+      params['filter.in.issueType'] = getDefectsString(defects);
     }
     if (startTime) {
       params['filter.btw.startTime'] = startTime.join(',');


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description 
passing defects to link selector to have the passed filter in the list page 
 

## Visuals 

https://github.com/user-attachments/assets/773f6dfe-47a5-4004-94d7-64d55b73a9f2


