### PR TITLE
EPMRPP-101148 || Plugins. Text needs adjustments in Uninstall plugin …

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -1257,7 +1257,7 @@
   "InstancesSection.resetToGlobalSettingsDescription": "Актывуе глабальныя налады. Усе карыстацкія інтэграцыі будуць выдалены.",
   "InstancesSection.resetToGlobalSettingsTitle": "Вярнуцца да Глабальных Налад",
   "InstancesSection.resetToGlobalSuccess": "Глабальныя інтэграцыі паспяхова ўжытыя",
-  "InstancesSection.uninstallPluginConfirmation": "Вы сапраўды жадаеце выдаліць {pluginName} плагін?",
+  "InstancesSection.uninstallPluginConfirmation": "Вы сапраўды жадаеце выдаліць <b>{pluginName}</b> плагін?",
   "InstancesSection.uninstallPluginNote": "Выдаліце гэты плагін з ReportPortal і адмяніце ўсе правы доступу і аўтарызацыі",
   "InstancesSection.uninstallPluginTitle": "Выдаліць плагін",
   "InstancesSection.unlinkAndSetupManuallyDescription": "Адлучыце бягучы праект ад глабальных налад і наладзьце сваю ўласную інтэграцыю. Вы заўсёды можаце вярнуцца да глабальных налад.",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -1259,7 +1259,7 @@
   "InstancesSection.resetToGlobalSettingsDescription": "Activa las configuraciones globales. Todas las integraciones personalizadas serán eliminadas.",
   "InstancesSection.resetToGlobalSettingsTitle": "Restablecer a configuraciones globales",
   "InstancesSection.resetToGlobalSuccess": "Integraciones globales aplicadas exitosamente",
-  "InstancesSection.uninstallPluginConfirmation": "¿Realmente desea desinstalar el plugin {pluginName}?",
+  "InstancesSection.uninstallPluginConfirmation": "¿Realmente desea desinstalar el plugin <b>{pluginName}</b>?",
   "InstancesSection.uninstallPluginNote": "Elimine este plugin de ReportPortal y cancele todos los permisos de acceso y autorización",
   "InstancesSection.uninstallPluginTitle": "Desinstalar plugin",
   "InstancesSection.unlinkAndSetupManuallyDescription": "Desvincula el proyecto actual de las configuraciones globales y configura tu propia integración. Siempre puedes volver a las configuraciones globales.",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -1258,7 +1258,7 @@
   "InstancesSection.resetToGlobalSettingsDescription": "Активирует глобальные настройки. Все пользовательские интеграции будут удалены.",
   "InstancesSection.resetToGlobalSettingsTitle": "Вернуться к Глобальным настройкам",
   "InstancesSection.resetToGlobalSuccess": "Глобальные интеграции успешно применены",
-  "InstancesSection.uninstallPluginConfirmation": "Вы действительно хотите удалить {pluginName} плагин?",
+  "InstancesSection.uninstallPluginConfirmation": "Вы действительно хотите удалить <b>{pluginName}</b> плагин?",
   "InstancesSection.uninstallPluginNote": "Удалите этот плагин из ReportPortal и отмените все права доступа и авторизации",
   "InstancesSection.uninstallPluginTitle": "Удалить плагин",
   "InstancesSection.unlinkAndSetupManuallyDescription": "Отсоедините текущий проект от глобальных настроек и настройте свою собственную интеграцию. Вы всегда можете вернуться к глобальным настройкам.",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -1258,7 +1258,7 @@
   "InstancesSection.resetToGlobalSettingsDescription": "Активує глобальні налаштування. Всі користувальницькі інтеграції будуть видалені.",
   "InstancesSection.resetToGlobalSettingsTitle": "Повернутися до Глобальних налаштувань",
   "InstancesSection.resetToGlobalSuccess": "Глобальні інтеграції успішно застосовані",
-  "InstancesSection.uninstallPluginConfirmation": "Вы действительно хотите удалить {pluginName} плагин?",
+  "InstancesSection.uninstallPluginConfirmation": "Вы действительно хотите удалить <b>{pluginName}</b> плагин?",
   "InstancesSection.uninstallPluginNote": "Видаліть цей плагін з ReportPortal і зніміть всі права доступу авторизації",
   "InstancesSection.uninstallPluginTitle": "Видалити плагін",
   "InstancesSection.unlinkAndSetupManuallyDescription": "Від'єднайте поточний проект від глобальних налаштувань і настройте свою власну інтеграцію. Ви завжди можете повернутися до глобальних налаштувань.",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -1258,7 +1258,7 @@
   "InstancesSection.resetToGlobalSettingsDescription": "Активує глобальні налаштування. Всі користувальницькі інтеграції будуть видалені.",
   "InstancesSection.resetToGlobalSettingsTitle": "Повернутися до Глобальних налаштувань",
   "InstancesSection.resetToGlobalSuccess": "Глобальні інтеграції успішно застосовані",
