### PR TITLE
EPMRPP-115715 || Reset Test Library folders state on project switch

### DIFF
--- a/app/src/controllers/testCase/reducer.ts
+++ b/app/src/controllers/testCase/reducer.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { combineReducers } from 'redux';
+import { combineReducers, AnyAction } from 'redux';
 import { isEmpty, isNil } from 'es-toolkit/compat';
 
 import { getParentFoldersIds } from 'common/utils/folderUtils';
 import { fetchReducer } from 'controllers/fetch';
 import { loadingReducer } from 'controllers/loading';
+import { FETCH_PROJECT_SUCCESS } from 'controllers/project';
 import { getInitialExpandedFolderIds } from 'controllers/utils/folderReducerUtils';
 import { hasPayloadProps } from 'controllers/utils/types';
 import {
@@ -383,21 +384,31 @@ const expandedFolderIdsReducer = (
   }
 };
 
+const foldersReducer = combineReducers({
+  data: queueReducers(
+    fetchReducer(NAMESPACE, { initialState: [], contentPath: 'content' }),
+    folderReducer,
+  ),
+  expandedFolderIds: expandedFolderIdsReducer,
+  isCreatingFolder: isCreatingFolderReducer,
+  isLoadingFolder: isLoadingFolderReducer,
+  loading: loadingReducer(NAMESPACE),
+  areFoldersFetched: areFoldersFetchedReducer,
+  filteredFolders: filteredFoldersReducer,
+  isLoadingFilteredFolders: isLoadingFilteredFoldersReducer,
+});
+
+const resettableFoldersReducer = (
+  state: ReturnType<typeof foldersReducer> | undefined,
+  action: AnyAction,
+) =>
+  action.type === FETCH_PROJECT_SUCCESS
+    ? foldersReducer(undefined, action)
+    : foldersReducer(state, action);
+
 const reducer = combineReducers({
   details: testCaseDetailsReducer,
-  folders: combineReducers({
-    data: queueReducers(
-      fetchReducer(NAMESPACE, { initialState: [], contentPath: 'content' }),
-      folderReducer,
-    ),
-    expandedFolderIds: expandedFolderIdsReducer,
-    isCreatingFolder: isCreatingFolderReducer,
-    isLoadingFolder: isLoadingFolderReducer,
-    loading: loadingReducer(NAMESPACE),
-    areFoldersFetched: areFoldersFetchedReducer,
-    filteredFolders: filteredFoldersReducer,
-    isLoadingFilteredFolders: isLoadingFilteredFoldersReducer,
-  }),
+  folders: resettableFoldersReducer,
   testCases: testCasesReducer,
 });
 


### PR DESCRIPTION
The TMS folder slice was never reset on project change, so the `areFoldersFetched` guard in the getFolders saga skipped the re-fetch and the sidebar kept showing the previous project's folder tree until a full page refresh. Reset the folders sub-state on FETCH_PROJECT_SUCCESS (fires only on a real project switch / initial load) so the route thunk re-fetches folders for the newly active project.

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management architecture for project loading operations to enhance application stability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5366)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->