### PR TITLE
EPMRPP-114365 || Wrong filter is applied when clicking on Failed chart in "Cumulative trend chart" widget 

### DIFF
--- a/app/src/components/widgets/multiLevelWidgets/cumulativeTrendChart/cumulativeTrendChart.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/cumulativeTrendChart/cumulativeTrendChart.jsx
@@ -375,9 +375,17 @@ export class CumulativeTrendChart extends PureComponent {
         filterType: true,
       });
     } else {
+      let statisticsStatuses;
+      if (!selectedStatus) {
+        statisticsStatuses = [PASSED, FAILED, SKIPPED, INTERRUPTED];
+      } else if (selectedStatus === FAILED) {
+        statisticsStatuses = [FAILED, INTERRUPTED];
+      } else {
+        statisticsStatuses = [selectedStatus];
+      }
       link = getStatisticsLink({
         ...(selectedDefectLocators?.length && { defects: selectedDefectLocators }),
-        statuses: selectedStatus ? [selectedStatus] : [PASSED, FAILED, SKIPPED, INTERRUPTED],
+        statuses: statisticsStatuses,
         levelAttribute: activeAttributes.map(formatAttribute).join(','),
         launchesLimit: widget.contentParameters.itemsCount,
         providerType: PROVIDER_TYPE_WIDGET,


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
now after clicking "show filter "of failed status , the failed and interrupted status are applied to list

## Visuals

https://github.com/user-attachments/assets/8d26fab5-1707-487f-84ca-6dec1b98bb03