### PR TITLE
EPMRPP-114631 || Copy icon has wrong background on hover

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -525,6 +525,7 @@
   "CopySendDefectModal.headerSendTitle": "Адправіць вынікі ў апошні запуск",
   "CopySendDefectModal.successMessage": "Дэфекты абноўлены",
   "ClipboardButton.copyToClipboard": "Скапіявана ў буфер абмену",
+  "ClipboardButton.copy": "Скапіяваць у буфер абмену",
   "CreatePatternAnalysisModal.createPatternModalCondition": "Умова патэрна",
   "CreatePatternAnalysisModal.createPatternModalDescription": "Стварыце патэрн, паказаўшы ўмову для агульнай прычыны адмовы",
   "CreatePatternAnalysisModal.createPatternModalHeader": "Стварыць Правіла Патэрна",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -525,6 +525,7 @@
   "CopySendDefectModal.headerSendTitle": "Enviar resultados a la última ejecución",
   "CopySendDefectModal.successMessage": "Defectos actualizados",
   "ClipboardButton.copyToClipboard": "Copied to clipboard",
+  "ClipboardButton.copy": "Copiar al portapapeles",
   "CreatePatternAnalysisModal.createPatternModalCondition": "Condición del patrón",
   "CreatePatternAnalysisModal.createPatternModalDescription": "Cree un patrón especificando la condición para la causa común del fallo",
   "CreatePatternAnalysisModal.createPatternModalHeader": "Crear regla de patrón",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -525,6 +525,7 @@
   "CopySendDefectModal.headerSendTitle": "Отправить результаты в последний запуск",
   "CopySendDefectModal.successMessage": "Дефекты обновлены",
   "ClipboardButton.copyToClipboard": "Скопировано в буфер обмена",
+  "ClipboardButton.copy": "Скопировать в буфер обмена",
   "CreatePatternAnalysisModal.createPatternModalCondition": "Условие паттерна",
   "CreatePatternAnalysisModal.createPatternModalDescription": "Создайте паттерн, указав условие для общей причины отказа",
   "CreatePatternAnalysisModal.createPatternModalHeader": "Создать Правило Паттерна",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -525,6 +525,7 @@
   "CopySendDefectModal.headerSendTitle": "Відправити результати до останнього запуску",
   "CopySendDefectModal.successMessage": "Дефекти оновлено",
   "ClipboardButton.copyToClipboard": "Скопійовано в буфер обміну",
+  "ClipboardButton.copy": "Скопіювати в буфер обміну",
   "CreatePatternAnalysisModal.createPatternModalCondition": "Умова патерну",
   "CreatePatternAnalysisModal.createPatternModalDescription": "Створіть патерн, вказавши умову для загальної причини відмови",
   "CreatePatternAnalysisModal.createPatternModalHeader": "Створити Правило Патерну",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -525,6 +525,7 @@
   "CopySendDefectModal.headerSendTitle": "发送缺陷到最新的测试项中",
   "CopySendDefectModal.successMessage": "缺陷已更新",
   "ClipboardButton.copyToClipboard": "Copied to clipboard",
+  "ClipboardButton.copy": "复制到剪贴板",
   "CreatePatternAnalysisModal.createPatternModalCondition": "模板适用条件",
   "CreatePatternAnalysisModal.createPatternModalDescription": "以常见失败原因作为条件创建一个模板",
   "CreatePatternAnalysisModal.createPatternModalHeader": "创建模板",

--- a/app/src/components/buttons/copyClipboardButton/copyClipboardButton.jsx
+++ b/app/src/components/buttons/copyClipboardButton/copyClipboardButton.jsx
@@ -20,7 +20,7 @@ import classNames from 'classnames/bind';
 import { defineMessages, useIntl } from 'react-intl';
 import Parser from 'html-react-parser';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { Button, Tooltip } from '@reportportal/ui-kit';
+import { Tooltip } from '@reportportal/ui-kit';
 import IconDuplicate from 'common/img/duplicate-inline.svg';
 import IconTick from 'common/img/newIcons/tick-inline.svg';
 import styles from './copyClipboardButton.scss';
