### PR TITLE
EPMRPP-95632 || Fallback in AddIntegrationModal when form is unavailable

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -83,6 +83,7 @@
   "AddIntegrationModal.createProjectTitle": "Стварыць праектную інтэграцыю",
   "AddIntegrationModal.editGlobalIntegrationTitle": "Рэдагаваць глабальную інтэграцыю",
   "AddIntegrationModal.editProjectIntegrationTitle": "Рэдагаваць інтэграцыю праекта",
+  "AddIntegrationModal.formNotAvailable": "Форма наладкі для гэтага плагіна недаступная. Усталюйце або абнавіце пашырэнне інтэрфейсу плагіна з палямі інтэграцыі.",
   "AddLdapIntegrationModal.createLdapTitle": "Стварэнне глабальнай інтэграцыі",
   "AddLdapIntegrationModal.editLdapIntegrationTitle": "Рэдагаваць глабальную інтэграцыю",
   "AddLdapIntegrationModal.fieldSettingsTitle": "Налады поля",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -83,6 +83,7 @@
   "AddIntegrationModal.createProjectTitle": "Crear integración de proyecto",
   "AddIntegrationModal.editGlobalIntegrationTitle": "Editar integración global",
   "AddIntegrationModal.editProjectIntegrationTitle": "Editar integración de proyecto",
+  "AddIntegrationModal.formNotAvailable": "El formulario de configuración no está disponible para este plugin. Instale o actualice una extensión de interfaz del plugin que proporcione los campos de integración.",
   "AddLdapIntegrationModal.createLdapTitle": "Crear Integración Global",
   "AddLdapIntegrationModal.editLdapIntegrationTitle": "Editar Integratión Global",
   "AddLdapIntegrationModal.fieldSettingsTitle": "Configuración de campos",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -83,6 +83,7 @@
   "AddIntegrationModal.createProjectTitle": "Создать проектную интеграцию",
   "AddIntegrationModal.editGlobalIntegrationTitle": "Редактировать глобальную интеграцию",
   "AddIntegrationModal.editProjectIntegrationTitle": "Редактировать интеграцию проекта",
+  "AddIntegrationModal.formNotAvailable": "Форма настройки для этого плагина недоступна. Установите или обновите расширение интерфейса плагина с полями интеграции.",
   "AddLdapIntegrationModal.createLdapTitle": "Создать глобальную интеграцию",
   "AddLdapIntegrationModal.editLdapIntegrationTitle": "Изменить глобальную интеграцию",
   "AddLdapIntegrationModal.fieldSettingsTitle": "Найстройки полей",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -83,6 +83,7 @@
   "AddIntegrationModal.createProjectTitle": "Створити проектну інтеграцію",
   "AddIntegrationModal.editGlobalIntegrationTitle": "Редагувати глобальну інтеграцію",
   "AddIntegrationModal.editProjectIntegrationTitle": "Редагувати інтеграцію проекту",
+  "AddIntegrationModal.formNotAvailable": "Форма налаштування для цього плагіна недоступна. Встановіть або оновіть розширення інтерфейсу плагіна, яке містить поля інтеграції.",
   "AddLdapIntegrationModal.createLdapTitle": "Створення глобальної інтеграції",
   "AddLdapIntegrationModal.editLdapIntegrationTitle": "Редагувати глобальну інтеграцію",
   "AddLdapIntegrationModal.fieldSettingsTitle": "Налаштування поля",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -83,6 +83,7 @@
   "AddIntegrationModal.createProjectTitle": "创建项目集成",
   "AddIntegrationModal.editGlobalIntegrationTitle": "编辑全局集成",
   "AddIntegrationModal.editProjectIntegrationTitle": "编辑项目集成",
+  "AddIntegrationModal.formNotAvailable": "此插件没有可用的配置表单。请安装或更新可提供集成字段的插件界面扩展。",
   "AddLdapIntegrationModal.createLdapTitle": "Create Global Integration",
   "AddLdapIntegrationModal.editLdapIntegrationTitle": "Edit Global Integration",
   "AddLdapIntegrationModal.fieldSettingsTitle": "Field settings",

--- a/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.jsx
+++ b/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.jsx
@@ -60,6 +60,11 @@ const messages = defineMessages({
     id: 'AddIntegrationModal.editGlobalIntegrationTitle',
     defaultMessage: 'Edit Global Integration',
   },
+  formNotAvailable: {
+    id: 'AddIntegrationModal.formNotAvailable',
+    defaultMessage:
+      'Configuration form is not available for this plugin. Install or update a plugin UI extension that provides integration fields.',
+  },
 });
 
 const AddIntegrationModal = ({ data, initialize, change, handleSubmit, dirty }) => {
@@ -89,12 +94,17 @@ const AddIntegrationModal = ({ data, initialize, change, handleSubmit, dirty }) 
     onConfirm(newData, metaData);
   };
 
+  const hasFormFields =
+    Boolean(INTEGRATIONS_FORM_FIELDS_COMPONENTS_MAP[data.instanceType]) ||
+    Boolean(integrationFieldsExtension);
+
   const okButton = {
     children: customProps.editAuthMode
       ? formatMessage(COMMON_LOCALE_KEYS.SAVE)
       : formatMessage(COMMON_LOCALE_KEYS.CREATE),
     onClick: () => handleSubmit(onSubmit)(),
     'data-automation-id': 'submitButton',
+    disabled: !hasFormFields,
   };
   const cancelButton = {
     children: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
@@ -108,7 +118,7 @@ const AddIntegrationModal = ({ data, initialize, change, handleSubmit, dirty }) 
 
   const FieldsComponent =
     INTEGRATIONS_FORM_FIELDS_COMPONENTS_MAP[data.instanceType] ||
-    (integrationFieldsExtension && ExtensionLoader);
+    (integrationFieldsExtension ? ExtensionLoader : null);
 
   return (
     <Modal
@@ -129,14 +139,18 @@ const AddIntegrationModal = ({ data, initialize, change, handleSubmit, dirty }) 
         </SystemMessage>
       )}
 
-      <div className={cx('content')}>
-        <FieldsComponent
-          initialize={initialize}
-          change={change}
-          updateMetaData={updateMetaData}
-          extension={integrationFieldsExtension}
-          {...customProps}
-        />
+      <div className={cx('content', { 'with-form': hasFormFields })}>
+        {FieldsComponent ? (
+          <FieldsComponent
+            initialize={initialize}
+            change={change}
+            updateMetaData={updateMetaData}
+            extension={integrationFieldsExtension}
+            {...customProps}
+          />
+        ) : (
+          <SystemMessage mode="info">{formatMessage(messages.formNotAvailable)}</SystemMessage>
+        )}
       </div>
     </Modal>
   );

--- a/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.scss
+++ b/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.scss
@@ -15,5 +15,7 @@
  */
 
 .content {
-  margin-top: 32px;
+  &.with-form {
+    margin-top: 32px;
+  }
 }


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

https://github.com/user-attachments/assets/f4480c39-a339-4428-a862-1125c1eeaa57



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added informational messaging when a plugin's configuration form is unavailable, with the submit button disabled in such cases.

* **Localization**
  * Added translations for the unavailable form message in Belarusian, Spanish, Russian, Ukrainian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->