### PR TITLE
EPMRPP-114707 || Restore dashboard permissions

### DIFF
--- a/app/src/pages/inside/dashboardItemPage/dashboardItemPage.jsx
+++ b/app/src/pages/inside/dashboardItemPage/dashboardItemPage.jsx
@@ -328,29 +328,33 @@ export const DashboardItemPage = () => {
                       {formatMessage(dashboard.locked ? messages.unlock : messages.lock)}
                     </GhostButton>
                   )}
-                  <LockedDashboardTooltip locked={dashboard.locked}>
-                    <GhostButton
-                      icon={EditIcon}
-                      onClick={onEditDashboardItem}
-                      disabled={isDisabled}
-                      appearance="faded"
-                    >
-                      {formatMessage(messages.editDashboard)}
-                    </GhostButton>
-                  </LockedDashboardTooltip>
+                  {isWorkWithWidgets && (
+                    <LockedDashboardTooltip locked={dashboard.locked}>
+                      <GhostButton
+                        icon={EditIcon}
+                        onClick={onEditDashboardItem}
+                        disabled={isDisabled}
+                        appearance="faded"
+                      >
+                        {formatMessage(messages.editDashboard)}
+                      </GhostButton>
+                    </LockedDashboardTooltip>
+                  )}
                   <GhostButton icon={FullscreenIcon} onClick={toggleFullscreen}>
                     {formatMessage(messages.fullscreen)}
                   </GhostButton>
-                  <LockedDashboardTooltip locked={dashboard.locked}>
-                    <GhostButton
-                      icon={CancelIcon}
-                      onClick={onDeleteDashboard}
-                      disabled={isDisabled}
-                      appearance="faded"
-                    >
-                      {formatMessage(messages.delete)}
-                    </GhostButton>
-                  </LockedDashboardTooltip>
+                  {isWorkWithWidgets && (
+                    <LockedDashboardTooltip locked={dashboard.locked}>
+                      <GhostButton
+                        icon={CancelIcon}
+                        onClick={onDeleteDashboard}
+                        disabled={isDisabled}
+                        appearance="faded"
+                      >
+                        {formatMessage(messages.delete)}
+                      </GhostButton>
+                    </LockedDashboardTooltip>
+                  )}
                   <Link
                     to={{
                       type: PROJECT_DASHBOARD_PRINT_PAGE,


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
<img width="1919" height="339" alt="image" src="https://github.com/user-attachments/assets/4999491e-ee73-47b4-abf0-95a2eba78007" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated dashboard item page to conditionally render Edit and Delete action buttons based on the current editing context, restricting their availability when not appropriate. Button functionality and styling remain unchanged when accessible.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5345)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->