-  "InstancesSection.uninstallPluginConfirmation": "Вы действительно хотите удалить <b>{pluginName}</b> плагин?",
+  "InstancesSection.uninstallPluginConfirmation": "Ви впевнені, що хочете видалити плагін <b>{pluginName}</b>?",
   "InstancesSection.uninstallPluginNote": "Видаліть цей плагін з ReportPortal і зніміть всі права доступу авторизації",
   "InstancesSection.uninstallPluginTitle": "Видалити плагін",
   "InstancesSection.unlinkAndSetupManuallyDescription": "Від'єднайте поточний проект від глобальних налаштувань і настройте свою власну інтеграцію. Ви завжди можете повернутися до глобальних налаштувань.",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -1258,7 +1258,7 @@
   "InstancesSection.resetToGlobalSettingsDescription": "激活全局设置。所有自定义集成都将被删除。",
   "InstancesSection.resetToGlobalSettingsTitle": "重置为全局设置",
   "InstancesSection.resetToGlobalSuccess": "已应用全局集成",
-  "InstancesSection.uninstallPluginConfirmation": "您确定要卸载{pluginName}插件吗？",
+  "InstancesSection.uninstallPluginConfirmation": "您确定要卸载<b>{pluginName}</b>插件吗？",
   "InstancesSection.uninstallPluginNote": "从ReportPortal中删除此插件并撤销所有访问和授权。",
   "InstancesSection.uninstallPluginTitle": "卸载插件",
   "InstancesSection.unlinkAndSetupManuallyDescription": "从全局设置中取消与当前项目的关联并配置您自己的集成。您随时可以将其重置为全局设置。",

--- a/app/src/components/integrations/containers/integrationInfoContainer/instancesSection/instancesSection.jsx
+++ b/app/src/components/integrations/containers/integrationInfoContainer/instancesSection/instancesSection.jsx
@@ -19,6 +19,7 @@ import classNames from 'classnames/bind';
 import { defineMessages, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import track from 'react-tracking';
+import DOMPurify from 'dompurify';
 import PlusIcon from 'common/img/plus-button-inline.svg';
 import { canUpdateSettings } from 'common/utils/permissions';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
@@ -217,7 +218,7 @@ export class InstancesSection extends Component {
       data: {
         message: formatMessage(messages.uninstallPluginConfirmation, {
           pluginName: pluginDetails.name || instanceType,
-          b: (chunks) => `<b>${chunks}</b>`,
+          b: (chunks) => DOMPurify.sanitize(`<b>${chunks}</b>`),
         }),
         onConfirm: this.removePlugin,
         title: formatMessage(messages.uninstallPluginTitle),

--- a/app/src/components/integrations/containers/integrationInfoContainer/instancesSection/instancesSection.jsx
+++ b/app/src/components/integrations/containers/integrationInfoContainer/instancesSection/instancesSection.jsx
@@ -98,7 +98,7 @@ const messages = defineMessages({
   },
   uninstallPluginConfirmation: {
     id: 'InstancesSection.uninstallPluginConfirmation',
-    defaultMessage: 'Are you sure you want to uninstall {pluginName} Plugin?',
+    defaultMessage: 'Are you sure you want to uninstall <b>{pluginName}</b> plugin?',
   },
   uninstallPluginTitle: {
     id: 'InstancesSection.uninstallPluginTitle',
@@ -217,6 +217,7 @@ export class InstancesSection extends Component {
       data: {
         message: formatMessage(messages.uninstallPluginConfirmation, {
           pluginName: pluginDetails.name || instanceType,
+          b: (chunks) => `<b>${chunks}</b>`,
         }),
         onConfirm: this.removePlugin,
         title: formatMessage(messages.uninstallPluginTitle),


### PR DESCRIPTION
…modal window

## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
<img width="1074" height="469" alt="image" src="https://github.com/user-attachments/assets/71765daa-80d6-4f49-81f4-8fce5fdf462d" />


<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Plugin names in uninstall confirmation dialogs are now displayed in bold formatting.
* **Localization Updates**
  * Updated confirmation message text across Belarusian, Spanish, Russian, Ukrainian, and Chinese translations to support text formatting enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->