### PR TITLE
EPMRPP-104687 rendering execution comment and comment hide logic

### DIFF
--- a/app/src/components/main/notification/notificationList/notificationList.jsx
+++ b/app/src/components/main/notification/notificationList/notificationList.jsx
@@ -431,6 +431,10 @@ export const notificationMessages = defineMessages({
     id: 'ManualLaunchesPage.executionStatusUpdated',
     defaultMessage: 'Status updated: Test marked as {status}.',
   },
+  executionCommentSaved: {
+    id: 'ManualLaunchesPage.executionCommentSaved',
+    defaultMessage: 'Execution comment saved.',
+  },
   testPlanUpdatedSuccess: {
     id: 'TestPlansPage.testPlanUpdatedSuccess',
     defaultMessage: 'Test Plan has been updated successfully.',
@@ -530,7 +534,7 @@ export class NotificationList extends PureComponent {
                     duration={duration}
                     title={Parser(
                       DOMPurify.sanitize(
-                        (messageId && notificationMessages[messageId])
+                        messageId && notificationMessages[messageId]
                           ? formatMessage(notificationMessages[messageId], values)
                           : message,
                         { ADD_ATTR: ['target'] },

--- a/app/src/controllers/manualLaunch/actionCreators.ts
+++ b/app/src/controllers/manualLaunch/actionCreators.ts
@@ -21,6 +21,7 @@ import {
   GET_MANUAL_LAUNCH_TEST_CASE_EXECUTIONS,
   GET_MANUAL_LAUNCH_EXECUTION,
   UPDATE_MANUAL_LAUNCH_EXECUTION_STATUS,
+  UPDATE_MANUAL_LAUNCH_EXECUTION_COMMENT,
   TOGGLE_MANUAL_LAUNCH_FOLDER_EXPANSION,
   EXPAND_MANUAL_LAUNCH_FOLDERS_TO_LEVEL,
   SET_MANUAL_LAUNCH_EXPANDED_FOLDER_IDS,
@@ -37,6 +38,7 @@ import {
   GetManualLaunchTestCaseExecutionsParams,
   GetManualLaunchExecutionParams,
   UpdateManualLaunchExecutionStatusParams,
+  UpdateManualLaunchExecutionCommentParams,
   ToggleManualLaunchFolderExpansionParams,
   SetManualLaunchExpandedFolderIdsParams,
   GetManualLaunchFilteredFoldersParams,
@@ -74,6 +76,13 @@ export const updateManualLaunchExecutionStatusAction = (
   params: UpdateManualLaunchExecutionStatusParams,
 ) => ({
   type: UPDATE_MANUAL_LAUNCH_EXECUTION_STATUS,
+  payload: params,
+});
+
+export const updateManualLaunchExecutionCommentAction = (
+  params: UpdateManualLaunchExecutionCommentParams,
+) => ({
+  type: UPDATE_MANUAL_LAUNCH_EXECUTION_COMMENT,
   payload: params,
 });
 

--- a/app/src/controllers/manualLaunch/constants.ts
+++ b/app/src/controllers/manualLaunch/constants.ts
@@ -20,6 +20,7 @@ export const GET_MANUAL_LAUNCH_FOLDERS = 'getManualLaunchFolders' as const;
 export const GET_MANUAL_LAUNCH_TEST_CASE_EXECUTIONS = 'getManualLaunchTestCaseExecutions' as const;
 export const GET_MANUAL_LAUNCH_EXECUTION = 'getManualLaunchExecution' as const;
 export const UPDATE_MANUAL_LAUNCH_EXECUTION_STATUS = 'updateManualLaunchExecutionStatus' as const;
+export const UPDATE_MANUAL_LAUNCH_EXECUTION_COMMENT = 'updateManualLaunchExecutionComment' as const;
 export const TOGGLE_MANUAL_LAUNCH_FOLDER_EXPANSION = 'toggleManualLaunchFolderExpansion' as const;
 export const EXPAND_MANUAL_LAUNCH_FOLDERS_TO_LEVEL = 'expandManualLaunchFoldersToLevel' as const;
 export const SET_MANUAL_LAUNCH_EXPANDED_FOLDER_IDS = 'setManualLaunchExpandedFolderIds' as const;

--- a/app/src/controllers/manualLaunch/index.ts
+++ b/app/src/controllers/manualLaunch/index.ts
@@ -21,6 +21,7 @@ export {
   getManualLaunchTestCaseExecutionsAction,
   getManualLaunchExecutionAction,
   updateManualLaunchExecutionStatusAction,
+  updateManualLaunchExecutionCommentAction,
   toggleManualLaunchFolderExpansionAction,
   expandManualLaunchFoldersToLevelAction,
   setManualLaunchExpandedFolderIdsAction,

--- a/app/src/controllers/manualLaunch/sagas.ts
+++ b/app/src/controllers/manualLaunch/sagas.ts
@@ -615,6 +615,82 @@ function* patchManualLaunchExecutionAndSyncList(
   return data;
 }
 
+type ManualLaunchStatusPatchBody = {
+  status: string;
+  executionComment?: {
+    comment?: string;
+    attachments?: Array<{ id: string; fileName: string; fileType: string; fileSize: number }>;
+    btsTickets?: BtsTicket[];
+  };
+};
+
+function applyToRunCommentClearIfNeeded(
+  requestData: ManualLaunchStatusPatchBody,
+  clearExecutionCommentAndBts?: boolean,
+): void {
+  if (!clearExecutionCommentAndBts) {
+    return;
+  }
+
+  requestData.executionComment = {
+    comment: '',
+    attachments: [],
+    btsTickets: [],
+  };
+}
+
+function mergeNonToRunExecutionComment(
+  requestData: ManualLaunchStatusPatchBody,
+  params: {
+    trimmedComment: string;
+    preserveExistingCommentIfFormSkipped?: boolean;
+    currentExecution: TestCaseExecution | null;
+    uploadedAttachments: UploadedAttachmentPayload[];
+    removedServerAttachmentIds?: Array<string | number>;
+    hasNewAttachments: boolean;
+  },
+): void {
+  let commentForRequest = params.trimmedComment;
+  const savedComment = params.currentExecution?.executionComment?.comment;
+
+  if (
+    params.preserveExistingCommentIfFormSkipped &&
+    isEmpty(params.trimmedComment) &&
+    isString(savedComment) &&
+    !isEmpty(savedComment)
+  ) {
+    commentForRequest = savedComment;
+  }
+
+  requestData.executionComment = {
+    comment: commentForRequest,
+  };
+
+  const {
+    removedServerAttachmentIds,
+    uploadedAttachments,
+    hasNewAttachments,
+    currentExecution,
+  } = params;
+
+  if (removedServerAttachmentIds !== undefined) {
+    const keptServer = (currentExecution?.executionComment?.attachments ?? []).filter(
+      (a) => !isAttachmentRemoved(a.id, removedServerAttachmentIds),
+    );
+    requestData.executionComment.attachments = [
+      ...keptServer.map(mapAttachmentForExecutionCommentPayload),
+      ...uploadedAttachments,
+    ];
+  } else if (hasNewAttachments) {
+    requestData.executionComment.attachments = uploadedAttachments;
+  }
+
+  const existingBts = currentExecution?.executionComment?.btsTickets;
+  if (!isUndefined(existingBts) && existingBts.length > 0) {
+    requestData.executionComment.btsTickets = existingBts;
+  }
+}
+
 function* updateManualLaunchExecutionStatus(
   action: UpdateManualLaunchExecutionStatusAction,
 ): Generator {
@@ -634,14 +710,7 @@ function* updateManualLaunchExecutionStatus(
   try {
     const statusUpper = status.toUpperCase();
 
-    const requestData: {
-      status: string;
-      executionComment?: {
-        comment?: string;
-        attachments?: Array<{ id: string; fileName: string; fileType: string; fileSize: number }>;
-        btsTickets?: BtsTicket[];
-      };
-    } = {
+    const requestData: ManualLaunchStatusPatchBody = {
       status: statusUpper,
     };
 
@@ -661,51 +730,20 @@ function* updateManualLaunchExecutionStatus(
     const hasNewAttachments = !isEmpty(uploadedAttachments);
 
     if (statusUpper === MANUAL_LAUNCH_TO_RUN_STATUS_QUERY_VALUE) {
-      if (clearExecutionCommentAndBts) {
-        requestData.executionComment = {
-          comment: '',
-          attachments: [],
-          btsTickets: [],
-        };
-      }
-    
+      applyToRunCommentClearIfNeeded(requestData, clearExecutionCommentAndBts);
     } else {
       const currentExecution = (yield select(
         activeManualLaunchExecutionSelector,
       )) as TestCaseExecution | null;
 
-      let commentForRequest = trimmedComment;
-      const savedComment = currentExecution?.executionComment?.comment;
-
-      if (
-        preserveExistingCommentIfFormSkipped &&
-        isEmpty(trimmedComment) &&
-        isString(savedComment) &&
-        !isEmpty(savedComment)
-      ) {
-        commentForRequest = savedComment;
-      }
-
-      requestData.executionComment = {
-        comment: commentForRequest,
-      };
-
-      if (removedServerAttachmentIds !== undefined) {
-        const keptServer = (currentExecution?.executionComment?.attachments ?? []).filter(
-          (a) => !isAttachmentRemoved(a.id, removedServerAttachmentIds),
-        );
-        requestData.executionComment.attachments = [
-          ...keptServer.map(mapAttachmentForExecutionCommentPayload),
-          ...uploadedAttachments,
-        ];
-      } else if (hasNewAttachments) {
-        requestData.executionComment.attachments = uploadedAttachments;
-      }
-
-      const existingBts = currentExecution?.executionComment?.btsTickets;
-      if (!isUndefined(existingBts) && existingBts.length > 0) {
-        requestData.executionComment.btsTickets = existingBts;
-      }
+      mergeNonToRunExecutionComment(requestData, {
+        trimmedComment,
+        preserveExistingCommentIfFormSkipped,
+        currentExecution,
+        uploadedAttachments,
+        removedServerAttachmentIds,
+        hasNewAttachments,
+      });
     }
 
     yield call(patchManualLaunchExecutionAndSyncList, projectKey, launchId, executionId, requestData);

--- a/app/src/controllers/manualLaunch/sagas.ts
+++ b/app/src/controllers/manualLaunch/sagas.ts
@@ -16,7 +16,7 @@
 
 import { Action } from 'redux';
 import { takeLatest, call, select, all, put, cancelled } from 'redux-saga/effects';
-import { isString } from 'es-toolkit';
+import { isString, isUndefined } from 'es-toolkit';
 import { isEmpty, isNil, isNumber } from 'es-toolkit/compat';
 
 import { URLS } from 'common/urls';
@@ -49,6 +49,7 @@ import {
   GET_MANUAL_LAUNCH_TEST_CASE_EXECUTIONS,
   GET_MANUAL_LAUNCH_EXECUTION,
   UPDATE_MANUAL_LAUNCH_EXECUTION_STATUS,
+  UPDATE_MANUAL_LAUNCH_EXECUTION_COMMENT,
   GET_MANUAL_LAUNCH_FILTERED_FOLDERS,
   MANUAL_LAUNCHES_NAMESPACE,
   ACTIVE_MANUAL_LAUNCH_NAMESPACE,
@@ -67,7 +68,12 @@ import {
   MANUAL_LAUNCH_TEST_PLAN_ID_FILTER_KEY,
   MANUAL_LAUNCH_COMPOSITE_ATTRIBUTE_FILTER_KEY,
   defaultManualLaunchesQueryParams,
+  MANUAL_LAUNCH_TO_RUN_STATUS_QUERY_VALUE,
 } from './constants';
+import {
+  isAttachmentRemoved,
+  mapAttachmentForExecutionCommentPayload,
+} from './utils';
 import {
   GetManualLaunchesParams,
   GetManualLaunchParams,
@@ -75,13 +81,19 @@ import {
   GetManualLaunchTestCaseExecutionsParams,
   GetManualLaunchExecutionParams,
   UpdateManualLaunchExecutionStatusParams,
+  UpdateManualLaunchExecutionCommentParams,
+  BtsTicket,
   GetManualLaunchFilteredFoldersParams,
   ManualLaunchFoldersResponse,
   ManualLaunchFolder,
   TestCaseExecutionsResponse,
   TestCaseExecution,
 } from './types';
-import { manualLaunchContentSelector, activeManualLaunchSelector } from './selectors';
+import {
+  manualLaunchContentSelector,
+  activeManualLaunchSelector,
+  activeManualLaunchExecutionSelector,
+} from './selectors';
 import {
   setManualLaunchFilteredFoldersAction,
   startLoadingManualLaunchFilteredFoldersAction,
@@ -558,18 +570,30 @@ function* uploadAttachments(projectKey: string, attachments?: File[]): Generator
 function* updateManualLaunchExecutionStatus(
   action: UpdateManualLaunchExecutionStatusAction,
 ): Generator {
-  const { projectKey, launchId, executionId, status, comment, attachments, onSuccess } =
-    action.payload;
+  const {
+    projectKey,
+    launchId,
+    executionId,
+    status,
+    comment,
+    attachments,
+    clearExecutionCommentAndBts,
+    preserveExistingCommentIfFormSkipped,
+    onSuccess,
+  } = action.payload;
 
   try {
+    const statusUpper = status.toUpperCase();
+
     const requestData: {
       status: string;
       executionComment?: {
         comment?: string;
         attachments?: Array<{ id: string; fileName: string; fileType: string; fileSize: number }>;
+        btsTickets?: BtsTicket[];
       };
     } = {
-      status,
+      status: statusUpper,
     };
 
     const uploadedAttachments = (yield call(uploadAttachments, projectKey, attachments)) as Array<{
@@ -580,17 +604,45 @@ function* updateManualLaunchExecutionStatus(
     }>;
 
     const trimmedComment = isString(comment) ? comment.trim() : '';
-    const hasAttachments = !isEmpty(uploadedAttachments);
+    const hasNewAttachments = !isEmpty(uploadedAttachments);
 
-    if (trimmedComment || hasAttachments) {
-      requestData.executionComment = {};
+    if (statusUpper === MANUAL_LAUNCH_TO_RUN_STATUS_QUERY_VALUE) {
+      if (clearExecutionCommentAndBts) {
+        requestData.executionComment = {
+          comment: '',
+          attachments: [],
+          btsTickets: [],
+        };
+      }
+    
+    } else {
+      const currentExecution = (yield select(
+        activeManualLaunchExecutionSelector,
+      )) as TestCaseExecution | null;
 
-      if (trimmedComment) {
-        requestData.executionComment.comment = trimmedComment;
+      let commentForRequest = trimmedComment;
+      const savedComment = currentExecution?.executionComment?.comment;
+
+      if (
+        preserveExistingCommentIfFormSkipped &&
+        isEmpty(trimmedComment) &&
+        isString(savedComment) &&
+        !isEmpty(savedComment)
+      ) {
+        commentForRequest = savedComment;
       }
 
-      if (hasAttachments) {
+      requestData.executionComment = {
+        comment: commentForRequest,
+      };
+
+      if (hasNewAttachments) {
         requestData.executionComment.attachments = uploadedAttachments;
+      }
+
+      const existingBts = currentExecution?.executionComment?.btsTickets;
+      if (!isUndefined(existingBts) && existingBts.length > 0) {
+        requestData.executionComment.btsTickets = existingBts;
       }
     }
 
@@ -624,7 +676,8 @@ function* updateManualLaunchExecutionStatus(
       );
     }
 
-    const capitalizedStatus = status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
+    const capitalizedStatus =
+      statusUpper.charAt(0).toUpperCase() + statusUpper.slice(1).toLowerCase();
 
     yield put(
       showNotification({
@@ -648,8 +701,132 @@ function* updateManualLaunchExecutionStatus(
   }
 }
 
+interface UpdateManualLaunchExecutionCommentAction extends Action<
+  typeof UPDATE_MANUAL_LAUNCH_EXECUTION_COMMENT
+> {
+  payload: UpdateManualLaunchExecutionCommentParams;
+}
+
+function* updateManualLaunchExecutionComment(
+  action: UpdateManualLaunchExecutionCommentAction,
+): Generator {
+  const {
+    projectKey,
+    launchId,
+    executionId,
+    executionStatus,
+    comment,
+    existingAttachments,
+    newFiles,
+    removedAttachmentIds,
+    btsTickets,
+    onSuccess,
+    onFinally,
+  } = action.payload;
+
+  try {
+    const keptExisting = existingAttachments.filter(
+      (a) => !isAttachmentRemoved(a.id, removedAttachmentIds),
+    );
+
+    const uploadedAttachments = (yield call(uploadAttachments, projectKey, newFiles)) as Array<{
+      id: string;
+      fileName: string;
+      fileType: string;
+      fileSize: number;
+    }>;
+
+    const attachmentPayload = [
+      ...keptExisting.map(mapAttachmentForExecutionCommentPayload),
+      ...uploadedAttachments,
+    ];
+
+    const trimmedComment = isString(comment) ? comment.trim() : '';
+
+    const executionComment: {
+      comment: string;
+      attachments: Array<{
+        id: string;
+        fileName: string;
+        fileType: string;
+        fileSize: number;
+      }>;
+      btsTickets?: BtsTicket[];
+    } = {
+      comment: trimmedComment,
+      attachments: attachmentPayload,
+    };
+
+    if (!isUndefined(btsTickets)) {
+      executionComment.btsTickets = btsTickets;
+    }
+
+    const requestData = {
+      status: executionStatus,
+      executionComment,
+    };
+
+    const data = (yield call(
+      fetch,
+      URLS.manualLaunchExecutionById(projectKey, launchId, executionId),
+      {
+        method: 'PATCH',
+        data: requestData,
+      },
+    )) as TestCaseExecution;
+
+    yield put(fetchSuccessAction(ACTIVE_MANUAL_LAUNCH_EXECUTION_NAMESPACE, data));
+
+    const executionsState = (yield select(
+      (state: AppState) => state.manualLaunchTestCaseExecutions?.data,
+    )) as { content: TestCaseExecution[]; page: Page } | null;
+
+    if (executionsState?.content) {
+      const updatedContent = executionsState.content.map((exec) =>
+        exec.id === data.id ? data : exec,
+      );
+
+      yield put(
+        fetchSuccessAction(MANUAL_LAUNCH_TEST_CASE_EXECUTIONS_NAMESPACE, {
+          data: {
+            content: updatedContent,
+            page: executionsState.page,
+          },
+        }),
+      );
+    }
+
+    yield put(
+      showNotification({
+        messageId: 'executionCommentSaved',
+        type: NOTIFICATION_TYPES.SUCCESS,
+        typographyColor: NOTIFICATION_TYPOGRAPHY_COLOR_TYPES.WHITE,
+        duration: WARNING_NOTIFICATION_DURATION,
+      }),
+    );
+
+    if (onSuccess) {
+      onSuccess();
+    }
+  } catch {
+    yield put(
+      showErrorNotification({
+        messageId: 'errorOccurredTryAgain',
+      }),
+    );
+  } finally {
+    if (onFinally) {
+      onFinally();
+    }
+  }
+}
+
 function* watchUpdateManualLaunchExecutionStatus() {
   yield takeLatest(UPDATE_MANUAL_LAUNCH_EXECUTION_STATUS, updateManualLaunchExecutionStatus);
+}
+
+function* watchUpdateManualLaunchExecutionComment() {
+  yield takeLatest(UPDATE_MANUAL_LAUNCH_EXECUTION_COMMENT, updateManualLaunchExecutionComment);
 }
 
 function* watchGetManualLaunchFilteredFolders() {
@@ -664,6 +841,7 @@ export function* manualLaunchesSagas() {
     watchGetManualLaunchTestCaseExecutions(),
     watchGetManualLaunchExecution(),
     watchUpdateManualLaunchExecutionStatus(),
+    watchUpdateManualLaunchExecutionComment(),
     watchGetManualLaunchFilteredFolders(),
   ]);
 }

--- a/app/src/controllers/manualLaunch/sagas.ts
+++ b/app/src/controllers/manualLaunch/sagas.ts
@@ -523,16 +523,24 @@ interface UpdateManualLaunchExecutionStatusAction extends Action<
   payload: UpdateManualLaunchExecutionStatusParams;
 }
 
+type UploadedAttachmentPayload = {
+  id: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+};
+
+interface UploadAttachmentsResult {
+  attachments: UploadedAttachmentPayload[];
+  failureCount: number;
+}
+
 function* uploadAttachments(projectKey: string, attachments?: File[]): Generator {
-  const uploadedAttachments: Array<{
-    id: string;
-    fileName: string;
-    fileType: string;
-    fileSize: number;
-  }> = [];
+  const uploadedAttachments: UploadedAttachmentPayload[] = [];
+  let failureCount = 0;
 
   if (!attachments || attachments.length === 0) {
-    return uploadedAttachments;
+    return { attachments: uploadedAttachments, failureCount: 0 };
   }
 
   for (const file of attachments) {
@@ -552,6 +560,7 @@ function* uploadAttachments(projectKey: string, attachments?: File[]): Generator
         fileSize: file.size,
       });
     } catch {
+      failureCount += 1;
       yield put(
         showNotification({
           messageId: 'ExecutionStatusConfirmModal.attachmentUploadFailed',
@@ -564,7 +573,46 @@ function* uploadAttachments(projectKey: string, attachments?: File[]): Generator
     }
   }
 
-  return uploadedAttachments;
+  return { attachments: uploadedAttachments, failureCount };
+}
+
+function* patchManualLaunchExecutionAndSyncList(
+  projectKey: string,
+  launchId: string | number,
+  executionId: string | number,
+  requestData: unknown,
+): Generator {
+  const data = (yield call(
+    fetch,
+    URLS.manualLaunchExecutionById(projectKey, launchId, executionId),
+    {
+      method: 'PATCH',
+      data: requestData,
+    },
+  )) as TestCaseExecution;
+
+  yield put(fetchSuccessAction(ACTIVE_MANUAL_LAUNCH_EXECUTION_NAMESPACE, data));
+
+  const executionsState = (yield select(
+    (state: AppState) => state.manualLaunchTestCaseExecutions?.data,
+  )) as { content: TestCaseExecution[]; page: Page } | null;
+
+  if (executionsState?.content) {
+    const updatedContent = executionsState.content.map((exec) =>
+      exec.id === data.id ? data : exec,
+    );
+
+    yield put(
+      fetchSuccessAction(MANUAL_LAUNCH_TEST_CASE_EXECUTIONS_NAMESPACE, {
+        data: {
+          content: updatedContent,
+          page: executionsState.page,
+        },
+      }),
+    );
+  }
+
+  return data;
 }
 
 function* updateManualLaunchExecutionStatus(
@@ -580,6 +628,7 @@ function* updateManualLaunchExecutionStatus(
     clearExecutionCommentAndBts,
     preserveExistingCommentIfFormSkipped,
     onSuccess,
+    removedServerAttachmentIds,
   } = action.payload;
 
   try {
@@ -596,12 +645,17 @@ function* updateManualLaunchExecutionStatus(
       status: statusUpper,
     };
 
-    const uploadedAttachments = (yield call(uploadAttachments, projectKey, attachments)) as Array<{
-      id: string;
-      fileName: string;
-      fileType: string;
-      fileSize: number;
-    }>;
+    const { attachments: uploadedAttachments, failureCount: attachmentUploadFailures } =
+      (yield call(uploadAttachments, projectKey, attachments)) as UploadAttachmentsResult;
+
+    if (attachmentUploadFailures > 0) {
+      yield put(
+        showErrorNotification({
+          messageId: 'errorOccurredTryAgain',
+        }),
+      );
+      return;
+    }
 
     const trimmedComment = isString(comment) ? comment.trim() : '';
     const hasNewAttachments = !isEmpty(uploadedAttachments);
@@ -636,7 +690,15 @@ function* updateManualLaunchExecutionStatus(
         comment: commentForRequest,
       };
 
-      if (hasNewAttachments) {
+      if (removedServerAttachmentIds !== undefined) {
+        const keptServer = (currentExecution?.executionComment?.attachments ?? []).filter(
+          (a) => !isAttachmentRemoved(a.id, removedServerAttachmentIds),
+        );
+        requestData.executionComment.attachments = [
+          ...keptServer.map(mapAttachmentForExecutionCommentPayload),
+          ...uploadedAttachments,
+        ];
+      } else if (hasNewAttachments) {
         requestData.executionComment.attachments = uploadedAttachments;
       }
 
@@ -646,35 +708,7 @@ function* updateManualLaunchExecutionStatus(
       }
     }
 
-    const data = (yield call(
-      fetch,
-      URLS.manualLaunchExecutionById(projectKey, launchId, executionId),
-      {
-        method: 'PATCH',
-        data: requestData,
-      },
-    )) as TestCaseExecution;
-
-    yield put(fetchSuccessAction(ACTIVE_MANUAL_LAUNCH_EXECUTION_NAMESPACE, data));
-
-    const executionsState = (yield select(
-      (state: AppState) => state.manualLaunchTestCaseExecutions?.data,
-    )) as { content: TestCaseExecution[]; page: Page } | null;
-
-    if (executionsState?.content) {
-      const updatedContent = executionsState.content.map((exec) =>
-        exec.id === data.id ? data : exec,
-      );
-
-      yield put(
-        fetchSuccessAction(MANUAL_LAUNCH_TEST_CASE_EXECUTIONS_NAMESPACE, {
-          data: {
-            content: updatedContent,
-            page: executionsState.page,
-          },
-        }),
-      );
-    }
+    yield call(patchManualLaunchExecutionAndSyncList, projectKey, launchId, executionId, requestData);
 
     const capitalizedStatus =
       statusUpper.charAt(0).toUpperCase() + statusUpper.slice(1).toLowerCase();
@@ -729,12 +763,17 @@ function* updateManualLaunchExecutionComment(
       (a) => !isAttachmentRemoved(a.id, removedAttachmentIds),
     );
 
-    const uploadedAttachments = (yield call(uploadAttachments, projectKey, newFiles)) as Array<{
-      id: string;
-      fileName: string;
-      fileType: string;
-      fileSize: number;
-    }>;
+    const { attachments: uploadedAttachments, failureCount: attachmentUploadFailures } =
+      (yield call(uploadAttachments, projectKey, newFiles)) as UploadAttachmentsResult;
+
+    if (attachmentUploadFailures > 0) {
+      yield put(
+        showErrorNotification({
+          messageId: 'errorOccurredTryAgain',
+        }),
+      );
+      return;
+    }
 
     const attachmentPayload = [
       ...keptExisting.map(mapAttachmentForExecutionCommentPayload),
@@ -766,35 +805,7 @@ function* updateManualLaunchExecutionComment(
       executionComment,
     };
 
-    const data = (yield call(
-      fetch,
-      URLS.manualLaunchExecutionById(projectKey, launchId, executionId),
-      {
-        method: 'PATCH',
-        data: requestData,
-      },
-    )) as TestCaseExecution;
-
-    yield put(fetchSuccessAction(ACTIVE_MANUAL_LAUNCH_EXECUTION_NAMESPACE, data));
-
-    const executionsState = (yield select(
-      (state: AppState) => state.manualLaunchTestCaseExecutions?.data,
-    )) as { content: TestCaseExecution[]; page: Page } | null;
-
-    if (executionsState?.content) {
-      const updatedContent = executionsState.content.map((exec) =>
-        exec.id === data.id ? data : exec,
-      );
-
-      yield put(
-        fetchSuccessAction(MANUAL_LAUNCH_TEST_CASE_EXECUTIONS_NAMESPACE, {
-          data: {
-            content: updatedContent,
-            page: executionsState.page,
-          },
-        }),
-      );
-    }
+    yield call(patchManualLaunchExecutionAndSyncList, projectKey, launchId, executionId, requestData);
 
     yield put(
       showNotification({

--- a/app/src/controllers/manualLaunch/types.ts
+++ b/app/src/controllers/manualLaunch/types.ts
@@ -90,6 +90,7 @@ export interface UpdateManualLaunchExecutionStatusParams extends ManualLaunchExe
   comment?: string;
   postIssueToBts?: boolean;
   attachments?: File[];
+  removedServerAttachmentIds?: Array<string | number>;
   clearExecutionCommentAndBts?: boolean;
   preserveExistingCommentIfFormSkipped?: boolean;
   onSuccess?: () => void;

--- a/app/src/controllers/manualLaunch/types.ts
+++ b/app/src/controllers/manualLaunch/types.ts
@@ -79,15 +79,31 @@ export interface GetManualLaunchExecutionParams {
   executionId: string | number;
 }
 
-export interface UpdateManualLaunchExecutionStatusParams {
+export interface ManualLaunchExecutionActionKey {
   projectKey: string;
   launchId: string | number;
   executionId: string | number;
+}
+
+export interface UpdateManualLaunchExecutionStatusParams extends ManualLaunchExecutionActionKey {
   status: string;
   comment?: string;
   postIssueToBts?: boolean;
   attachments?: File[];
+  clearExecutionCommentAndBts?: boolean;
+  preserveExistingCommentIfFormSkipped?: boolean;
   onSuccess?: () => void;
+}
+
+export interface UpdateManualLaunchExecutionCommentParams extends ManualLaunchExecutionActionKey {
+  executionStatus: string;
+  comment: string;
+  existingAttachments: Attachment[];
+  newFiles: File[];
+  removedAttachmentIds: Array<string | number>;
+  btsTickets?: BtsTicket[];
+  onSuccess?: () => void;
+  onFinally?: () => void;
 }
 
 export interface ManualLaunchState {

--- a/app/src/controllers/manualLaunch/utils.ts
+++ b/app/src/controllers/manualLaunch/utils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isNumber } from 'es-toolkit/compat';
+
+import type { Attachment } from './types';
+
+export function mapAttachmentForExecutionCommentPayload(a: Attachment): {
+  id: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+} {
+  return {
+    id: String(a.id),
+    fileName: a.fileName,
+    fileType: a.fileType,
+    fileSize: isNumber(a.fileSize) ? a.fileSize : 0,
+  };
+}
+
+export function isAttachmentRemoved(
+  id: string | number,
+  removed: Array<string | number>,
+): boolean {
+  const idStr = String(id);
+  return removed.some((r) => String(r) === idStr);
+}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.scss
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.execution-comment-section {
+  margin-top: 24px;
+  margin-bottom: 72px;
+  padding: 32px;
+  border: 1px solid var(--rp-ui-base-e-100);
+  border-radius: 8px;
+  background-color: var(--rp-ui-base-bg-000);
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  label {
+    font-family: $FONT-ROBOTO-MEDIUM;
+    font-size: 13px;
+    line-height: 20px;
+    text-indent: 1px;
+    color: $COLOR--almost-black;
+  }
+
+  textarea {
+    font-family: $FONT-ROBOTO-REGULAR;
+    font-size: 13px;
+    line-height: 20px;
+    color: var(--rp-ui-base-almost-black);
+
+    &::placeholder {
+      color: var(--rp-ui-base-e-400);
+    }
+  }
+
+  &__divider {
+    margin-top: 32px;
+    border-top: 1px solid var(--rp-ui-base-e-100);
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 16px;
+    margin-top: 16px;
+  }
+
+  &__clear {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    box-shadow: none;
+    cursor: pointer;
+    font-family: $FONT-ROBOTO-MEDIUM;
+    font-size: 13px;
+    line-height: 20px;
+    color: $COLOR--topaz-2;
+
+    &:hover,
+    &:active {
+      border: none !important;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--rp-ui-base-topaz-focused);
+      outline-offset: 2px;
+    }
+  }
+
+  &__save {
+    min-width: 120px;
+  }
+}
+
+.attachments-block {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  :global(.rp-ui-fp__attached-files-list) {
+    padding-top: 8px;
+    padding-bottom: 0;
+  }
+
+  &__dropzone {
+    width: 100%;
+    height: 54px;
+    border-radius: 4px;
+    border: 2px dashed var(--rp-ui-base-e-200);
+    background: transparent;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: relative;
+    min-height: 54px;
+    pointer-events: none;
+    margin-bottom: 8px;
+
+    > * {
+      pointer-events: auto;
+    }
+  }
+
+  &__title {
+    font-family: $FONT-ROBOTO-MEDIUM;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--rp-ui-base-almost-black);
+  }
+
+  &__add {
+    display: flex;
+    align-items: center;
+    column-gap: 8px;
+  }
+
+  &__hint {
+    display: flex;
+    align-items: center;
+    column-gap: 4px;
+    font-size: 11px;
+    color: var(--rp-ui-base-e-400);
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  &__existing {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-bottom: 8px;
+  }
+
+  &__existing-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--rp-ui-base-e-100);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__existing-preview {
+    flex: 1;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  &__slider {
+    margin-top: 0;
+  }
+
+  &__remove {
+    flex-shrink: 0;
+    align-self: center;
+  }
+}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
@@ -83,7 +83,7 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
 
   useEffect(() => {
     setComment(savedComment);
-  }, [savedComment]);
+  }, [execution.id, savedComment]);
 
   const visibleExistingAttachments = useMemo(() => {
     const list = execution.executionComment?.attachments ?? [];

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
@@ -95,9 +95,17 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
     const savedTrimmed = savedComment.trim();
     const draftTrimmed = comment.trim();
     return (
-      draftTrimmed !== savedTrimmed || pendingFiles.length > 0 || removedAttachmentIds.size > 0
+      draftTrimmed !== savedTrimmed ||
+      !isEmpty(pendingFiles) ||
+      !isEmpty(removedAttachmentIds)
     );
-  }, [comment, pendingFiles.length, removedAttachmentIds, savedComment]);
+  }, [comment, pendingFiles, removedAttachmentIds, savedComment]);
+
+  const hasClearableContent = useMemo(
+    () =>
+      !isEmpty(comment.trim()) || !isEmpty(pendingFiles) || !isEmpty(visibleExistingAttachments),
+    [comment, pendingFiles, visibleExistingAttachments],
+  );
 
   const handleCommentChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
     setComment(e.target.value);
@@ -120,9 +128,13 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
   };
 
   const handleClearLocal = () => {
-    setComment(savedComment);
+    setComment('');
     setPendingFiles([]);
-    setRemovedAttachmentIds(new Set());
+    setRemovedAttachmentIds(
+      new Set(
+        (execution.executionComment?.attachments ?? []).map((a) => String(a.id)),
+      ),
+    );
   };
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
@@ -230,7 +242,7 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
             type="button"
             variant="ghost"
             className={cx('execution-comment-section__clear')}
-            disabled={isSaving}
+            disabled={isSaving || !hasClearableContent}
             onClick={handleClearLocal}
           >
             {formatMessage(messages.clearExecutionComment)}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FC,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  FormEventHandler,
+  ChangeEventHandler,
+} from 'react';
+import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Button,
+  DeleteIcon,
+  DragAndDropIcon,
+  FieldTextFlex,
+  FileDropArea,
+  PlusIcon,
+} from '@reportportal/ui-kit';
+import { MIME_TYPES, FileWithValidation } from '@reportportal/ui-kit/fileDropArea';
+import { isEmpty } from 'es-toolkit/compat';
+
+import { createClassnames } from 'common/utils';
+import { MAX_FILE_SIZE } from 'common/constants/fileConstants';
+import { useTextareaAutoResize } from 'common/hooks';
+import { projectKeySelector } from 'controllers/project';
+import {
+  updateManualLaunchExecutionCommentAction,
+  type TestCaseExecution,
+} from 'controllers/manualLaunch';
+import { useManualLaunchId } from 'hooks/useTypedSelector';
+
+import { AttachmentsWithSlider } from 'pages/inside/common/attachmentsWithSlider';
+import { messages as statusModalMessages } from '../executionStatusConfirmModal/messages';
+import { messages } from '../messages';
+import { toAttachmentWithSlider } from '../utils';
+import { commonMessages } from 'pages/inside/common/common-messages';
+
+import styles from './executionCommentSection.scss';
+
+const cx = createClassnames(styles);
+
+export interface ExecutionCommentSectionProps {
+  execution: TestCaseExecution;
+}
+
+export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ execution }) => {
+  const { formatMessage } = useIntl();
+  const dispatch = useDispatch();
+  const projectKey = useSelector(projectKeySelector);
+  const launchId = useManualLaunchId();
+
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  useTextareaAutoResize(textareaRef);
+
+  const savedComment = execution.executionComment?.comment ?? '';
+
+  const [comment, setComment] = useState(savedComment);
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [removedAttachmentIds, setRemovedAttachmentIds] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setComment(savedComment);
+    setPendingFiles([]);
+    setRemovedAttachmentIds(new Set());
+  }, [execution.id]);
+
+  useEffect(() => {
+    setComment(savedComment);
+  }, [savedComment]);
+
+  const visibleExistingAttachments = useMemo(() => {
+    const list = execution.executionComment?.attachments ?? [];
+    return list.filter((a) => !removedAttachmentIds.has(String(a.id)));
+  }, [execution.executionComment?.attachments, removedAttachmentIds]);
+
+  const isDirty = useMemo(() => {
+    const savedTrimmed = savedComment.trim();
+    const draftTrimmed = comment.trim();
+    return (
+      draftTrimmed !== savedTrimmed || pendingFiles.length > 0 || removedAttachmentIds.size > 0
+    );
+  }, [comment, pendingFiles.length, removedAttachmentIds, savedComment]);
+
+  const handleCommentChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
+    setComment(e.target.value);
+  };
+
+  const handleFilesAdded = (filesWithValidation: FileWithValidation[]) => {
+    const files = filesWithValidation.map((f) => f.file);
+    setPendingFiles((prev) => [...prev, ...files]);
+  };
+
+  const handlePendingRemove = (fileId: string) => {
+    const index = pendingFiles.findIndex((f, i) => `${f.name}-${i}` === fileId);
+    if (index !== -1) {
+      setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+    }
+  };
+
+  const handleExistingRemove = (id: string | number) => {
+    setRemovedAttachmentIds((prev) => new Set([...prev, String(id)]));
+  };
+
+  const handleClearLocal = () => {
+    setComment(savedComment);
+    setPendingFiles([]);
+    setRemovedAttachmentIds(new Set());
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    if (!launchId || isSaving || !isDirty) return;
+
+    setIsSaving(true);
+    dispatch(
+      updateManualLaunchExecutionCommentAction({
+        projectKey,
+        launchId,
+        executionId: execution.id,
+        executionStatus: execution.executionStatus,
+        comment,
+        existingAttachments: execution.executionComment?.attachments ?? [],
+        newFiles: pendingFiles,
+        removedAttachmentIds: Array.from(removedAttachmentIds),
+        btsTickets: execution.executionComment?.btsTickets,
+        onSuccess: () => {
+          setPendingFiles([]);
+          setRemovedAttachmentIds(new Set());
+        },
+        onFinally: () => setIsSaving(false),
+      }),
+    );
+  };
+
+  return (
+    <section className={cx('execution-comment-section')}>
+      <form className={cx('execution-comment-section__form')} onSubmit={handleSubmit}>
+        <FieldTextFlex
+          ref={textareaRef}
+          label={formatMessage(messages.executionCommentTitle)}
+          placeholder={formatMessage(statusModalMessages.commentPlaceholder)}
+          value={comment}
+          onChange={handleCommentChange}
+          minHeight={100}
+        />
+        <div className={cx('execution-comment-section__divider')} />
+        <div className={cx('attachments-block')}>
+          <FileDropArea
+            variant="overlay"
+            maxFileSize={MAX_FILE_SIZE}
+            acceptFileMimeTypes={[MIME_TYPES.jpeg, MIME_TYPES.png, MIME_TYPES.pdf]}
+            onFilesAdded={handleFilesAdded}
+            messages={{
+              incorrectFileSize: formatMessage(statusModalMessages.incorrectFileSize),
+              incorrectFileFormat: formatMessage(statusModalMessages.incorrectFileFormat),
+            }}
+          >
+            <FileDropArea.DropZone className={cx('attachments-block__dropzone')} icon={<div />} />
+            <div className={cx('attachments-block__header')}>
+              <span className={cx('attachments-block__title')}>
+                {formatMessage(commonMessages.attachments)}
+              </span>
+              <div className={cx('attachments-block__add')}>
+                <span className={cx('attachments-block__hint')}>
+                  <DragAndDropIcon />
+                  {formatMessage(statusModalMessages.dropFilesHere)}
+                </span>
+                <FileDropArea.BrowseButton icon={<PlusIcon />}>
+                  {formatMessage(statusModalMessages.add)}
+                </FileDropArea.BrowseButton>
+              </div>
+            </div>
+            {!isEmpty(visibleExistingAttachments) && (
+              <div className={cx('attachments-block__existing')}>
+                {visibleExistingAttachments.map((att) => (
+                  <div key={String(att.id)} className={cx('attachments-block__existing-row')}>
+                    <div className={cx('attachments-block__existing-preview')}>
+                      <AttachmentsWithSlider
+                        attachments={[toAttachmentWithSlider(att)]}
+                        className={cx('attachments-block__slider')}
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      variant="text"
+                      adjustWidthOn="content"
+                      className={cx('attachments-block__remove')}
+                      onClick={() => handleExistingRemove(att.id)}
+                      aria-label={formatMessage(messages.removeAttachment)}
+                    >
+                      <DeleteIcon />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {!isEmpty(pendingFiles) && (
+              <FileDropArea.AttachedFilesList
+                files={pendingFiles.map((file, index) => ({
+                  id: `${file.name}-${index}`,
+                  fileName: file.name,
+                  file,
+                  size: file.size,
+                }))}
+                onRemoveFile={handlePendingRemove}
+              />
+            )}
+          </FileDropArea>
+        </div>
+        <div className={cx('execution-comment-section__footer')}>
+          <Button
+            type="button"
+            variant="ghost"
+            className={cx('execution-comment-section__clear')}
+            disabled={isSaving}
+            onClick={handleClearLocal}
+          >
+            {formatMessage(messages.clearExecutionComment)}
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={isSaving || !isDirty}
+            className={cx('execution-comment-section__save')}
+          >
+            {formatMessage(messages.saveExecutionComment)}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
@@ -77,7 +77,6 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    setComment(savedComment);
     setPendingFiles([]);
     setRemovedAttachmentIds(new Set());
   }, [execution.id]);
@@ -172,6 +171,7 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
           value={comment}
           onChange={handleCommentChange}
           minHeight={100}
+          disabled={isSaving}
         />
         <div className={cx('execution-comment-section__divider')} />
         <div className={cx('attachments-block')}>
@@ -179,6 +179,7 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
             variant="overlay"
             maxFileSize={MAX_FILE_SIZE}
             acceptFileMimeTypes={[MIME_TYPES.jpeg, MIME_TYPES.png, MIME_TYPES.pdf]}
+            isDisabled={isSaving}
             onFilesAdded={handleFilesAdded}
             messages={{
               incorrectFileSize: formatMessage(statusModalMessages.incorrectFileSize),

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
@@ -91,11 +91,40 @@
   flex-direction: column;
   position: relative;
   margin-top: 16px;
+  row-gap: 8px;
 
   :global(.rp-ui-fp__attached-files-list) {
     padding-top: 8px;
     padding-bottom: 16px;
   }
+}
+
+.modal-existing-attachments {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.modal-existing-attachments__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.modal-existing-attachments__preview {
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.modal-existing-attachments__slider {
+  margin-top: 0;
+}
+
+.modal-existing-attachments__remove {
+  flex-shrink: 0;
+  align-self: center;
 }
 
 .checkbox-section + .divider {

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { FC, useState, useEffect, FormEvent, useRef } from 'react';
+import { FC, useState, useEffect, useMemo, FormEvent, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { reduxForm, InjectedFormProps, initialize } from 'redux-form';
 import {
+  Button,
+  DeleteIcon,
   Modal,
   FileDropArea,
   FieldTextFlex,
@@ -45,8 +47,11 @@ import { MAX_FILE_SIZE } from 'common/constants/fileConstants';
 import { useModalButtons } from 'hooks/useModalButtons';
 import { useTextareaAutoResize } from 'common/hooks';
 import { ExecutionStatus } from 'pages/inside/manualLaunchesPage/types';
+import { AttachmentsWithSlider } from 'pages/inside/common/attachmentsWithSlider';
+import { toAttachmentWithSlider } from '../utils';
 
 import type { ExecutionStatusConfirmFormValues, ExecutionStatusConfirmModalProps } from '../types';
+import { messages as manualExecutionPageMessages } from '../messages';
 import {
   EXECUTION_STATUS_CONFIRM_MODAL,
   EXECUTION_STATUS_CONFIRM_FORM_NAME,
@@ -69,6 +74,9 @@ const ExecutionStatusConfirmModalComponent: FC<
   const launchId = useManualLaunchId();
   const activeExecution = useSelector(activeManualLaunchExecutionSelector);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
+  const [removedServerAttachmentIds, setRemovedServerAttachmentIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   useTextareaAutoResize(textareaRef);
 
@@ -82,6 +90,10 @@ const ExecutionStatusConfirmModalComponent: FC<
     if (index !== -1) {
       setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
     }
+  };
+
+  const handleServerAttachmentRemove = (id: string | number) => {
+    setRemovedServerAttachmentIds((prev) => new Set([...prev, String(id)]));
   };
 
   const status = data?.status || 'passed';
@@ -99,6 +111,17 @@ const ExecutionStatusConfirmModalComponent: FC<
     : formatMessage(messages.markAsStatus, { status: statusLabel });
 
   const shouldSeedCommentForm = !isStatusChange && !isClearStatus;
+
+  const visibleServerAttachments = useMemo(() => {
+    if (!executionId || activeExecution?.id !== executionId) return [];
+    const list = activeExecution.executionComment?.attachments ?? [];
+    return list.filter((a) => !removedServerAttachmentIds.has(String(a.id)));
+  }, [
+    executionId,
+    activeExecution?.id,
+    activeExecution?.executionComment?.attachments,
+    removedServerAttachmentIds,
+  ]);
 
   useEffect(() => {
     if (!executionId || dirty || !shouldSeedCommentForm) return;
@@ -126,6 +149,7 @@ const ExecutionStatusConfirmModalComponent: FC<
 
   useEffect(() => {
     setAttachedFiles([]);
+    setRemovedServerAttachmentIds(new Set());
   }, [data?.executionId, data?.status, data?.currentStatus]);
 
   const onSubmit = (values: ExecutionStatusConfirmFormValues) => {
@@ -147,6 +171,9 @@ const ExecutionStatusConfirmModalComponent: FC<
         attachments: clearCommentCheckboxChecked ? [] : attachedFiles,
         clearExecutionCommentAndBts: isClearStatus ? clearCommentCheckboxChecked : undefined,
         preserveExistingCommentIfFormSkipped: isStatusChange,
+        ...(!isClearStatus && !isStatusChange
+          ? { removedServerAttachmentIds: Array.from(removedServerAttachmentIds) }
+          : {}),
       }),
     );
     dispatch(hideModalAction());
@@ -229,6 +256,35 @@ const ExecutionStatusConfirmModalComponent: FC<
             {showPostIssueToBts && <div className={cx('divider')} />}
 
             <div className={cx('attachments-section')}>
+              {!isEmpty(visibleServerAttachments) && (
+                <div className={cx('modal-existing-attachments')}>
+                  {visibleServerAttachments.map((att) => (
+                    <div
+                      key={String(att.id)}
+                      className={cx('modal-existing-attachments__row')}
+                    >
+                      <div className={cx('modal-existing-attachments__preview')}>
+                        <AttachmentsWithSlider
+                          attachments={[toAttachmentWithSlider(att)]}
+                          className={cx('modal-existing-attachments__slider')}
+                        />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="text"
+                        adjustWidthOn="content"
+                        className={cx('modal-existing-attachments__remove')}
+                        onClick={() => handleServerAttachmentRemove(att.id)}
+                        aria-label={formatMessage(
+                          manualExecutionPageMessages.removeAttachment,
+                        )}
+                      >
+                        <DeleteIcon />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
               <FileDropArea
                 variant="overlay"
                 maxFileSize={MAX_FILE_SIZE}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { FC, useState, FormEvent, useRef } from 'react';
+import { FC, useState, useEffect, FormEvent, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { reduxForm, InjectedFormProps } from 'redux-form';
+import { reduxForm, InjectedFormProps, initialize } from 'redux-form';
 import {
   Modal,
   FileDropArea,
@@ -30,17 +30,21 @@ import { VoidFn } from '@reportportal/ui-kit/common';
 
 import { withModal, hideModalAction } from 'controllers/modal';
 import { createClassnames } from 'common/utils';
+import { isString } from 'es-toolkit';
 import { isEmpty } from 'es-toolkit/compat';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { InputCheckbox } from 'components/inputs/inputCheckbox';
 import { useManualLaunchId } from 'hooks/useTypedSelector';
-import { updateManualLaunchExecutionStatusAction } from 'controllers/manualLaunch';
+import {
+  updateManualLaunchExecutionStatusAction,
+  activeManualLaunchExecutionSelector,
+} from 'controllers/manualLaunch';
 import { projectKeySelector } from 'controllers/project';
 import { MAX_FILE_SIZE } from 'common/constants/fileConstants';
 import { useModalButtons } from 'hooks/useModalButtons';
 import { useTextareaAutoResize } from 'common/hooks';
-import { ExecutionStatus } from "pages/inside/manualLaunchesPage/types";
+import { ExecutionStatus } from 'pages/inside/manualLaunchesPage/types';
 
 import type { ExecutionStatusConfirmFormValues, ExecutionStatusConfirmModalProps } from '../types';
 import {
@@ -63,6 +67,7 @@ const ExecutionStatusConfirmModalComponent: FC<
   const dispatch = useDispatch();
   const projectKey = useSelector(projectKeySelector);
   const launchId = useManualLaunchId();
+  const activeExecution = useSelector(activeManualLaunchExecutionSelector);
   const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   useTextareaAutoResize(textareaRef);
@@ -93,8 +98,43 @@ const ExecutionStatusConfirmModalComponent: FC<
     ? formatMessage(messages.clearStatus)
     : formatMessage(messages.markAsStatus, { status: statusLabel });
 
+  const shouldSeedCommentForm = !isStatusChange && !isClearStatus;
+
+  useEffect(() => {
+    if (!executionId || dirty || !shouldSeedCommentForm) return;
+
+    const comment =
+      activeExecution?.id === executionId
+        ? String(activeExecution.executionComment?.comment ?? '')
+        : '';
+
+    dispatch(
+      initialize(EXECUTION_STATUS_CONFIRM_FORM_NAME, {
+        comment,
+        postIssueToBts: false,
+        clearCommentAndLinksToBTS: false,
+      }),
+    );
+  }, [
+    executionId,
+    shouldSeedCommentForm,
+    dirty,
+    dispatch,
+    activeExecution?.id,
+    activeExecution?.executionComment?.comment,
+  ]);
+
+  useEffect(() => {
+    setAttachedFiles([]);
+  }, [data?.executionId, data?.status, data?.currentStatus]);
+
   const onSubmit = (values: ExecutionStatusConfirmFormValues) => {
     if (!executionId) return;
+
+    const clearValue = values.clearCommentAndLinksToBTS as boolean | string | undefined;
+    const clearCommentCheckboxChecked = isString(clearValue)
+      ? clearValue.toLowerCase() === 'true'
+      : clearValue === true;
 
     dispatch(
       updateManualLaunchExecutionStatusAction({
@@ -102,9 +142,11 @@ const ExecutionStatusConfirmModalComponent: FC<
         launchId,
         executionId,
         status: status.toUpperCase(),
-        comment: values.clearCommentAndLinksToBTS ? '' : values.comment,
-        postIssueToBts: values.clearCommentAndLinksToBTS ? false : values.postIssueToBts,
-        attachments: values.clearCommentAndLinksToBTS ? [] : attachedFiles,
+        comment: clearCommentCheckboxChecked ? '' : values.comment,
+        postIssueToBts: clearCommentCheckboxChecked ? false : values.postIssueToBts,
+        attachments: clearCommentCheckboxChecked ? [] : attachedFiles,
+        clearExecutionCommentAndBts: isClearStatus ? clearCommentCheckboxChecked : undefined,
+        preserveExistingCommentIfFormSkipped: isStatusChange,
       }),
     );
     dispatch(hideModalAction());
@@ -246,10 +288,13 @@ const ExecutionStatusConfirmModalComponent: FC<
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 export const ExecutionStatusConfirmModal = withModal(EXECUTION_STATUS_CONFIRM_MODAL)(
   reduxForm<ExecutionStatusConfirmFormValues, ExecutionStatusConfirmModalProps>({
     form: EXECUTION_STATUS_CONFIRM_FORM_NAME,
     destroyOnUnmount: true,
+    initialValues: {
+      clearCommentAndLinksToBTS: false,
+      postIssueToBts: false,
+    },
   })(ExecutionStatusConfirmModalComponent),
 );

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { isEmpty } from 'es-toolkit/compat';
@@ -45,9 +45,11 @@ import { ExecutionStatusDropdown } from './executionStatusDropdown';
 import { ExecutionStatusConfirmModal } from './executionStatusConfirmModal';
 import { TextBasedContent } from './textBasedContent';
 import { StepsBasedContent } from './stepsBasedContent';
+import { ExecutionCommentSection } from './executionCommentSection/executionCommentSection';
 import { messages } from './messages';
 import { commonMessages } from 'pages/inside/common/common-messages';
 import { messages as manualLaunchesMessages } from '../messages';
+import { hasPersistedExecutionComment } from './utils';
 
 import styles from './manualLaunchExecutionPage.scss';
 
@@ -120,6 +122,12 @@ export const ManualLaunchExecutionPage = () => {
   const isInProgress = executionStatus === ExecutionStatus.IN_PROGRESS;
   const hasStatus = executionStatus && executionStatus !== ExecutionStatus.TO_RUN && !isInProgress;
 
+  const showExecutionCommentSection = hasStatus || hasPersistedExecutionComment(execution);
+
+  useEffect(() => {
+    setShowStatusButtons(false);
+  }, [execution?.id, hasStatus]);
+
   const handleRunTestClick = () => {
     setShowStatusButtons(true);
   };
@@ -178,7 +186,9 @@ export const ManualLaunchExecutionPage = () => {
       <span className={cx('manual-launch-execution-page__title-business-id')}>
         {execution.testCaseDisplayId}
       </span>
-      <span className={cx('manual-launch-execution-page__title-name')}>{execution.testCaseName}</span>
+      <span className={cx('manual-launch-execution-page__title-name')}>
+        {execution.testCaseName}
+      </span>
     </span>
   );
 
@@ -199,6 +209,7 @@ export const ManualLaunchExecutionPage = () => {
             ) : (
               <StepsBasedContent execution={execution} />
             )}
+            {showExecutionCommentSection && <ExecutionCommentSection execution={execution} />}
           </div>
         </div>
       </ScrollWrapper>

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/messages.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/messages.ts
@@ -49,6 +49,22 @@ export const messages = defineMessages({
     id: 'ManualLaunchExecutionPage.executionStatusUpdated',
     defaultMessage: 'Execution status updated to {status}',
   },
+  executionCommentTitle: {
+    id: 'ManualLaunchExecutionPage.executionCommentTitle',
+    defaultMessage: 'Execution comment',
+  },
+  clearExecutionComment: {
+    id: 'ManualLaunchExecutionPage.clearExecutionComment',
+    defaultMessage: 'Clear comment',
+  },
+  saveExecutionComment: {
+    id: 'ManualLaunchExecutionPage.saveExecutionComment',
+    defaultMessage: 'Save',
+  },
+  removeAttachment: {
+    id: 'ManualLaunchExecutionPage.removeAttachment',
+    defaultMessage: 'Remove attachment',
+  },
   clearStatus: {
     id: 'ExecutionStatusPopover.clearStatus',
     defaultMessage: 'Clear status',

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/utils.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/utils.ts
@@ -14,8 +14,46 @@
  * limitations under the License.
  */
 
-import type { ManualScenarioRequirement } from 'controllers/manualLaunch';
+import { isNotNil } from 'es-toolkit';
+import { isEmpty } from 'es-toolkit/compat';
+
+import type {
+  Attachment,
+  ManualScenarioRequirement,
+  TestCaseExecution,
+} from 'controllers/manualLaunch';
 import type { Requirement } from 'types/testCase';
+import type { AttachmentWithSlider } from 'pages/inside/common/attachmentsWithSlider/types';
+import { getFileExtension } from 'pages/inside/common/attachmentsWithSlider/utils';
 
 export const requirementsToItems = (requirements?: ManualScenarioRequirement[]): Requirement[] =>
   requirements?.map((requirement) => ({ id: requirement.id, value: requirement.value })) ?? [];
+
+export function hasPersistedExecutionComment(
+  execution: TestCaseExecution | null | undefined,
+): boolean {
+  const payload = execution?.executionComment;
+  if (!payload) return false;
+
+  return Boolean(payload.comment?.trim()) || !isEmpty(payload.attachments ?? []);
+}
+
+const PREVIEWABLE_IMAGE_EXT = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg']);
+
+export function toAttachmentWithSlider(attachment: Attachment): AttachmentWithSlider {
+  const id = Number(attachment.id);
+  const ext = getFileExtension(attachment.fileName);
+  const hasThumbFlag = (attachment as { hasThumbnail?: boolean }).hasThumbnail;
+  const hasThumbnail =
+    Boolean(hasThumbFlag) ||
+    (Boolean(attachment.fileType) && /^image\//i.test(attachment.fileType)) ||
+    (isNotNil(ext) && PREVIEWABLE_IMAGE_EXT.has(ext));
+
+  return {
+    id: Number.isFinite(id) ? id : 0,
+    fileName: attachment.fileName,
+    fileSize: attachment.fileSize,
+    fileType: attachment.fileType,
+    hasThumbnail,
+  };
+}


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

https://github.com/user-attachments/assets/8d0afc11-781a-42af-804e-25a822a70717




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution comment section: editable comment, save/clear actions, attachment upload, preview and removal.
  * Separate comment save flow with success/error notifications.

* **Bug Fixes**
  * Prevent partial saves by aborting when attachment uploads fail.
  * Respect user choices to preserve or clear comments/attachments when updating status.

* **Style**
  * Improved styling and layout for comment, attachments, and modal attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->