### PR TITLE
EPMRPP-114619 Ga4-tracking-test-plans

### DIFF
--- a/app/src/components/main/analytics/events/ga4Events/milestonesPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/milestonesPageEvents.ts
@@ -36,7 +36,12 @@ const CLICK = getBasicClickEventParameters(MILESTONES);
 
 export type MilestoneStatusType = 'scheduled' | 'testing' | 'completed';
 
-export type MilestonesPageViewType = 'populated' | 'empty';
+export const MILESTONES_PAGE_VIEW_TYPE = {
+  POPULATED: 'populated',
+  EMPTY: 'empty',
+} as const;
+export type MilestonesPageViewType =
+  (typeof MILESTONES_PAGE_VIEW_TYPE)[keyof typeof MILESTONES_PAGE_VIEW_TYPE];
 
 export {
   type MilestoneChangeStatusModalButtonElementName,

--- a/app/src/components/main/analytics/events/ga4Events/milestonesPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/milestonesPageEvents.ts
@@ -36,6 +36,8 @@ const CLICK = getBasicClickEventParameters(MILESTONES);
 
 export type MilestoneStatusType = 'scheduled' | 'testing' | 'completed';
 
+export type MilestonesPageViewType = 'populated' | 'empty';
+
 export {
   type MilestoneChangeStatusModalButtonElementName,
   type MilestoneStatusDropdownChooseType,
@@ -44,10 +46,11 @@ export {
 } from 'pages/inside/testPlansPage/milestones/milestoneStatus';
 
 export const MILESTONES_PAGE_EVENTS = {
-  VIEW_MILESTONES_PAGE: {
+  viewMilestonesPage: (type: MilestonesPageViewType) => ({
     ...getBasicEventParameters('page_view', MILESTONES),
     place: PLACE_PAGE,
-  },
+    type,
+  }),
   CLICK_CREATE_MILESTONE: {
     ...CLICK,
     place: PLACE_PAGE,

--- a/app/src/components/main/analytics/events/ga4Events/testPlansPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/testPlansPageEvents.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  getBasicClickEventParameters,
+  getBasicEventParameters,
+} from '../common/ga4Utils';
+
+const TEST_PLANS = 'test_plans';
+
+const PLACE_DETAILS = 'test_plan_details';
+const PLACE_ADD_TESTS_SIDEBAR = 'add_tests_sidebar';
+const PLACE_KEBAB = 'test_plan_kebab_menu';
+const PLACE_LIST = 'test_plans_list';
+
+const CLICK = getBasicClickEventParameters(TEST_PLANS);
+
+export const TEST_PLAN_DETAILS_VIEW_TYPE = {
+  POPULATED: 'populated',
+  EMPTY: 'empty',
+} as const;
+export type TestPlanDetailsViewType =
+  (typeof TEST_PLAN_DETAILS_VIEW_TYPE)[keyof typeof TEST_PLAN_DETAILS_VIEW_TYPE];
+
+export const ADD_TESTS_SIDEBAR_CONDITION = {
+  ADD_TESTS_BUTTON: 'add_tests_button',
+  EMPTY_PLAN_CTA: 'empty_plan_cta',
+} as const;
+export type AddTestsSidebarCondition =
+  (typeof ADD_TESTS_SIDEBAR_CONDITION)[keyof typeof ADD_TESTS_SIDEBAR_CONDITION];
+
+export const DND_DROP_TARGET = {
+  PLAN_LIST: 'plan_list',
+  ADD_AND_CREATE_LAUNCH: 'add_and_create_launch',
+} as const;
+export type DndDropTarget = (typeof DND_DROP_TARGET)[keyof typeof DND_DROP_TARGET];
+
+export type DndItemCountType = 'single' | 'multi';
+
+export const TEST_PLANS_PAGE_EVENTS = {
+  viewTestPlanDetailsPage: (type: TestPlanDetailsViewType) => ({
+    ...getBasicEventParameters('page_view', TEST_PLANS),
+    place: PLACE_DETAILS,
+    type,
+  }),
+  CLICK_START_CREATE_LAUNCH_FROM_PLAN: {
+    ...CLICK,
+    place: PLACE_DETAILS,
+    element_name: 'start_create_launch_from_plan',
+    type: 'existing_launch',
+  },
+  clickStartBulkAddToLaunch: (number: number) => ({
+    ...CLICK,
+    place: PLACE_DETAILS,
+    element_name: 'start_bulk_add_to_launch',
+    number,
+  }),
+  clickOpenAddTestsSidebar: (condition: AddTestsSidebarCondition) => ({
+    ...CLICK,
+    place: PLACE_DETAILS,
+    element_name: 'open_add_tests_sidebar',
+    condition,
+  }),
+  submitAddTestsFromLibrary: (number: number) => ({
+    ...CLICK,
+    place: PLACE_ADD_TESTS_SIDEBAR,
+    element_name: 'submit_add_tests_from_library',
+    number,
+  }),
+  dragDropTestCaseToPlan: (params: {
+    switcher: DndDropTarget;
+    type: DndItemCountType;
+    number: number;
+  }) => ({
+    ...CLICK,
+    place: PLACE_ADD_TESTS_SIDEBAR,
+    element_name: 'drag_drop_test_case_to_plan',
+    switcher: params.switcher,
+    type: params.type,
+    number: params.number,
+  }),
+  SUBMIT_REMOVE_TEST_FROM_PLAN: {
+    ...CLICK,
+    place: PLACE_DETAILS,
+    element_name: 'submit_remove_test_from_plan',
+    modal: 'remove_test_from_plan',
+  },
+  CLICK_OPEN_TEST_CASE_IN_LIBRARY: {
+    ...CLICK,
+    place: PLACE_DETAILS,
+    element_name: 'open_test_case_in_library',
+  },
+  CLICK_START_EDIT_TEST_PLAN: {
+    ...CLICK,
+    place: PLACE_KEBAB,
+    element_name: 'start_edit_test_plan',
+  },
+  submitEditTestPlan: (params: { number: number; condition: string }) => ({
+    ...CLICK,
+    place: PLACE_LIST,
+    modal: 'edit_test_plan',
+    element_name: 'submit_edit_test_plan',
+    number: params.number,
+    condition: params.condition,
+  }),
+  CLICK_START_DUPLICATE_TEST_PLAN: {
+    ...CLICK,
+    place: PLACE_KEBAB,
+    element_name: 'start_duplicate_test_plan',
+  },
+  SUBMIT_DUPLICATE_TEST_PLAN: {
+    ...CLICK,
+    place: PLACE_LIST,
+    modal: 'duplicate_test_plan',
+    element_name: 'submit_duplicate_test_plan',
+  },
+  CLICK_START_DELETE_TEST_PLAN: {
+    ...CLICK,
+    place: PLACE_KEBAB,
+    element_name: 'start_delete_test_plan',
+  },
+  SUBMIT_DELETE_TEST_PLAN: {
+    ...CLICK,
+    place: PLACE_LIST,
+    modal: 'delete_test_plan',
+    element_name: 'submit_delete_test_plan',
+  },
+};

--- a/app/src/components/main/analytics/events/ga4Events/testPlansPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/testPlansPageEvents.ts
@@ -48,7 +48,12 @@ export const DND_DROP_TARGET = {
 } as const;
 export type DndDropTarget = (typeof DND_DROP_TARGET)[keyof typeof DND_DROP_TARGET];
 
-export type DndItemCountType = 'single' | 'multi';
+export const DND_ITEM_COUNT_TYPE = {
+  SINGLE: 'single',
+  MULTI: 'multi',
+} as const;
+export type DndItemCountType =
+  (typeof DND_ITEM_COUNT_TYPE)[keyof typeof DND_ITEM_COUNT_TYPE];
 
 export const TEST_PLANS_PAGE_EVENTS = {
   viewTestPlanDetailsPage: (type: TestPlanDetailsViewType) => ({

--- a/app/src/pages/inside/common/testLibrarySidePanel/testLibrarySidePanel.tsx
+++ b/app/src/pages/inside/common/testLibrarySidePanel/testLibrarySidePanel.tsx
@@ -16,10 +16,12 @@
 
 import { useIntl } from 'react-intl';
 import { useCallback, useState } from 'react';
+import { useTracking } from 'react-tracking';
 import { isEmpty } from 'es-toolkit/compat';
 import { VoidFn } from '@reportportal/ui-kit/common';
 import { Button, SidePanel, Selection, Toggle } from '@reportportal/ui-kit';
 
+import { TEST_PLANS_PAGE_EVENTS } from 'analyticsEvents/testPlansPageEvents';
 import { createClassnames } from 'common/utils';
 import { useModal } from 'common/hooks';
 import { useUserPermissions } from 'hooks/useUserPermissions';
@@ -55,6 +57,7 @@ export const TestLibrarySidePanel = ({
   onClose,
 }: TestLibrarySidePanelProps) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const { canManageTestCases } = useUserPermissions();
   const [shouldHideAddedTestCases, setShouldHideAddedTestCases] = useState(true);
 
@@ -99,6 +102,15 @@ export const TestLibrarySidePanel = ({
       });
     }
   }, [addToTestPlan, openAddToLaunchModal, testPlanId, selectedTestCases]);
+
+  const handleSubmitAddToTestPlan = useCallback(async () => {
+    const count = selectedTestCases.length;
+    const isSuccess = await addToTestPlan();
+
+    if (isSuccess) {
+      trackEvent(TEST_PLANS_PAGE_EVENTS.submitAddTestsFromLibrary(count));
+    }
+  }, [addToTestPlan, selectedTestCases, trackEvent]);
 
   const titleComponent = (
     <div className={cx('test-library-panel__title')}>
@@ -158,7 +170,7 @@ export const TestLibrarySidePanel = ({
           variant="primary"
           disabled={isSubmitButtonDisabled}
           onClick={() => {
-            addToTestPlan();
+            handleSubmitAddToTestPlan();
           }}
         >
           {formatMessage(messages.addToTestPlan)}

--- a/app/src/pages/inside/common/testLibrarySidePanel/testPlanDropZonesContainer/testPlanDropZonesContainer.tsx
+++ b/app/src/pages/inside/common/testLibrarySidePanel/testPlanDropZonesContainer/testPlanDropZonesContainer.tsx
@@ -15,8 +15,14 @@
  */
 
 import { useCallback, useRef, useState } from 'react';
+import { useTracking } from 'react-tracking';
 import { isEmpty } from 'es-toolkit/compat';
 
+import {
+  DND_DROP_TARGET,
+  DndDropTarget,
+  TEST_PLANS_PAGE_EVENTS,
+} from 'analyticsEvents/testPlansPageEvents';
 import { useModal } from 'common/hooks';
 import { TestCase } from 'types/testCase';
 import { TransformedFolder } from 'controllers/testCase';
@@ -41,6 +47,7 @@ export const TestPlanDropZonesContainer = ({
   onAddTestCases,
   onClose,
 }: TestPlanDropZonesContainerProps) => {
+  const { trackEvent } = useTracking();
   const { getFolderTestCaseIds } = usePanelActions();
   const { testCasesMap } = usePanelState();
   const [isAddToTestPlanLoading, setIsAddToTestPlanLoading] = useState(false);
@@ -49,6 +56,22 @@ export const TestPlanDropZonesContainer = ({
   const testCasesMapRef = useRef(testCasesMap);
 
   testCasesMapRef.current = testCasesMap;
+
+  const trackDropSuccess = useCallback(
+    (switcher: DndDropTarget, count: number) => {
+      if (count <= 0) {
+        return;
+      }
+      trackEvent(
+        TEST_PLANS_PAGE_EVENTS.dragDropTestCaseToPlan({
+          switcher,
+          type: count === 1 ? 'single' : 'multi',
+          number: count,
+        }),
+      );
+    },
+    [trackEvent],
+  );
 
   const { openModal: openAddToLaunchModal } = useModal<AddTestCasesToLaunchModalProps>({
     modalKey: ADD_TEST_CASES_TO_LAUNCH_MODAL_KEY,
@@ -96,9 +119,11 @@ export const TestPlanDropZonesContainer = ({
       setIsAddToTestPlanLoading(true);
 
       try {
-        const isSuccess = await onAddTestCases(testCases.map(({ id }) => id));
+        const ids = testCases.map(({ id }) => id);
+        const isSuccess = await onAddTestCases(ids);
 
         if (isSuccess) {
+          trackDropSuccess(DND_DROP_TARGET.PLAN_LIST, ids.length);
           onClose();
         }
       } finally {
@@ -106,7 +131,7 @@ export const TestPlanDropZonesContainer = ({
         setIsAddInFlight(false);
       }
     },
-    [isAddInFlight, onAddTestCases, onClose],
+    [isAddInFlight, onAddTestCases, onClose, trackDropSuccess],
   );
 
   const addTestCasesAndCreateLaunch = useCallback(
@@ -123,6 +148,7 @@ export const TestPlanDropZonesContainer = ({
         const isSuccess = await onAddTestCases(ids);
 
         if (isSuccess) {
+          trackDropSuccess(DND_DROP_TARGET.ADD_AND_CREATE_LAUNCH, ids.length);
           onClose();
           openAddToLaunchModal({
             selectedRowsIds: ids,
@@ -135,7 +161,7 @@ export const TestPlanDropZonesContainer = ({
         setIsAddInFlight(false);
       }
     },
-    [isAddInFlight, onAddTestCases, onClose, openAddToLaunchModal, testPlanId],
+    [isAddInFlight, onAddTestCases, onClose, openAddToLaunchModal, testPlanId, trackDropSuccess],
   );
 
   const addFolder = useCallback(
@@ -157,6 +183,7 @@ export const TestPlanDropZonesContainer = ({
         const isSuccess = await onAddTestCases(ids);
 
         if (isSuccess) {
+          trackDropSuccess(DND_DROP_TARGET.PLAN_LIST, ids.length);
           onClose();
         }
       } finally {
@@ -164,7 +191,7 @@ export const TestPlanDropZonesContainer = ({
         setIsAddInFlight(false);
       }
     },
-    [getFolderIds, isAddInFlight, onAddTestCases, onClose],
+    [getFolderIds, isAddInFlight, onAddTestCases, onClose, trackDropSuccess],
   );
 
   const addFolderAndCreateLaunch = useCallback(
@@ -186,6 +213,7 @@ export const TestPlanDropZonesContainer = ({
         const isSuccess = await onAddTestCases(ids);
 
         if (isSuccess) {
+          trackDropSuccess(DND_DROP_TARGET.ADD_AND_CREATE_LAUNCH, ids.length);
           onClose();
           openAddToLaunchModal({
             selectedRowsIds: ids,
@@ -206,6 +234,7 @@ export const TestPlanDropZonesContainer = ({
       onClose,
       openAddToLaunchModal,
       testPlanId,
+      trackDropSuccess,
     ],
   );
 

--- a/app/src/pages/inside/common/testLibrarySidePanel/testPlanDropZonesContainer/testPlanDropZonesContainer.tsx
+++ b/app/src/pages/inside/common/testLibrarySidePanel/testPlanDropZonesContainer/testPlanDropZonesContainer.tsx
@@ -20,6 +20,7 @@ import { isEmpty } from 'es-toolkit/compat';
 
 import {
   DND_DROP_TARGET,
+  DND_ITEM_COUNT_TYPE,
   DndDropTarget,
   TEST_PLANS_PAGE_EVENTS,
 } from 'analyticsEvents/testPlansPageEvents';
@@ -65,7 +66,7 @@ export const TestPlanDropZonesContainer = ({
       trackEvent(
         TEST_PLANS_PAGE_EVENTS.dragDropTestCaseToPlan({
           switcher,
-          type: count === 1 ? 'single' : 'multi',
+          type: count === 1 ? DND_ITEM_COUNT_TYPE.SINGLE : DND_ITEM_COUNT_TYPE.MULTI,
           number: count,
         }),
       );

--- a/app/src/pages/inside/testPlansPage/milestonesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/milestonesPage.tsx
@@ -18,7 +18,7 @@ import { useIntl } from 'react-intl';
 import { isNotNil, isUndefined } from 'es-toolkit';
 import { isEmpty } from 'es-toolkit/compat';
 import { useSelector, useDispatch } from 'react-redux';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useTracking } from 'react-tracking';
 import { Button, RefreshIcon } from '@reportportal/ui-kit';
 
@@ -79,9 +79,17 @@ export const MilestonesPage = () => {
     }
   }, [dispatch, milestones, milestonesLoading, queryParams]);
 
+  const hasTrackedViewRef = useRef(false);
+
   useEffect(() => {
-    trackEvent(MILESTONES_PAGE_EVENTS.VIEW_MILESTONES_PAGE);
-  }, [trackEvent]);
+    if (hasTrackedViewRef.current || milestonesLoading || !isNotNil(milestones)) {
+      return;
+    }
+    hasTrackedViewRef.current = true;
+    trackEvent(
+      MILESTONES_PAGE_EVENTS.viewMilestonesPage(isEmpty(milestones) ? 'empty' : 'populated'),
+    );
+  }, [milestones, milestonesLoading, trackEvent]);
 
   const handleCreateMilestone = () => {
     trackEvent(MILESTONES_PAGE_EVENTS.CLICK_CREATE_MILESTONE);

--- a/app/src/pages/inside/testPlansPage/milestonesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/milestonesPage.tsx
@@ -22,7 +22,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useTracking } from 'react-tracking';
 import { Button, RefreshIcon } from '@reportportal/ui-kit';
 
-import { MILESTONES_PAGE_EVENTS } from 'analyticsEvents/milestonesPageEvents';
+import { MILESTONES_PAGE_EVENTS, MILESTONES_PAGE_VIEW_TYPE } from 'analyticsEvents/milestonesPageEvents';
 
 import { SettingsLayout } from 'layouts/settingsLayout';
 import { ScrollWrapper } from 'components/main/scrollWrapper';
@@ -87,7 +87,9 @@ export const MilestonesPage = () => {
     }
     hasTrackedViewRef.current = true;
     trackEvent(
-      MILESTONES_PAGE_EVENTS.viewMilestonesPage(isEmpty(milestones) ? 'empty' : 'populated'),
+      MILESTONES_PAGE_EVENTS.viewMilestonesPage(
+        isEmpty(milestones) ? MILESTONES_PAGE_VIEW_TYPE.EMPTY : MILESTONES_PAGE_VIEW_TYPE.POPULATED,
+      ),
     );
   }, [milestones, milestonesLoading, trackEvent]);
 

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/constants.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/constants.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TEST_PLANS_PAGE_EVENTS } from 'analyticsEvents/testPlansPageEvents';
+
+export const KEBAB_START_EVENT_MAP = {
+  edit: TEST_PLANS_PAGE_EVENTS.CLICK_START_EDIT_TEST_PLAN,
+  duplicate: TEST_PLANS_PAGE_EVENTS.CLICK_START_DUPLICATE_TEST_PLAN,
+  delete: TEST_PLANS_PAGE_EVENTS.CLICK_START_DELETE_TEST_PLAN,
+} as const;

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/emptyTestPlan/emptyTestPlan.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/emptyTestPlan/emptyTestPlan.tsx
@@ -15,7 +15,12 @@
  */
 
 import { useIntl } from 'react-intl';
+import { useTracking } from 'react-tracking';
 
+import {
+  ADD_TESTS_SIDEBAR_CONDITION,
+  TEST_PLANS_PAGE_EVENTS,
+} from 'analyticsEvents/testPlansPageEvents';
 import { createClassnames } from 'common/utils';
 import { EmptyStatePage } from 'pages/inside/common/emptyStatePage';
 
@@ -32,6 +37,14 @@ interface EmptyTestPlanProps {
 
 export const EmptyTestPlan = ({ onOpenTestLibrary }: EmptyTestPlanProps) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
+
+  const handleOpenTestLibrary = () => {
+    trackEvent(
+      TEST_PLANS_PAGE_EVENTS.clickOpenAddTestsSidebar(ADD_TESTS_SIDEBAR_CONDITION.EMPTY_PLAN_CTA),
+    );
+    onOpenTestLibrary();
+  };
 
   return (
     <div className={cx('empty-test-plan')}>
@@ -44,7 +57,7 @@ export const EmptyTestPlan = ({ onOpenTestLibrary }: EmptyTestPlanProps) => {
             name: formatMessage(commonMessages.addTestsFromLibrary),
             dataAutomationId: 'addTestsFromLibraryButton',
             isCompact: true,
-            handleButton: onOpenTestLibrary,
+            handleButton: handleOpenTestLibrary,
           },
         ]}
       />

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanDetailsPage.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanDetailsPage.tsx
@@ -18,8 +18,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { isEmpty } from 'es-toolkit/compat';
+import { useTracking } from 'react-tracking';
 import { Button } from '@reportportal/ui-kit';
 
+import {
+  ADD_TESTS_SIDEBAR_CONDITION,
+  TEST_PLAN_DETAILS_VIEW_TYPE,
+  TEST_PLANS_PAGE_EVENTS,
+} from 'analyticsEvents/testPlansPageEvents';
 import { createClassnames } from 'common/utils';
 import { SEARCH_DELAY } from 'common/constants/delayTime';
 import { SettingsLayout } from 'layouts/settingsLayout';
@@ -72,6 +78,7 @@ import {
 } from '../testPlanModals';
 import { useAddTestCasesToCurrentTestPlan } from '../testPlanModals';
 import { TestPlanFolders } from './testPlanFolders';
+import { KEBAB_START_EVENT_MAP } from './constants';
 
 import styles from './testPlanDetailsPage.scss';
 
@@ -80,6 +87,7 @@ const cx = createClassnames(styles);
 export const TestPlanDetailsPage = () => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
+  const { trackEvent } = useTracking();
   const { organizationSlug, projectSlug } = useProjectDetails();
   const { canManageTestCases, canCreateManualLaunch } = useUserPermissions();
   const [isTestLibrarySidePanelOpen, setIsTestLibrarySidePanelOpen] = useState(false);
@@ -151,23 +159,47 @@ export const TestPlanDetailsPage = () => {
     [dispatch],
   );
 
-  const { openModal: openEditModal } = useEditTestPlanModal();
+  const { openModal: openEditModal } = useEditTestPlanModal({
+    onSubmitSuccess: ({ attributesCount, editedFieldsCondition }) =>
+      trackEvent(
+        TEST_PLANS_PAGE_EVENTS.submitEditTestPlan({
+          number: attributesCount,
+          condition: editedFieldsCondition,
+        }),
+      ),
+  });
   const { openModal: openDuplicateModal } = useDuplicateTestPlanModal({
-    onSuccess: (newTestPlanId) =>
+    onSuccess: (newTestPlanId) => {
+      trackEvent(TEST_PLANS_PAGE_EVENTS.SUBMIT_DUPLICATE_TEST_PLAN);
       dispatch({
         type: PROJECT_TEST_PLAN_DETAILS_PAGE,
         payload: { organizationSlug, projectSlug, testPlanId: newTestPlanId },
-      }),
+      });
+    },
   });
   const { openModal: openDeleteModal } = useDeleteTestPlanModal({
-    onSuccess: () =>
+    onSuccess: () => {
+      trackEvent(TEST_PLANS_PAGE_EVENTS.SUBMIT_DELETE_TEST_PLAN);
       dispatch({
         type: PROJECT_MILESTONES_PAGE,
         payload: { organizationSlug, projectSlug },
-      }),
+      });
+    },
   });
 
   const { openModal: openCreateLaunchModal } = useCreateLaunchModal(testCases || []);
+
+  const handleOpenCreateLaunchModal = () => {
+    trackEvent(TEST_PLANS_PAGE_EVENTS.CLICK_START_CREATE_LAUNCH_FROM_PLAN);
+    openCreateLaunchModal();
+  };
+
+  const handleOpenTestLibrarySidePanel = () => {
+    trackEvent(
+      TEST_PLANS_PAGE_EVENTS.clickOpenAddTestsSidebar(ADD_TESTS_SIDEBAR_CONDITION.ADD_TESTS_BUTTON),
+    );
+    setIsTestLibrarySidePanelOpen(true);
+  };
 
   const actionsMap = {
     edit: openEditModal,
@@ -177,11 +209,32 @@ export const TestPlanDetailsPage = () => {
 
   const openActionModal = (action: keyof typeof actionsMap) => () => {
     if (testPlan) {
+      trackEvent(KEBAB_START_EVENT_MAP[action]);
       actionsMap[action](testPlan);
     }
   };
 
   const { addTestCasesToCurrentTestPlan, isAddingTestCases } = useAddTestCasesToCurrentTestPlan();
+
+  const lastTrackedTestPlanIdRef = useRef<string | number | null>(null);
+
+  useEffect(() => {
+    if (isLoading || areFoldersLoading || !testPlan || testPlanId == null) {
+      return;
+    }
+    if (lastTrackedTestPlanIdRef.current === testPlanId) {
+      return;
+    }
+    lastTrackedTestPlanIdRef.current = testPlanId;
+
+    const isEmptyPlan = !testPlan.executionStatistic.total && isEmpty(testPlanFolders);
+
+    trackEvent(
+      TEST_PLANS_PAGE_EVENTS.viewTestPlanDetailsPage(
+        isEmptyPlan ? TEST_PLAN_DETAILS_VIEW_TYPE.EMPTY : TEST_PLAN_DETAILS_VIEW_TYPE.POPULATED,
+      ),
+    );
+  }, [isLoading, areFoldersLoading, testPlan, testPlanFolders, testPlanId, trackEvent]);
 
   useEffect(() => {
     if (!isLoading && isEmpty(testPlan)) {
@@ -242,7 +295,7 @@ export const TestPlanDetailsPage = () => {
             <Button
               variant="ghost"
               data-automation-id="addTestsFromLibraryButton"
-              onClick={() => setIsTestLibrarySidePanelOpen(true)}
+              onClick={handleOpenTestLibrarySidePanel}
             >
               {formatMessage(commonMessages.addTestsFromLibrary)}
             </Button>
@@ -251,7 +304,7 @@ export const TestPlanDetailsPage = () => {
             <Button
               variant="primary"
               data-automation-id="createLaunchButton"
-              onClick={openCreateLaunchModal}
+              onClick={handleOpenCreateLaunchModal}
             >
               {formatMessage(messages.addToLaunch)}
             </Button>

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/allTestCasesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/allTestCasesPage.tsx
@@ -17,9 +17,11 @@
 import { useState, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
+import { useTracking } from 'react-tracking';
 import { isEmpty } from 'es-toolkit/compat';
 import { Pagination, Button, Selection } from '@reportportal/ui-kit';
 
+import { TEST_PLANS_PAGE_EVENTS } from 'analyticsEvents/testPlansPageEvents';
 import { createClassnames } from 'common/utils';
 import { TestCaseList } from 'pages/inside/common/testCaseList';
 import { ITEMS_PER_PAGE_OPTIONS } from 'pages/inside/common/testCaseList/constants';
@@ -49,6 +51,7 @@ export const AllTestCasesPage = ({
   folderName,
 }: AllTestCasesPageProps) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const testPlansTestCasesPageData = useSelector(testPlanTestCasesPageSelector);
   const payload = useSelector(payloadSelector);
   const { organizationSlug, projectSlug } = useProjectDetails();
@@ -82,6 +85,11 @@ export const AllTestCasesPage = ({
       selectedTestCaseIds: selectedRowIds,
       onClearSelection,
     });
+  };
+
+  const handleOpenAddToLaunchModal = () => {
+    trackEvent(TEST_PLANS_PAGE_EVENTS.clickStartBulkAddToLaunch(selectedRowIds.length));
+    openAddToLaunchModal();
   };
 
   return (
@@ -130,7 +138,7 @@ export const AllTestCasesPage = ({
               >
                 {formatMessage(removeTestCasesFromTestPlanMessages.removeFromTestPlanTitle)}
               </Button>
-              <Button variant="primary" onClick={openAddToLaunchModal}>
+              <Button variant="primary" onClick={handleOpenAddToLaunchModal}>
                 {formatMessage(COMMON_LOCALE_KEYS.ADD_TO_LAUNCH)}
               </Button>
             </div>

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/allTestCasesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/allTestCasesPage.tsx
@@ -44,6 +44,8 @@ import styles from './allTestCasesPage.scss';
 
 const cx = createClassnames(styles);
 
+const BULK_ADD_TO_LAUNCH_MIN_SELECTION = 2;
+
 export const AllTestCasesPage = ({
   testCases,
   loading,
@@ -88,7 +90,9 @@ export const AllTestCasesPage = ({
   };
 
   const handleOpenAddToLaunchModal = () => {
-    trackEvent(TEST_PLANS_PAGE_EVENTS.clickStartBulkAddToLaunch(selectedRowIds.length));
+    if (selectedRowIds.length >= BULK_ADD_TO_LAUNCH_MIN_SELECTION) {
+      trackEvent(TEST_PLANS_PAGE_EVENTS.clickStartBulkAddToLaunch(selectedRowIds.length));
+    }
     openAddToLaunchModal();
   };
 

--- a/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/editTestPlanModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/editTestPlanModal.tsx
@@ -23,17 +23,32 @@ import { TestPlanDto } from 'controllers/testPlan';
 import { TestPlanModal, TestPlanFormValues } from '../testPlanModal';
 import { commonMessages } from '../../commonMessages';
 import { useEditTestPlan } from './useEditTestPlan';
+import { EditTestPlanSubmitMeta } from './useEditTestPlanModal';
+import { buildEditedFieldsCondition } from './utils';
 
 export const EDIT_TEST_PLAN_MODAL_KEY = 'editTestPlanModalKey';
 
 interface EditTestPlanModalProps {
   data: TestPlanDto;
-  onSubmitSuccess?: (attributesCount: number) => void;
+  onSubmitSuccess?: (meta: EditTestPlanSubmitMeta) => void;
 }
 
 export const EditTestPlanModal = ({ data, onSubmitSuccess }: EditTestPlanModalProps) => {
   const { formatMessage } = useIntl();
-  const { isLoading, submitTestPlan } = useEditTestPlan({ onSubmitSuccess });
+  const initialValues = {
+    name: data.name,
+    description: data.description,
+    attributes: data.attributes || [],
+  };
+  const { isLoading, submitTestPlan } = useEditTestPlan({
+    onSubmitSuccess: onSubmitSuccess
+      ? (submittedValues, attributesCount) =>
+          onSubmitSuccess({
+            attributesCount,
+            editedFieldsCondition: buildEditedFieldsCondition(initialValues, submittedValues),
+          })
+      : undefined,
+  });
 
   const handleSubmit = async (formValues: TestPlanFormValues) => {
     const payload = {
@@ -51,11 +66,7 @@ export const EditTestPlanModal = ({ data, onSubmitSuccess }: EditTestPlanModalPr
       submitButtonText={formatMessage(COMMON_LOCALE_KEYS.SAVE)}
       isLoading={isLoading}
       formName="edit-test-plan-modal-form"
-      initialValues={{
-        name: data.name,
-        description: data.description,
-        attributes: data.attributes || [],
-      }}
+      initialValues={initialValues}
       requiresChanges
       onSubmit={handleSubmit}
     />

--- a/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/useEditTestPlan.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/useEditTestPlan.ts
@@ -34,7 +34,7 @@ interface EditTestPlanFormValues extends TestPlanFormValues {
 }
 
 interface UseEditTestPlanOptions {
-  onSubmitSuccess?: (attributesCount: number) => void;
+  onSubmitSuccess?: (submittedValues: TestPlanFormValues, attributesCount: number) => void;
 }
 
 export const useEditTestPlan = ({ onSubmitSuccess }: UseEditTestPlanOptions = {}) => {
@@ -57,7 +57,7 @@ export const useEditTestPlan = ({ onSubmitSuccess }: UseEditTestPlanOptions = {}
         },
       });
 
-      onSubmitSuccess?.(payload.attributes?.length ?? 0);
+      onSubmitSuccess?.(payload, payload.attributes?.length ?? 0);
       dispatch(hideModalAction());
       dispatch(
         showSuccessNotification({

--- a/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/useEditTestPlanModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/useEditTestPlanModal.tsx
@@ -19,8 +19,13 @@ import { useModal } from 'common/hooks';
 
 import { EDIT_TEST_PLAN_MODAL_KEY, EditTestPlanModal } from './editTestPlanModal';
 
+export interface EditTestPlanSubmitMeta {
+  attributesCount: number;
+  editedFieldsCondition: string;
+}
+
 interface UseEditTestPlanModalOptions {
-  onSubmitSuccess?: (attributesCount: number) => void;
+  onSubmitSuccess?: (meta: EditTestPlanSubmitMeta) => void;
 }
 
 export const useEditTestPlanModal = ({ onSubmitSuccess }: UseEditTestPlanModalOptions = {}) =>

--- a/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/utils.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/utils.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEqual } from 'es-toolkit';
+
+import type { TestPlanFormValues } from 'pages/inside/testPlansPage/testPlanModals/testPlanModal';
+
+type BuildEditedFieldsConditionInitial = {
+  name: string;
+  description?: string;
+  attributes: TestPlanFormValues['attributes'];
+};
+
+export const buildEditedFieldsCondition = (
+  initial: BuildEditedFieldsConditionInitial,
+  submitted: TestPlanFormValues,
+): string => {
+  const edited: string[] = [];
+
+  if (initial.name !== submitted.name) {
+    edited.push('name');
+  }
+  if ((initial.description ?? '') !== (submitted.description ?? '')) {
+    edited.push('description');
+  }
+  if (!isEqual(initial.attributes ?? [], submitted.attributes ?? [])) {
+    edited.push('attributes');
+  }
+
+  return edited.sort().join('#');
+};

--- a/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/utils.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/editTestPlanModal/utils.ts
@@ -40,5 +40,7 @@ export const buildEditedFieldsCondition = (
     edited.push('attributes');
   }
 
-  return edited.sort().join('#');
+  const sortedEdited = [...edited].sort((a, b) => a.localeCompare(b));
+
+  return sortedEdited.join('#');
 };

--- a/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/useRemoveTestCasesFromTestPlan.ts
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/removeTestCasesFromTestPlanModal/useRemoveTestCasesFromTestPlan.ts
@@ -17,8 +17,10 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
+import { useTracking } from 'react-tracking';
 import { noop } from 'es-toolkit';
 
+import { TEST_PLANS_PAGE_EVENTS } from 'analyticsEvents/testPlansPageEvents';
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
 import { useDebouncedSpinner, useNotification } from 'common/hooks';
@@ -42,6 +44,7 @@ export const useRemoveTestCasesFromTestPlan = ({
   onSuccess = noop,
 }: UseRemoveTestCasesFromTestPlanOptions) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const { isLoading, showSpinner, hideSpinner } = useDebouncedSpinner();
   const dispatch = useDispatch();
   const projectKey = useSelector(projectKeySelector);
@@ -96,6 +99,8 @@ export const useRemoveTestCasesFromTestPlan = ({
           }),
         );
 
+        trackEvent(TEST_PLANS_PAGE_EVENTS.SUBMIT_REMOVE_TEST_FROM_PLAN);
+
         showSuccessNotification({
           messageId: 'removeFromTestPlanSuccess',
           values: { count: testCaseIds.length },
@@ -126,6 +131,7 @@ export const useRemoveTestCasesFromTestPlan = ({
       onSuccess,
       showErrorNotification,
       hideSpinner,
+      trackEvent,
     ],
   );
 

--- a/app/src/pages/inside/testPlansPage/testPlanSidePanel/testPlanSidePanel.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanSidePanel/testPlanSidePanel.tsx
@@ -18,6 +18,7 @@ import { memo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
+import { useTracking } from 'react-tracking';
 import { isEmpty } from 'es-toolkit/compat';
 import {
   Button,
@@ -31,6 +32,7 @@ import {
 } from '@reportportal/ui-kit';
 import { VoidFn } from '@reportportal/ui-kit/common';
 
+import { TEST_PLANS_PAGE_EVENTS } from 'analyticsEvents/testPlansPageEvents';
 import { createClassnames, copyToClipboard } from 'common/utils';
 import { useOnClickOutside } from 'common/hooks';
 import { CollapsibleSection } from 'components/collapsibleSection';
@@ -72,6 +74,7 @@ interface TestPlanSidePanelProps {
 export const TestPlanSidePanel = memo(
   ({ testPlan, isVisible, onClose }: TestPlanSidePanelProps) => {
     const { formatMessage } = useIntl();
+    const { trackEvent } = useTracking();
     const sidePanelRef = useRef<HTMLDivElement>(null);
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const { canManageTestCases } = useUserPermissions();
@@ -109,6 +112,7 @@ export const TestPlanSidePanel = memo(
     };
 
     const handleOpenInLibraryClick = () => {
+      trackEvent(TEST_PLANS_PAGE_EVENTS.CLICK_OPEN_TEST_CASE_IN_LIBRARY);
       openRouteInNewTab({
         type: TEST_CASE_LIBRARY_PAGE,
         payload: {

--- a/app/src/pages/inside/testPlansPage/testPlansTable/testPlansTable.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlansTable/testPlansTable.tsx
@@ -55,7 +55,7 @@ export const TestPlansTable = ({
   const isInMilestoneContext = analyticsPlace === PLACE_TP_ROW;
   const { openModal: openEditModal } = useEditTestPlanModal({
     onSubmitSuccess: isInMilestoneContext
-      ? (attributesCount) =>
+      ? ({ attributesCount }) =>
           trackEvent(MILESTONES_PAGE_EVENTS.submitEditTestPlan(attributesCount))
       : undefined,
   });


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics across Test Plans and Milestones: more granular page-view events (empty vs populated), once-per-view tracking, click/submit events for modals and kebab actions, drag-and-drop success events, bulk “add to launch” tracking, and library add-to-plan telemetry.
  * Updated handlers to emit tracking events before opening panels/modals or completing actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5356)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->