### PR TITLE
EPMRPP-115649 || Fix side panel overlap and scrollbar in Test Case Library

### DIFF
--- a/app/src/layouts/settingsLayout/settingsLayout.jsx
+++ b/app/src/layouts/settingsLayout/settingsLayout.jsx
@@ -20,19 +20,23 @@ import styles from './settingsLayout.scss';
 
 const cx = classNames.bind(styles);
 
-export const SettingsLayout = ({ navigation, children }) => (
+export const SettingsLayout = ({ navigation, children, fitContent }) => (
   <div className={cx('container')}>
     {navigation && <div className={cx('navigation')}>{navigation}</div>}
     <div className={cx('section')}>
-      <div className={cx('section-content')}>{children}</div>
+      <div className={cx('section-content', { 'section-content--fit': fitContent })}>
+        {children}
+      </div>
     </div>
   </div>
 );
 SettingsLayout.propTypes = {
   navigation: PropTypes.node,
   children: PropTypes.node,
+  fitContent: PropTypes.bool,
 };
 SettingsLayout.defaultProps = {
   navigation: null,
   children: null,
+  fitContent: false,
 };

--- a/app/src/layouts/settingsLayout/settingsLayout.scss
+++ b/app/src/layouts/settingsLayout/settingsLayout.scss
@@ -39,4 +39,10 @@
 .section-content {
   width: 100%;
   flex: 1 0 auto;
+
+  &--fit {
+    position: relative;
+    flex: 1 1 0;
+    overflow: hidden;
+  }
 }

--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.scss
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.scss
@@ -67,7 +67,9 @@
 }
 
 .expanded-options {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 1fr;
   position: relative;
   width: 100%;
   height: 100%;
@@ -245,13 +247,19 @@
     }
   }
 
+  &--no-sidebar {
+    grid-template-columns: 1fr;
+  }
+
+  &__content-scroll {
+    min-width: 580px;
+    overflow: hidden;
+  }
+
   &__content {
     width: 100%;
-    min-width: 580px;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    height: 100%;
   }
 
   &__no-search-results {

--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
@@ -254,7 +254,7 @@ export const ExpandedOptions = ({
           }}
         />
       )}
