### PR TITLE
EPMRPP-104675 || Implement single test case removal from the test plan

### DIFF
--- a/app/src/pages/inside/common/hooks/index.ts
+++ b/app/src/pages/inside/common/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,4 @@
  * limitations under the License.
  */
 
-export { TestCaseList } from './testCaseList';
-export { STATUS_TYPES, ITEMS_PER_PAGE_OPTIONS } from './constants';
-export { useTestCaseTooltipItems } from './useTestCaseTooltipItems';
+export { findFolderById, useTestPlanActiveFolders } from './useTestPlanActiveFolders';

--- a/app/src/pages/inside/common/hooks/useTestPlanActiveFolders.ts
+++ b/app/src/pages/inside/common/hooks/useTestPlanActiveFolders.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { useSelector } from 'react-redux';
 import { isEmpty } from 'es-toolkit/compat';
 

--- a/app/src/pages/inside/common/testCaseList/messages.ts
+++ b/app/src/pages/inside/common/testCaseList/messages.ts
@@ -66,8 +66,4 @@ export const messages = defineMessages({
     defaultMessage:
       "Your search or filter criteria didn't match any results. Please try different keywords or adjust your filter settings.",
   },
-  removeTestCase: {
-    id: 'TestCaseList.removeTestCase',
-    defaultMessage: 'Remove test case',
-  },
 });

--- a/app/src/pages/inside/common/testCaseList/testCaseExecutionCell/useTooltipItems.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseExecutionCell/useTooltipItems.tsx
@@ -17,12 +17,15 @@
 import { useIntl } from 'react-intl';
 
 import { useUserPermissions } from 'hooks/useUserPermissions';
-import { TMS_INSTANCE_KEY } from 'pages/inside/common/constants';
-import { useTestCaseTooltipItems } from 'pages/inside/testCaseLibraryPage/allTestCasesPage/useTestCaseTooltipItems';
-import { ExtendedTestCase } from 'types/testCase';
 import { PopoverItem } from 'pages/common/popoverControl/popoverControl';
+import { TMS_INSTANCE_KEY } from 'pages/inside/common/constants';
+import {
+  useRemoveTestCasesFromTestPlanModal,
+  removeTestCasesFromTestPlanMessages,
+} from 'pages/inside/testPlansPage/testPlanModals';
+import { ExtendedTestCase } from 'types/testCase';
 
-import { messages } from '../messages';
+import { useTestCaseTooltipItems } from '../useTestCaseTooltipItems';
 
 interface UseTooltipItemsProps {
   instanceKey: TMS_INSTANCE_KEY;
@@ -33,16 +36,23 @@ export const useTooltipItems = ({ instanceKey, testCase }: UseTooltipItemsProps)
   const { formatMessage } = useIntl();
   const { canManageTestCases } = useUserPermissions();
   const testCaseTooltipItems = useTestCaseTooltipItems({ testCase });
-
+  const { openModal: openRemoveFromTestPlanModal } = useRemoveTestCasesFromTestPlanModal();
 
   const tooltipItemsByInstance: Partial<Record<TMS_INSTANCE_KEY, PopoverItem[]>> = {
-    [TMS_INSTANCE_KEY.TEST_PLAN]: canManageTestCases ? [
-      {
-        label: formatMessage(messages.removeTestCase) + 11,
-        variant: 'danger',
-        onClick: () => {},
-      },
-    ] : [],
+    [TMS_INSTANCE_KEY.TEST_PLAN]: canManageTestCases
+      ? [
+          {
+            label: formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanTitle),
+            variant: 'danger',
+            onClick: () => {
+              openRemoveFromTestPlanModal({
+                selectedTestCaseIds: [testCase.id],
+                testCaseName: testCase.name,
+              });
+            },
+          },
+        ]
+      : [],
     [TMS_INSTANCE_KEY.TEST_CASE]: testCaseTooltipItems,
     [TMS_INSTANCE_KEY.MANUAL_LAUNCH]: testCaseTooltipItems,
   };

--- a/app/src/pages/inside/common/testCaseList/useTestCaseTooltipItems.tsx
+++ b/app/src/pages/inside/common/testCaseList/useTestCaseTooltipItems.tsx
@@ -17,15 +17,14 @@
 import { useIntl } from 'react-intl';
 
 import { useUserPermissions } from 'hooks/useUserPermissions';
