### PR TITLE
EPMRPP-115651 || Fix white-space handling in TMS read-only text fields

### DIFF
--- a/app/src/pages/inside/common/scenario/scenario.scss
+++ b/app/src/pages/inside/common/scenario/scenario.scss
@@ -34,6 +34,7 @@
     &-value {
       font-family: var(--rp-ui-base-font-family);
       font-weight: 400;
+      white-space: pre-wrap;
     }
   }
 }

--- a/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.scss
+++ b/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.scss
@@ -37,6 +37,7 @@
     font-size: 13px;
     font-weight: 400;
     line-height: 20px;
+    white-space: pre-wrap;
   }
 
   &.full-view {

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseDetails/steps/step/step.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseDetails/steps/step/step.scss
@@ -42,6 +42,7 @@
       color: var(--rp-ui-base-almost-black);
       line-height: 20px;
       min-height: 20px;
+      white-space: pre-wrap;
     }
 
     .section-border {

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/precondition/preconditions.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/precondition/preconditions.scss
@@ -41,6 +41,7 @@
 
   &__value {
     padding: 16px;
+    white-space: pre-wrap;
   }
 
   &__attachments-wrapper {

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/step/step.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/step/step.scss
@@ -47,6 +47,7 @@
   &__expected-result {
     padding: 16px;
     width: 50%;
+    white-space: pre-wrap;
   }
 
   &__attachments-wrapper {


### PR DESCRIPTION
## Problem

Line breaks entered in test case step fields (instructions, expected result), scenario fields, and precondition were collapsed into a single line when displayed in read-only views. The issue affected all views: right side panel and test case details page.

The `description` field was already rendering line breaks correctly via `white-space: pre-wrap` in `ExpandedTextSection`, but the remaining text fields were missing this rule.

## Changes

Added `white-space: pre-wrap`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text formatting in test case scenarios, preconditions, and steps to preserve line breaks and whitespace for better content readability and presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5368)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->