-      <div className={cx('expanded-options')}>
+      <div className={cx('expanded-options', { 'expanded-options--no-sidebar': hideSidebar })}>
         {hideSidebar || (
           <div className={cx('expanded-options__sidebar')}>
             <div className={cx('sidebar-header')}>
@@ -356,17 +356,19 @@ export const ExpandedOptions = ({
           </div>
         )}
         {stableHidePageSearchSidebar ? (
-          <div className={cx('expanded-options__content')}>
-            <div className={cx('expanded-options__no-search-results')}>
-              <EmptyPageState
-                label={formatMessage(COMMON_LOCALE_KEYS.NO_RESULTS)}
-                description={formatMessage(testCaseListMessages.noResultsDescription)}
-                emptyIcon={NoResultsIcon}
-              />
+          <div className={cx('expanded-options__content-scroll')}>
+            <div className={cx('expanded-options__content')}>
+              <div className={cx('expanded-options__no-search-results')}>
+                <EmptyPageState
+                  label={formatMessage(COMMON_LOCALE_KEYS.NO_RESULTS)}
+                  description={formatMessage(testCaseListMessages.noResultsDescription)}
+                  emptyIcon={NoResultsIcon}
+                />
+              </div>
             </div>
           </div>
         ) : (
-          <ScrollWrapper>
+          <ScrollWrapper className={cx('expanded-options__content-scroll')}>
             <div className={cx('expanded-options__content')}>{children}</div>
           </ScrollWrapper>
         )}

--- a/app/src/pages/inside/common/testCaseList/testCaseList.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseList.tsx
@@ -15,6 +15,7 @@
  */
 
 import { memo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useTracking } from 'react-tracking';
@@ -247,20 +248,24 @@ export const TestCaseList = memo(
                 />
               </>
             )}
-            {isTestLibraryRoute && (
-              <TestCaseSidePanel
-                testCase={selectedTestPlan}
-                isVisible={!!selectedTestCaseId}
-                onClose={handleCloseSidePanel}
-              />
-            )}
-            {isTestPlanRoute && (
-              <TestPlanSidePanel
-                testPlan={selectedTestPlan}
-                isVisible={!!selectedTestCaseId}
-                onClose={handleCloseSidePanel}
-              />
-            )}
+            {isTestLibraryRoute &&
+              createPortal(
+                <TestCaseSidePanel
+                  testCase={selectedTestPlan}
+                  isVisible={!!selectedTestCaseId}
+                  onClose={handleCloseSidePanel}
+                />,
+                document.body,
+              )}
+            {isTestPlanRoute &&
+              createPortal(
+                <TestPlanSidePanel
+                  testPlan={selectedTestPlan}
+                  isVisible={!!selectedTestCaseId}
+                  onClose={handleCloseSidePanel}
+                />,
+                document.body,
+              )}
           </>
         )}
       </div>

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.scss
@@ -19,12 +19,11 @@
 .test-case-library-page {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
 
   &__header {
-    position: sticky;
-    top: 0;
-    z-index: $Z_INDEX-GRID_HEADER;
     background-color: var(--rp-ui-base-bg-000);
     padding: 16px 32px 12px;
     border-bottom: 1px solid var(--rp-ui-base-e-100);

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
@@ -31,7 +31,6 @@ import { useBreadCrumbsTree } from 'common/hooks';
 import { createClassnames, debounce } from 'common/utils';
 import { ProjectDetails } from 'pages/organization/constants';
 import { NavLink } from 'components/main/navLink';
-import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { SettingsLayout } from 'layouts/settingsLayout';
 import ImportIcon from 'common/img/import-thin-inline.svg';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
@@ -181,9 +180,8 @@ export const TestCaseLibraryPage = () => {
   };
 
   return (
-    <SettingsLayout>
-      <ScrollWrapper resetRequired>
-        <div className={cx('test-case-library-page')}>
+    <SettingsLayout fitContent>
+      <div className={cx('test-case-library-page')}>
           <div className={cx('test-case-library-page__header')}>
             <div className={cx('test-case-library-page__breadcrumb')}>
               <Breadcrumbs
@@ -269,7 +267,6 @@ export const TestCaseLibraryPage = () => {
             onApply={handleApplyFilters}
           />
         </div>
-      </ScrollWrapper>
     </SettingsLayout>
   );
 };


### PR DESCRIPTION
### Problem

**Primary (EPMRPP-115649):** The `FilterSidePanel` on the Test Case Library page was sliding under the page header due to `position: sticky` and `z-index` on the header creating a stacking context that overlapped the panel.

**Secondary:** The vertical scrollbar in the test case list only responded to the mouse wheel — dragging the thumb had no effect. The outer `ScrollWrapper` wrapping the entire page prevented the inner one from getting a constrained height, so `react-custom-scrollbars-2` computed a thumb height of `0px`. Additionally, `TestCaseSidePanel` was rendered inside the `ScrollWrapper` stacking context, causing it to appear behind the scrollbar tracks.

### Fix

- Removed `position: sticky` and `z-index` from the page header, which resolves the side panel overlap.
- Restructured the page layout so the inner `ScrollWrapper` receives a definite height — the scrollbar thumb is now correctly sized and draggable.
- Moved `TestCaseSidePanel` and `TestPlanSidePanel` rendering outside the `ScrollWrapper` DOM tree via `createPortal` so they always appear on top.

## Visuals

**Before**

https://github.com/user-attachments/assets/46632253-7990-47bd-b634-89d177b59aee


**After**

https://github.com/user-attachments/assets/24898463-a5be-4ee4-b905-533ec2591251




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Improved settings layout flexibility for customizable content spacing
  * Enhanced expanded options panel with grid-based layout for better responsiveness
  * Optimized side panel rendering and positioning behavior
  * Refined page layout positioning and scroll behavior for improved user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5361)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->