-import { TestCaseMenuAction } from 'pages/inside/common/testCaseList/types';
 import { createTestCaseMenuItems } from 'pages/inside/common/testCaseList/configUtils';
-import { useDeleteTestCaseModal } from 'pages/inside/testCaseLibraryPage/deleteTestCaseModal';
+import { TestCaseMenuAction } from 'pages/inside/common/testCaseList/types';
 import { getExcludedActionsFromPermissionMap } from 'pages/inside/common/testCaseList/utils';
+import { useDeleteTestCaseModal } from 'pages/inside/testCaseLibraryPage/deleteTestCaseModal';
+import { useDuplicateSelectedTestCaseModal } from 'pages/inside/testCaseLibraryPage/duplicateSelectedTestCaseModal';
+import { useEditTestCaseModal } from 'pages/inside/testCaseLibraryPage/editSelectedTestCaseModal';
+import { useMoveTestCaseModal } from 'pages/inside/testCaseLibraryPage/moveTestCaseModal/useMoveTestCaseModal';
 import { ExtendedTestCase } from 'types/testCase';
-
-import { useEditTestCaseModal } from '../editSelectedTestCaseModal';
-import { useMoveTestCaseModal } from '../moveTestCaseModal/useMoveTestCaseModal';
-import { useDuplicateSelectedTestCaseModal } from '../duplicateSelectedTestCaseModal';
 
 interface TestCaseTooltipItemsProps {
   testCase: ExtendedTestCase;
@@ -44,7 +43,7 @@ export const useTestCaseTooltipItems = ({ testCase }: TestCaseTooltipItemsProps)
     TestCaseMenuAction.EDIT,
     TestCaseMenuAction.MOVE,
     TestCaseMenuAction.DELETE,
-  ].map(action => ({
+  ].map((action) => ({
     isAllowed: canManageTestCases,
     action,
   }));

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/testCaseFolders.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/testCaseFolders.tsx
@@ -51,7 +51,7 @@ import { TMS_INSTANCE_KEY } from 'pages/inside/common/constants';
 import { TestCasePageDefaultValues } from 'pages/inside/common/testCaseList/constants';
 import { userIdSelector } from 'controllers/user';
 import { ExtendedTestCase } from 'types/testCase';
-import { findFolderById } from 'pages/inside/testCaseLibraryPage/hooks/useTestPlanActiveFolders';
+import { findFolderById } from 'pages/inside/common/hooks';
 import type { NotificationMessageKey } from 'common/hooks/useNotification';
 
 import { ExpandedOptions } from '../../common/expandedOptions';

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/allTestCasesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/allTestCasesPage.tsx
@@ -35,7 +35,7 @@ import { useProjectDetails, useTestPlanId } from 'hooks/useTypedSelector';
 import { useURLBoundPagination } from 'pages/inside/common/testCaseList/useURLBoundPagination';
 
 import { useRemoveTestCasesFromTestPlanModal } from '../../../testPlanModals';
-import { messages } from '../../../testPlanModals/removeTestCasesFromTestPlanModal/messages';
+import { removeTestCasesFromTestPlanMessages } from '../../../testPlanModals/removeTestCasesFromTestPlanModal/messages';
 import { useAddTestCasesToLaunchModal } from './addTestCasesToLaunchModal';
 import { AllTestCasesPageProps } from './types';
 import styles from './allTestCasesPage.scss';
@@ -128,7 +128,7 @@ export const AllTestCasesPage = ({
                 onClick={handleOpenRemoveModal}
                 className={cx('selection-controls__remove-button')}
               >
-                {formatMessage(messages.removeFromTestPlanTitle)}
+                {formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanTitle)}
               </Button>
               <Button variant="primary" onClick={openAddToLaunchModal}>
                 {formatMessage(COMMON_LOCALE_KEYS.ADD_TO_LAUNCH)}

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/testPlanFolders.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/testPlanFolders.tsx
@@ -23,7 +23,7 @@ import {
 } from 'controllers/testPlan';
 import { PROJECT_TEST_PLAN_DETAILS_PAGE, locationSelector } from 'controllers/pages';
 import { TMS_INSTANCE_KEY } from 'pages/inside/common/constants';
-import { useTestPlanActiveFolders } from 'pages/inside/testCaseLibraryPage/hooks/useTestPlanActiveFolders';
+import { useTestPlanActiveFolders } from 'pages/inside/common/hooks';
 
 import { ExpandedOptions } from '../../../common/expandedOptions';
 import { AllTestCasesPage } from './allTestCasesPage';

--- a/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/index.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/index.ts
@@ -17,3 +17,4 @@
 export { useRemoveTestCasesFromTestPlanModal } from './useRemoveTestCasesFromTestPlanModal';
 export type { RemoveTestCasesFromTestPlanModalData } from './types';
 export { REMOVE_TEST_CASES_FROM_TEST_PLAN_MODAL_KEY } from './constants';
+export { removeTestCasesFromTestPlanMessages } from './messages';

--- a/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/messages.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/messages.ts
@@ -16,7 +16,7 @@
 
 import { defineMessages } from 'react-intl';
 
-export const messages = defineMessages({
+export const removeTestCasesFromTestPlanMessages = defineMessages({
   removeFromTestPlanTitle: {
     id: 'RemoveTestCasesFromTestPlanModal.title',
     defaultMessage: 'Remove from Test Plan',
@@ -25,6 +25,10 @@ export const messages = defineMessages({
     id: 'RemoveTestCasesFromTestPlanModal.description',
     defaultMessage:
       'Are you sure you want to remove the <b>{count, number}</b> {count, plural, one {test case} other {test cases}} from the test plan?',
+  },
+  removeFromTestPlanSingleDescription: {
+    id: 'RemoveTestCasesFromTestPlanModal.singleDescription',
+    defaultMessage: 'Are you sure you want to remove <b>{testCaseName}</b>?',
   },
   removeFromTestPlanError: {
     id: 'RemoveTestCasesFromTestPlanModal.errorMessage',

--- a/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/removeTestCasesFromTestPlanModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/removeTestCasesFromTestPlanModal.tsx
@@ -27,7 +27,7 @@ import { ModalLoadingOverlay } from 'components/modalLoadingOverlay';
 import { useModalButtons } from 'hooks/useModalButtons';
 
 import { useRemoveTestCasesFromTestPlan } from './useRemoveTestCasesFromTestPlan';
-import { messages } from './messages';
+import { removeTestCasesFromTestPlanMessages } from './messages';
 import { REMOVE_TEST_CASES_FROM_TEST_PLAN_MODAL_KEY, MODAL_Z_INDEX } from './constants';
 import { RemoveTestCasesFromTestPlanModalProps } from './types';
 
@@ -40,7 +40,7 @@ const BoldText = ({ children, className }: { children: ReactNode; className?: st
 );
 
 const RemoveTestCasesFromTestPlanModal = ({ data }: RemoveTestCasesFromTestPlanModalProps) => {
-  const { selectedTestCaseIds = [], onClearSelection = noop } = data || {};
+  const { selectedTestCaseIds = [], onClearSelection = noop, testCaseName } = data || {};
 
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
@@ -69,17 +69,22 @@ const RemoveTestCasesFromTestPlanModal = ({ data }: RemoveTestCasesFromTestPlanM
 
   return (
     <Modal
-      title={formatMessage(messages.removeFromTestPlanTitle)}
+      title={formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanTitle)}
       okButton={okButton}
       cancelButton={cancelButton}
       onClose={hideModal}
       zIndex={MODAL_Z_INDEX}
     >
       <div>
-        {formatMessage(messages.removeFromTestPlanDescription, {
-          count: selectedTestCaseIds.length,
-          b: renderBoldText,
-        })}
+        {testCaseName
+          ? formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanSingleDescription, {
+              testCaseName,
+              b: renderBoldText,
+            })
+          : formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanDescription, {
+              count: selectedTestCaseIds.length,
+              b: renderBoldText,
+            })}
         <ModalLoadingOverlay isVisible={isLoading} />
       </div>
     </Modal>

--- a/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/types.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/types.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { UseModalData } from 'common/hooks';
 import { VoidFn } from '@reportportal/ui-kit/common/types/commonTypes';
+
+import { UseModalData } from 'common/hooks';
 
 export interface RemoveTestCasesFromTestPlanModalData {
   selectedTestCaseIds: number[];
-  onClearSelection?: () => void;
+  testCaseName?: string;
+  onClearSelection?: VoidFn;
 }
 
 export type RemoveTestCasesFromTestPlanModalProps =

--- a/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/useRemoveTestCasesFromTestPlan.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/useRemoveTestCasesFromTestPlan.ts
@@ -23,10 +23,19 @@ import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
 import { useDebouncedSpinner, useNotification } from 'common/hooks';
 import { projectKeySelector } from 'controllers/project';
-import { getTestPlanAction, defaultTestPlanTestCasesQueryParams } from 'controllers/testPlan';
+import { fetchSuccessAction } from 'controllers/fetch';
+import {
+  getTestPlanAction,
+  defaultTestPlanTestCasesQueryParams,
+  TEST_PLAN_FOLDERS_NAMESPACE,
+  TestPlanFoldersDto,
+} from 'controllers/testPlan';
+import { PROJECT_TEST_PLAN_DETAILS_PAGE } from 'controllers/pages';
+import { LocationInfo } from 'controllers/pages/typed-selectors';
 import { useTestPlanId } from 'hooks/useTypedSelector';
+import { useTestPlanActiveFolders } from 'pages/inside/common/hooks';
 
-import { messages } from './messages';
+import { removeTestCasesFromTestPlanMessages } from './messages';
 import { UseRemoveTestCasesFromTestPlanOptions } from './types';
 
 export const useRemoveTestCasesFromTestPlan = ({
@@ -37,23 +46,52 @@ export const useRemoveTestCasesFromTestPlan = ({
   const dispatch = useDispatch();
   const projectKey = useSelector(projectKeySelector);
   const testPlanId = useTestPlanId();
+  const testCasesSearchParams = useSelector(
+    (state: { location: LocationInfo }) => state.location?.query?.testCasesSearchParams,
+  );
+  const { activeFolderId, payload } = useTestPlanActiveFolders();
   const { showSuccessNotification, showErrorNotification } = useNotification();
 
   const removeTestCasesFromTestPlan = useCallback(
     async (testCaseIds: number[]) => {
+      const numericTestPlanId = Number(testPlanId);
+
       try {
         showSpinner();
 
-        await fetch(URLS.testPlanTestCasesBatch(projectKey, Number(testPlanId)), {
+        await fetch(URLS.testPlanTestCasesBatch(projectKey, numericTestPlanId), {
           method: 'delete',
           data: {
             testCaseIds,
           },
         });
 
+        const updatedFolders: TestPlanFoldersDto = await fetch(
+          URLS.testFolders(projectKey, { 'filter.eq.testPlanId': numericTestPlanId }),
+        );
+
+        dispatch(fetchSuccessAction(TEST_PLAN_FOLDERS_NAMESPACE, updatedFolders));
+
+        const isActiveFolderRemoved =
+          activeFolderId !== null &&
+          !updatedFolders.content.some((folder) => folder.id === activeFolderId);
+        const targetTestPlanRoute = isActiveFolderRemoved ? undefined : payload?.testPlanRoute;
+        const targetFolderId = isActiveFolderRemoved ? undefined : (activeFolderId ?? undefined);
+
+        dispatch({
+          type: PROJECT_TEST_PLAN_DETAILS_PAGE,
+          payload: {
+            ...payload,
+            testPlanRoute: targetTestPlanRoute,
+          },
+          meta: { query: { testCasesSearchParams } },
+        });
+
         dispatch(
           getTestPlanAction({
-            testPlanId: Number(testPlanId),
+            testPlanId: numericTestPlanId,
+            folderId: targetFolderId,
+            testCasesSearchParams,
             ...defaultTestPlanTestCasesQueryParams,
           }),
         );
@@ -66,7 +104,9 @@ export const useRemoveTestCasesFromTestPlan = ({
         onSuccess?.();
       } catch (error) {
         showErrorNotification({
-          message: (error as Error).message || formatMessage(messages.removeFromTestPlanError),
+          message:
+            (error as Error).message ||
+            formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanError),
         });
         throw error;
       } finally {
@@ -79,6 +119,9 @@ export const useRemoveTestCasesFromTestPlan = ({
       projectKey,
       testPlanId,
       dispatch,
+      payload,
+      activeFolderId,
+      testCasesSearchParams,
       showSuccessNotification,
       onSuccess,
       showErrorNotification,


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->

https://github.com/user-attachments/assets/44763569-a523-4b6b-b834-c5449725e8bf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Remove” action on test-case tooltips now opens the confirmation modal and, for single items, shows the test case name.

* **Bug Fixes**
  * Improved test case removal confirmation messaging to display specific test case names for clarity.
  * Enhanced folder state management after removals to keep navigation consistent and auto-navigate if the active folder is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->