### PR TITLE
EPMRPP-114184 || Extra focusing on "+Add attribute" button is displayed when working using keyboard

### DIFF
--- a/app/src/componentLibrary/attributeList/attributeList.jsx
+++ b/app/src/componentLibrary/attributeList/attributeList.jsx
@@ -336,7 +336,7 @@ export const AttributeList = ({
         {!hasEditedAttribute && !disabled && showButton && attributes.length < maxLength && (
           <Button
             refCallback={addNewAttButtonRefCb}
-            className={cx('button-focused', addButtonClassName)}
+            className={cx(addButtonClassName)}
             icon={Parser(PlusIcon)}
             onClick={onAddNew}
             variant={'text'}

--- a/app/src/componentLibrary/attributeList/attributeList.scss
+++ b/app/src/componentLibrary/attributeList/attributeList.scss
@@ -30,18 +30,3 @@
 .editable-attribute {
   margin-top: 16px;
 }
-
-.button-focused:focus:not(:active) {
-  position: relative;
-
-  &:not(:hover):after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 85%;
-    border-radius: 6px;
-    border: 2px solid $COLOR--topaz-focused;
-  }
-}

--- a/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.scss
+++ b/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.scss
@@ -91,7 +91,9 @@
   &:hover {
     background-color: $COLOR--bg-100;
   }
+}
 
+.item {
   &.active:not(:hover) {
     border: 1px solid $COLOR--topaz-focused;
     padding: 3px 11px;

--- a/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.scss
+++ b/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.scss
@@ -61,6 +61,11 @@
   width: 100%;
   font-family: $FONT-ROBOTO-MEDIUM;
   font-size: 13px;
+
+  &.active:not(:hover) {
+    border: 1px solid $COLOR--topaz-focused;
+    padding: 3px 11px;
+  }
 }
 
 .divider {
@@ -90,13 +95,6 @@
   &.active,
   &:hover {
     background-color: $COLOR--bg-100;
-  }
-}
-
-.item {
-  &.active:not(:hover) {
-    border: 1px solid $COLOR--topaz-focused;
-    padding: 3px 11px;
   }
 }
 


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<img width="478" height="205" alt="single-border-on-focus" src="https://github.com/user-attachments/assets/ccfd5bc6-a152-4199-a20b-577d39988f62" />
<img width="527" height="343" alt="borderless-new-value" src="https://github.com/user-attachments/assets/cd786504-dffd-4f8d-a2d1-0f3950c37c93" />

## Stories

- Extra focusing on "+Add attribute" button is displayed when working using keyboard
- Extra focusing on "+ New key"/"+ New value" row is displayed when working using mouse only



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed the special focus ring from the "Add attribute" button to simplify its focus appearance.
  * Refined active-state visuals for autocomplete options so only standard items show the topaz border/padding when active (new-item variants no longer receive that treatment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->