### PR TITLE
EPMRPP-114239 || Owner of the personal organization cannot open the Users page

### DIFF
--- a/app/src/controllers/pages/selectors.js
+++ b/app/src/controllers/pages/selectors.js
@@ -23,6 +23,7 @@ import {
   activeProjectSelector,
   assignedOrganizationsSelector,
   assignedProjectsSelector,
+  userAccountRoleSelector,
   userIdSelector,
 } from 'controllers/user';
 import { ALL } from 'common/constants/reservedFilterIds';
@@ -40,8 +41,6 @@ import {
   locationSelector,
   payloadSelector,
 } from './typed-selectors';
-import { userRolesSelector } from './'; // TODO: circular dependency — direct import from './userRolesSelector' breaks module resolution
-
 export const searchStringSelector = (state) => locationSelector(state).search || '';
 export const isInitialDispatchDoneSelector = (state) => !!locationSelector(state).kind;
 export const currentPathSelector = (state) => {
@@ -213,27 +212,28 @@ export const activeProjectRoleSelector = createSelector(
 export const userAssignedSelector = (projectSlug, organizationSlug) => (state) => {
   const assignedOrganizations = assignedOrganizationsSelector(state);
   const assignedProjects = assignedProjectsSelector(state);
-  const { userRole, organizationRole, projectRole } = userRolesSelector(state);
+  const userRole = userAccountRoleSelector(state);
 
-  const isAdmin = userRole === ADMINISTRATOR;
-  const isManager = organizationRole === MANAGER;
-  let isAssignedToTargetOrganization = false;
+  let assignedOrganization = organizationSlug ? assignedOrganizations[organizationSlug] : undefined;
 
   const assignedProject = findAssignedProjectByOrganization(
     assignedProjects,
-    assignedOrganizations[organizationSlug]?.organizationId,
+    assignedOrganization?.organizationId,
     projectSlug,
   );
 
-  if (organizationSlug) {
-    isAssignedToTargetOrganization = organizationSlug in assignedOrganizations;
-  } else {
-    const organizationId = assignedProject?.organizationId || '';
-
-    isAssignedToTargetOrganization = Object.keys(assignedOrganizations).some(
-      (key) => assignedOrganizations[key]?.organizationId === organizationId,
+  if (!organizationSlug && assignedProject) {
+    assignedOrganization = Object.values(assignedOrganizations).find(
+      (org) => org.organizationId === assignedProject.organizationId,
     );
   }
+
+  const organizationRole = assignedOrganization?.organizationRole;
+  const projectRole = assignedProject?.projectRole;
+
+  const isAdmin = userRole === ADMINISTRATOR;
+  const isManager = organizationRole === MANAGER;
+  const isAssignedToTargetOrganization = !!assignedOrganization;
 
   const isAssignedToTargetProject =
     projectSlug && assignedProject && isAssignedToTargetOrganization;
@@ -248,10 +248,8 @@ export const userAssignedSelector = (projectSlug, organizationSlug) => (state) =
 
   const userRoles = {
     userRole,
-    organizationRole: organizationSlug
-      ? assignedOrganizations[organizationSlug]?.organizationRole
-      : organizationRole,
-    projectRole: assignedProject ? assignedProject.projectRole : projectRole,
+    organizationRole,
+    projectRole,
   };
 
   return {

--- a/app/src/controllers/pages/selectors.js
+++ b/app/src/controllers/pages/selectors.js
@@ -213,7 +213,7 @@ export const activeProjectRoleSelector = createSelector(
 export const userAssignedSelector = (projectSlug, organizationSlug) => (state) => {
   const assignedOrganizations = assignedOrganizationsSelector(state);
   const assignedProjects = assignedProjectsSelector(state);
-  const { userRole, organizationRole } = userRolesSelector(state);
+  const { userRole, organizationRole, projectRole } = userRolesSelector(state);
 
   const isAdmin = userRole === ADMINISTRATOR;
   const isManager = organizationRole === MANAGER;
@@ -246,6 +246,14 @@ export const userAssignedSelector = (projectSlug, organizationSlug) => (state) =
 
   const assignedProjectKey = assignedProject?.projectKey;
 
+  const userRoles = {
+    userRole,
+    organizationRole: organizationSlug
+      ? assignedOrganizations[organizationSlug]?.organizationRole
+      : organizationRole,
+    projectRole: assignedProject ? assignedProject.projectRole : projectRole,
+  };
+
   return {
     isAdmin,
     hasPermission,
@@ -254,6 +262,7 @@ export const userAssignedSelector = (projectSlug, organizationSlug) => (state) =
     assignmentNotRequired,
     isAssignedToTargetProject,
     isAssignedToTargetOrganization,
+    userRoles,
   };
 };
 

--- a/app/src/controllers/pages/selectors.js
+++ b/app/src/controllers/pages/selectors.js
@@ -214,19 +214,15 @@ export const userAssignedSelector = (projectSlug, organizationSlug) => (state) =
   const assignedProjects = assignedProjectsSelector(state);
   const userRole = userAccountRoleSelector(state);
 
-  let assignedOrganization = organizationSlug ? assignedOrganizations[organizationSlug] : undefined;
+  const assignedOrganization = organizationSlug
+    ? assignedOrganizations[organizationSlug]
+    : undefined;
 
   const assignedProject = findAssignedProjectByOrganization(
     assignedProjects,
     assignedOrganization?.organizationId,
     projectSlug,
   );
-
-  if (!organizationSlug && assignedProject) {
-    assignedOrganization = Object.values(assignedOrganizations).find(
-      (org) => org.organizationId === assignedProject.organizationId,
-    );
-  }
 
   const organizationRole = assignedOrganization?.organizationRole;
   const projectRole = assignedProject?.projectRole;

--- a/app/src/pages/organization/organizationUsersPage/organizationUsersPage.jsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersPage.jsx
@@ -38,6 +38,7 @@ import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { showModalAction } from 'controllers/modal';
 import { InviteUserModal, Level } from 'pages/inside/common/invitations/inviteUserModal';
 import {
+  activeOrganizationLoadingSelector,
   activeOrganizationSelector,
   fetchOrganizationBySlugAction,
 } from 'controllers/organization';
@@ -65,6 +66,7 @@ const OrganizationUsersPageComponent = ({
   const { trackEvent } = useTracking();
   const users = useSelector(usersSelector);
   const { id: organizationId, slug: organizationSlug } = useSelector(activeOrganizationSelector);
+  const isOrganizationLoading = useSelector(activeOrganizationLoadingSelector);
   const isUsersLoading = useSelector(loadingSelector);
   const [searchValue, setSearchValue] = useState(null);
   const isEmptyUsers = users.length === 0;
@@ -93,7 +95,7 @@ const OrganizationUsersPageComponent = ({
   const getEmptyPageState = () => {
     return searchValue === null ? (
       <EmptyUsersPageState
-        isLoading={isUsersLoading}
+        isLoading={isOrganizationLoading || isUsersLoading}
         isNotEmpty={!isEmptyUsers}
         hasPermission={canInviteUserToOrganization}
         showInviteUserModal={showInviteUserModal}

--- a/app/src/store/organizationProjectRouteMiddleware.js
+++ b/app/src/store/organizationProjectRouteMiddleware.js
@@ -76,12 +76,17 @@ export const organizationProjectRouteMiddleware = (store) => (next) => (action) 
   const { slug: organizationSlug } = activeOrganizationSelector(getState());
   const { projectSlug } = activeProjectSelector(getState());
   const user = userInfoSelector(getState());
-  const { hasPermission, hasPermissionOrganization, assignedProjectKey, assignmentNotRequired } =
-    userAssignedSelector(hashProjectSlug, hashOrganizationSlug)(getState());
+  const {
+    hasPermission,
+    hasPermissionOrganization,
+    assignedProjectKey,
+    assignmentNotRequired,
+    userRoles,
+  } = userAssignedSelector(hashProjectSlug, hashOrganizationSlug)(getState());
 
   const isProjectPage = !!hashProjectSlug;
 
-  const hasPermissionOrganizationUsers = canSeeOrganizationMembers(userRolesSelector(getState()));
+  const hasPermissionOrganizationUsers = canSeeOrganizationMembers(userRoles);
 
   // For project pages check project-level permission, for org pages — org-level
   const hasOrganizationPageAccess =


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes

**Problem**  
The org/project route middleware runs **before** the route reducer updates `location`. `userRolesSelector` resolves the **organization role** from the **current URL** (`urlOrganizationSlugSelector`). When navigating from the **All organizations** (instance) view to an org page (e.g. **Organization users**), the store still reflected the **previous** route, so `organizationRole` was missing (e.g. no `MANAGER`) even though the user was a manager of the **target** org.

**What was done**  
1. **Resolved roles for the navigation target** using the list of organizations and projects user is assigned to.
2. **Centralized** this in **`userAssignedSelector(projectSlug, organizationSlug)`** by adding a returned **`userRoles`** object: `{ userRole, organizationRole, projectRole }`.  
3. **Refactored `userAssignedSelector`** — dropped the block that tried to resolve `assignedOrganization` from `assignedProject` when `organizationSlug` was missing. `findAssignedProjectByOrganization` always matches on both `organizationId` and `projectSlug`, so with no org we pass `undefined` as `organizationId` and a real assignment is never found — `assignedProject` stays `undefined` and the `if (!organizationSlug && assignedProject)` body never ran in practice. 

## Links
[EPMRPP-114239](https://jiraeu.epam.com/browse/EPMRPP-114239)


## Visuals
**Before:**

https://github.com/user-attachments/assets/3830441c-25a4-4b40-9d83-6382e59a518f


**After:**

https://github.com/user-attachments/assets/08f6b76e-ab3b-4ed0-a39b-3c95be5dce61



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state on the organization users page so empty-state UI correctly reflects combined organization and users loading status.

* **Refactor**
  * Rolled out a more consistent evaluation of user roles and permissions, leading to more reliable access checks for organization-related pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->