@@ -50,11 +50,11 @@ export const ClipboardButton = ({ text, className }) => {
           <div className={cx('popover-message')}>{Parser(IconTick)}</div>
         </Tooltip>
       ) : (
-        <Button onClick={copyToClipboardHandler} className={cx('clipboard')}>
+        <button onClick={copyToClipboardHandler} className={cx('clipboard')}>
           <CopyToClipboard className={cx('copy')} text={text}>
             {Parser(IconDuplicate)}
           </CopyToClipboard>
-        </Button>
+        </button>
       )}
     </div>
   );

--- a/app/src/components/buttons/copyClipboardButton/copyClipboardButton.jsx
+++ b/app/src/components/buttons/copyClipboardButton/copyClipboardButton.jsx
@@ -20,8 +20,7 @@ import classNames from 'classnames/bind';
 import { defineMessages, useIntl } from 'react-intl';
 import Parser from 'html-react-parser';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { Tooltip } from '@reportportal/ui-kit';
-import IconDuplicate from 'common/img/duplicate-inline.svg';
+import { BaseIconButton, CopyIcon, Tooltip } from '@reportportal/ui-kit';
 import IconTick from 'common/img/newIcons/tick-inline.svg';
 import styles from './copyClipboardButton.scss';
 
@@ -54,16 +53,13 @@ export const ClipboardButton = ({ text, className }) => {
           <div className={cx('popover-message')}>{Parser(IconTick)}</div>
         </Tooltip>
       ) : (
-        <button
-          type="button"
-          aria-label={formatMessage(messages.copy)}
-          onClick={copyToClipboardHandler}
-          className={cx('clipboard')}
-        >
-          <CopyToClipboard className={cx('copy')} text={text}>
-            {Parser(IconDuplicate)}
-          </CopyToClipboard>
-        </button>
+        <CopyToClipboard text={text} onCopy={copyToClipboardHandler}>
+          <BaseIconButton aria-label={formatMessage(messages.copy)} className={cx('clipboard')}>
+            <span className={cx('copy')}>
+              <CopyIcon />
+            </span>
+          </BaseIconButton>
+        </CopyToClipboard>
       )}
     </div>
   );

--- a/app/src/components/buttons/copyClipboardButton/copyClipboardButton.jsx
+++ b/app/src/components/buttons/copyClipboardButton/copyClipboardButton.jsx
@@ -32,6 +32,10 @@ const messages = defineMessages({
     id: 'ClipboardButton.copyToClipboard',
     defaultMessage: 'Copied to clipboard',
   },
+  copy: {
+    id: 'ClipboardButton.copy',
+    defaultMessage: 'Copy to clipboard',
+  },
 });
 
 export const ClipboardButton = ({ text, className }) => {
@@ -50,7 +54,12 @@ export const ClipboardButton = ({ text, className }) => {
           <div className={cx('popover-message')}>{Parser(IconTick)}</div>
         </Tooltip>
       ) : (
-        <button onClick={copyToClipboardHandler} className={cx('clipboard')}>
+        <button
+          type="button"
+          aria-label={formatMessage(messages.copy)}
+          onClick={copyToClipboardHandler}
+          className={cx('clipboard')}
+        >
           <CopyToClipboard className={cx('copy')} text={text}>
             {Parser(IconDuplicate)}
           </CopyToClipboard>

--- a/app/src/components/buttons/copyClipboardButton/copyClipboardButton.scss
+++ b/app/src/components/buttons/copyClipboardButton/copyClipboardButton.scss
@@ -28,7 +28,6 @@
 .copy {
   height: 16px;
   width: 16px;
-  stroke: $COLOR--e-300;
 
   &:hover {
     stroke: $COLOR--black-2;
@@ -55,7 +54,11 @@
 }
 
 .clipboard {
-  all: unset;
   display: flex;
   cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-ui-base-topaz-focused);
+    border-radius: 3px;
+  }
 }


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<img width="737" height="675" alt="image" src="https://github.com/user-attachments/assets/a6e41169-1f53-4dbc-b825-cde008d721e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clipboard button implementation updated without changing its outward behavior.
* **Accessibility**
  * Button now exposes an accessible label for screen readers and improved keyboard focus styling.
* **Localization**
  * New translation key for the clipboard action added across multiple languages so the button label appears correctly for localized UIs.
* **Style**
  * Icon and focus visuals adjusted for clearer hover/focus presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->