### PR TITLE
EPMRPP-113204 || Add Test Executions to the project sidebar

### DIFF
--- a/app/src/common/img/sidebar/test-executions-icon-inline.svg
+++ b/app/src/common/img/sidebar/test-executions-icon-inline.svg
@@ -1,0 +1,5 @@
+<svg width="48" height="40" viewBox="0 0 48 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M28 19C28 16.2386 25.7614 14 23 14C20.2386 14 18 16.2386 18 19C18 21.7614 20.2386 24 23 24V27C18.5817 27 15 23.4183 15 19C15 14.5817 18.5817 11 23 11C27.4183 11 31 14.5817 31 19C31 23.4183 27.4183 27 23 27V24C25.7614 24 28 21.7614 28 19Z" fill="#CFCFCF"/>
+    <rect x="23" y="16" width="4.24265" height="4.24265" rx="1" transform="rotate(45 23 16)" fill="#CFCFCF"/>
+    <rect x="27" y="25.1211" width="3" height="6.6063" rx="1" transform="rotate(-45 27 25.1211)" fill="#CFCFCF"/>
+</svg>

--- a/app/src/layouts/messages.js
+++ b/app/src/layouts/messages.js
@@ -73,6 +73,10 @@ export const messages = defineMessages({
     id: 'Sidebar.testCaseLibrary',
     defaultMessage: 'Test Case Library',
   },
+  testExecutions: {
+    id: 'Sidebar.testExecutions',
+    defaultMessage: 'Test Executions',
+  },
   organizations: {
     id: 'InstanceSidebar.organizations',
     defaultMessage: 'Organizations',

--- a/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
+++ b/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
@@ -62,6 +62,12 @@ import { useTmsEnabled } from 'hooks/useTmsEnabled';
 import { useTmsMilestonesEnabled } from 'hooks/useTmsMilestonesEnabled';
 
 const ORGANIZATION_CONTROL = 'Organization control';
+const TEST_EXECUTIONS_KEYWORD = 'testexecution';
+
+const normalizeExtensionValue = (value) => value?.toString().toLowerCase().replace(/[\s_-]/g, '');
+
+const isTestExecutionsExtension = (values) =>
+  values.some((value) => normalizeExtensionValue(value)?.includes(TEST_EXECUTIONS_KEYWORD));
 
 export const ProjectSidebar = ({ onClickNavBtn }) => {
   const { trackEvent } = useTracking();
@@ -110,9 +116,10 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
 
     projectPageExtensions.forEach(({ icon, internalRoute, name, title, iconName, menuOrder, payload = {} }) => {
       const pluginPage = internalRoute || payload.slug || name;
+      const isTestExecutionsPlugin = isTestExecutionsExtension([internalRoute, payload.slug, name, title, iconName]);
 
-      if (pluginPage) {
-        const itemName = iconName || title || name;
+      if (pluginPage && (icon || isTestExecutionsPlugin)) {
+        const itemName = iconName || title || (isTestExecutionsPlugin ? messages.testExecutions.defaultMessage : name);
         sidebarItems.push({
           onClick: (isSidebarCollapsed) => onClickButton({ itemName, isSidebarCollapsed }),
           link: {
@@ -120,7 +127,7 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
             payload: { organizationSlug, projectSlug, pluginPage },
           },
           icon: icon?.svg || TestExecutionsIcon,
-          message: icon?.title || title || name,
+          message: icon?.title || title || (isTestExecutionsPlugin ? formatMessage(messages.testExecutions) : name),
           menuOrder: menuOrder || (menuCounter += menuStep),
         });
       }

--- a/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
+++ b/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
@@ -53,6 +53,7 @@ import SettingsIcon from 'common/img/sidebar/settings-icon-inline.svg';
 import ProductVersionsIcon from 'common/img/sidebar/product-versions-inline.svg';
 import TestCaseIcon from 'common/img/sidebar/test-case-icon-inline.svg';
 import TestPlansIcon from 'common/img/sidebar/test-plans-icon-inline.svg';
+import TestExecutionsIcon from 'common/img/sidebar/test-executions-icon-inline.svg';
 import { projectNameSelector } from 'controllers/project';
 import { activeOrganizationNameSelector } from 'controllers/organization';
 import { OrganizationsControlWithPopover } from '../../organizationsControl';
@@ -105,6 +106,27 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
         message: formatMessage(messages.launches),
         menuOrder: (menuCounter += menuStep),
       },
+    ];
+
+    projectPageExtensions.forEach(({ icon, internalRoute, name, title, iconName, menuOrder, payload = {} }) => {
+      const pluginPage = internalRoute || payload.slug || name;
+
+      if (pluginPage) {
+        const itemName = iconName || title || name;
+        sidebarItems.push({
+          onClick: (isSidebarCollapsed) => onClickButton({ itemName, isSidebarCollapsed }),
+          link: {
+            type: PROJECT_PLUGIN_PAGE,
+            payload: { organizationSlug, projectSlug, pluginPage },
+          },
+          icon: icon?.svg || TestExecutionsIcon,
+          message: icon?.title || title || name,
+          menuOrder: menuOrder || (menuCounter += menuStep),
+        });
+      }
+    });
+
+    sidebarItems.push(
       ...(isTmsEnabled
         ? [
             {
@@ -152,9 +174,8 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
         icon: MembersIcon,
         message: formatMessage(messages.projectTeam),
         menuOrder: (menuCounter += menuStep),
-      }
-    ];
-
+      },
+    );
 
     if (isTmsEnabled) {
       sidebarItems.push(
@@ -216,21 +237,6 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
       icon: SettingsIcon,
       message: formatMessage(messages.projectsSettings),
       menuOrder: (menuCounter += menuStep),
-    });
-    projectPageExtensions.forEach(({ icon, internalRoute, name, title, iconName, menuOrder }) => {
-      if (icon) {
-        const itemName = iconName || title;
-        sidebarItems.push({
-          onClick: (isSidebarCollapsed) => onClickButton({ itemName, isSidebarCollapsed }),
-          link: {
-            type: PROJECT_PLUGIN_PAGE,
-            payload: { organizationSlug, projectSlug, pluginPage: internalRoute || name },
-          },
-          icon: icon.svg,
-          message: icon.title || title,
-          menuOrder: menuOrder || (menuCounter += menuStep),
-        });
-      }
     });
     sidebarExtensions.forEach((extension) =>
       sidebarItems.push({


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
added test execution icon after uploading the jar of plugin , and while turning on it

## Visuals

https://github.com/user-attachments/assets/b9254ea6-10b0-44f5-978b-12218151f0ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Test Executions" sidebar menu item and corresponding UI message entry.

* **Updates**
  * Plugin extension entries now appear earlier in the sidebar.
  * Sidebar entries handle missing icons gracefully with a default icon and fallback label.
  * Plugin page resolution is more flexible to support varied plugin metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->