### PR TITLE
EPMRPP-112506 || Fix the GitHub Organization name placeholder

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -1114,7 +1114,7 @@
   "GithubFormFields.clientSecretPlaceholder": "Укажыце сакрэт кліента (напр. a1b2c3…)",
   "GithubFormFields.githubOrganizationLabel": "Арганізацыя GitHub",
   "GithubFormFields.organizationNameHint": "Назва арганізацыі можа змяшчаць толькі лацінскія літары, лічбы і злучок",
-  "GithubFormFields.organizationPlaceholder": "Увядзіце назву арганізацыі",
+  "GithubFormFields.organizationPlaceholder": "Увядзіце назву арганізацыі (напрыклад, reportportal)",
   "GithubFormFields.removeGithubOrganization": "Выдаліць арганізацыю GitHub",
   "Hamburger.analysis": "Аналізаваць",
   "Hamburger.export": "Экспартаваць:",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -1116,7 +1116,7 @@
   "GithubFormFields.clientSecretPlaceholder": "Especifique el secreto de cliente (p. ej. a1b2c3…)",
   "GithubFormFields.githubOrganizationLabel": "Organización de GitHub",
   "GithubFormFields.organizationNameHint": "El nombre de la organización solo puede contener caracteres latinos, números y guiones",
-  "GithubFormFields.organizationPlaceholder": "Introduzca el nombre de la organización",
+  "GithubFormFields.organizationPlaceholder": "Introduzca el nombre de la organización (p. ej., reportportal)",
   "GithubFormFields.removeGithubOrganization": "Eliminar organización de GitHub",
   "Hamburger.analysis": "Análisis",
   "Hamburger.export": "Exportar:",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -1115,7 +1115,7 @@
   "GithubFormFields.clientSecretPlaceholder": "Укажите секрет клиента (напр. a1b2c3…)",
   "GithubFormFields.githubOrganizationLabel": "Организация GitHub",
   "GithubFormFields.organizationNameHint": "Имя организации может содержать только латинские буквы, цифры и дефис",
-  "GithubFormFields.organizationPlaceholder": "Введите имя организации",
+  "GithubFormFields.organizationPlaceholder": "Введите имя организации (например, reportportal)",
   "GithubFormFields.removeGithubOrganization": "Удалить организацию GitHub",
   "Hamburger.analysis": "Анализировать",
   "Hamburger.export": "Экспортировать:",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -1115,7 +1115,7 @@
   "GithubFormFields.clientSecretPlaceholder": "Вкажіть секрет клієнта (напр. a1b2c3…)",
   "GithubFormFields.githubOrganizationLabel": "Організація GitHub",
   "GithubFormFields.organizationNameHint": "Назва організації може містити лише латинські літери, цифри та дефіс",
-  "GithubFormFields.organizationPlaceholder": "Введіть назву організації",
+  "GithubFormFields.organizationPlaceholder": "Введіть назву організації (наприклад, reportportal)",
   "GithubFormFields.removeGithubOrganization": "Видалити організацію GitHub",
   "Hamburger.analysis": "Аналізувати",
   "Hamburger.export": "Експортувати:",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -1115,7 +1115,7 @@
   "GithubFormFields.clientSecretPlaceholder": "请填写客户端密钥（例如 a1b2c3…）",
   "GithubFormFields.githubOrganizationLabel": "GitHub 组织",
   "GithubFormFields.organizationNameHint": "组织名称只能包含拉丁字母、数字和连字符",
-  "GithubFormFields.organizationPlaceholder": "请输入组织名称",
+  "GithubFormFields.organizationPlaceholder": "请输入组织名称（例如 reportportal）",
   "GithubFormFields.removeGithubOrganization": "删除 GitHub 组织",
   "Hamburger.analysis": "分析",
   "Hamburger.export": "导出：",

--- a/app/src/components/integrations/integrationProviders/githubIntegration/githubFormFields/githubOrganizations.tsx
+++ b/app/src/components/integrations/integrationProviders/githubIntegration/githubFormFields/githubOrganizations.tsx
@@ -36,7 +36,7 @@ const messages = defineMessages({
   },
   organizationPlaceholder: {
     id: 'GithubFormFields.organizationPlaceholder',
-    defaultMessage: 'Enter the organization name',
+    defaultMessage: 'Enter the organization name (e.g. reportportal)',
   },
   removeGithubOrganization: {
     id: 'GithubFormFields.removeGithubOrganization',


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the GitHub organization name field placeholder text across all supported languages to include an example value (e.g., "reportportal"), providing clearer guidance during GitHub integration configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->