### PR TITLE
EPMRPP-113986 || Organizations. Fix routing in navigation via the bre…

### DIFF
--- a/app/src/pages/organization/organizationUsersPage/organizationUsersPageHeader/organizationUsersPageHeader.jsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersPageHeader/organizationUsersPageHeader.jsx
@@ -19,6 +19,7 @@ import classNames from 'classnames/bind';
 import { useIntl } from 'react-intl';
 import { NAMESPACE, SEARCH_KEY } from 'controllers/organization/users';
 import { ORGANIZATION_PROJECTS_PAGE, ORGANIZATIONS_PAGE } from 'controllers/pages/constants';
+import { urlOrganizationSlugSelector } from 'controllers/pages';
 import { SearchField } from 'components/fields/searchField';
 import { withFilter } from 'controllers/filter';
 import { useSelector } from 'react-redux';
@@ -45,7 +46,8 @@ export const OrganizationUsersPageHeader = ({
 }) => {
   const { formatMessage } = useIntl();
   const organization = useSelector(activeOrganizationSelector);
-  const organizationSlug = organization?.name;
+  const organizationName = organization?.name;
+  const organizationSlug = useSelector(urlOrganizationSlugSelector);
 
   const breadcrumbs = [
     {
@@ -56,7 +58,7 @@ export const OrganizationUsersPageHeader = ({
 
   if (organizationSlug) {
     breadcrumbs.push({
-      title: organizationSlug,
+      title: organizationName,
       link: { type: ORGANIZATION_PROJECTS_PAGE, payload: { organizationSlug } },
     });
   }

--- a/app/src/pages/organization/projectTeamPage/projectTeamPageHeader/projectTeamPageHeader.jsx
+++ b/app/src/pages/organization/projectTeamPage/projectTeamPageHeader/projectTeamPageHeader.jsx
@@ -19,7 +19,11 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { Button, FilterOutlineIcon } from '@reportportal/ui-kit';
-import { ORGANIZATION_PROJECTS_PAGE, ORGANIZATIONS_PAGE, PROJECT_MEMBERS_PAGE } from 'controllers/pages/constants';
+import {
+  ORGANIZATION_PROJECTS_PAGE,
+  ORGANIZATIONS_PAGE,
+  PROJECT_DASHBOARD_PAGE,
+} from 'controllers/pages/constants';
 import { useIntl } from 'react-intl';
 import { projectMembersSelector, projectNameSelector } from 'controllers/project';
 import { SearchField } from 'components/fields/searchField';
@@ -28,6 +32,7 @@ import { withFilter } from 'controllers/filter';
 import { PROJECT_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/projectPageEvents';
 import { ssoUsersOnlySelector } from 'controllers/appInfo';
 import { activeOrganizationNameSelector } from 'controllers/organization';
+import { urlOrganizationSlugSelector, urlProjectSlugSelector } from 'controllers/pages';
 import { LocationHeaderLayout } from 'layouts/locationHeaderLayout';
 import { messages } from '../../messages';
 import styles from './projectTeamPageHeader.scss';
@@ -46,10 +51,12 @@ export const ProjectTeamPageHeader = ({
   setSearchValue,
 }) => {
   const { formatMessage } = useIntl();
-  const projectSlug = useSelector(projectNameSelector);
+  const projectName = useSelector(projectNameSelector);
   const ssoOnlyEnabled = useSelector(ssoUsersOnlySelector);
-  
-  const organizationSlug = useSelector(activeOrganizationNameSelector);
+
+  const organizationName = useSelector(activeOrganizationNameSelector);
+  const organizationSlug = useSelector(urlOrganizationSlugSelector);
+  const projectSlug = useSelector(urlProjectSlugSelector);
   const isNotEmptyMembers = useSelector(projectMembersSelector).length > 0;
 
   const rootCrumb = {
@@ -59,14 +66,14 @@ export const ProjectTeamPageHeader = ({
   };
 
   const organizationCrumb = {
-    title: organizationSlug,
+    title: organizationName,
     link: { type: ORGANIZATION_PROJECTS_PAGE, payload: { organizationSlug } },
     children: []
   };
 
   const projectCrumb = {
-    title: projectSlug,
-    link: { type: PROJECT_MEMBERS_PAGE, payload: { organizationSlug, projectSlug } },
+    title: projectName,
+    link: { type: PROJECT_DASHBOARD_PAGE, payload: { organizationSlug, projectSlug } },
   };
 
   let lastCrumb = rootCrumb;


### PR DESCRIPTION
…adcrumbs

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

![Recording 2026-04-10 200808](https://github.com/user-attachments/assets/0b81882e-8bc0-4c9d-95c9-ad4c7a7c6191)
![Recording 2026-04-10 200947](https://github.com/user-attachments/assets/3ef6270f-68de-4eb3-a36c-663fa4fcc947)
![Recording 2026-04-10 201059](https://github.com/user-attachments/assets/13eeee03-ebb2-45bf-9d1d-bf0593bf660d)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization breadcrumbs now display the full organization name instead of slug for improved clarity.
  * Project breadcrumbs now navigate to the project dashboard instead of the team members page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->