### PR TITLE
EPMRPP-115666 ||  Create test case adding tag failed fix

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
@@ -19,6 +19,7 @@ import { isString } from 'es-toolkit';
 
 import { Attribute } from 'types/testCase';
 
+import { hasAttributeValue } from '../types';
 import { ManualScenarioDto, ManualScenarioType, CreateTestCaseFormData } from '../types';
 import { NewFolderData, isNewFolderData } from '../utils/getFolderFromFormValues';
 import { getMeaningfulRequirements } from '../utils/requirementsUtils';
@@ -101,6 +102,21 @@ export const processFolder = (
   };
 };
 
+export const mapAttributesForApi = (attributes: Attribute[]) =>
+  attributes.map((attr) => {
+    const payload: { id?: number; key: string; value?: string } = { key: attr.key };
+
+    if (attr.id > 0) {
+      payload.id = attr.id;
+    }
+
+    if (hasAttributeValue(attr)) {
+      payload.value = attr.value;
+    }
+
+    return payload;
+  });
+
 export const buildTestCaseData = (
   payload: CreateTestCaseFormData,
   manualScenario: ManualScenarioDto,
@@ -114,6 +130,6 @@ export const buildTestCaseData = (
     ...folderPayload,
     priority: payload.priority?.toUpperCase(),
     manualScenario,
-    attributes: attributes.map(({ key: _key, ...rest }) => rest),
+    attributes: mapAttributesForApi(attributes),
   };
 };

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
@@ -19,8 +19,12 @@ import { isString } from 'es-toolkit';
 
 import { Attribute } from 'types/testCase';
 
-import { hasAttributeValue } from '../types';
-import { ManualScenarioDto, ManualScenarioType, CreateTestCaseFormData } from '../types';
+import {
+  hasAttributeValue,
+  ManualScenarioDto,
+  ManualScenarioType,
+  CreateTestCaseFormData,
+} from '../types';
 import { NewFolderData, isNewFolderData } from '../utils/getFolderFromFormValues';
 import { getMeaningfulRequirements } from '../utils/requirementsUtils';
 import { hasStepContent } from '../../common/scenarioUtils';

--- a/app/src/pages/inside/testCaseLibraryPage/hooks/useTestCaseMutations.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/hooks/useTestCaseMutations.ts
@@ -97,31 +97,38 @@ export const useTestCaseMutations = (testCaseId?: number) => {
     [processFolderDestinationAndComplete],
   );
 
-  const createNewTags = useCallback(async (attributes: Attribute[] = []) => {
-    const newTags = attributes.filter(({ id }) => id < 0);
-    const existingTags = attributes.filter(({ id }) => id >= 0);
+  const createNewTags = useCallback(
+    async (attributes: Attribute[] = []) => {
+      const newTags = attributes.filter(({ id }) => id < 0);
+      const existingTags = attributes.filter(({ id }) => id >= 0);
 
-    if (isEmpty(newTags)) {
-      return attributes;
-    }
+      if (isEmpty(newTags)) {
+        return attributes;
+      }
 
-    const createdTags = await Promise.all(
-      newTags.map(async (tag) => {
-        try {
-          return fetch<Attribute>(URLS.createTmsAttribute(projectKey), {
-            method: 'POST',
-            data: { key: tag.key, value: tag.value },
-          });
-        } catch {
-          return null;
-        }
-      }),
-    );
+      if (!projectKey) {
+        return existingTags;
+      }
 
-    const successfullyCreatedTags = createdTags.filter((tag): tag is Attribute => tag !== null);
+      const createdTags = await Promise.all(
+        newTags.map(async (tag) => {
+          try {
+            return fetch<Attribute>(URLS.createTmsAttribute(projectKey), {
+              method: 'POST',
+              data: { key: tag.key, value: tag.value },
+            });
+          } catch {
+            return null;
+          }
+        }),
+      );
 
-    return [...existingTags, ...successfullyCreatedTags];
-  }, [projectKey]);
+      const successfullyCreatedTags = createdTags.filter((tag): tag is Attribute => tag !== null);
+
+      return [...existingTags, ...successfullyCreatedTags];
+    },
+    [projectKey],
+  );
 
   const handleTestCaseCreation = useCallback(
     async (

--- a/app/src/pages/inside/testCaseLibraryPage/tagPopover/useTagSearch.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/tagPopover/useTagSearch.ts
@@ -16,14 +16,14 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { isNotNil } from 'es-toolkit';
 
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
 import { projectKeySelector } from 'controllers/project';
 import { Tag } from 'types/testCase';
 
-import { TagError } from '../types';
-import { convertKeysToTags } from '../testCaseDetailsPage/utils';
+import { TagError, AttributesResponse } from '../types';
 
 export const useTagSearch = (searchValue: string = '') => {
   const [allTags, setAllTags] = useState<Tag[]>([]);
@@ -33,11 +33,18 @@ export const useTagSearch = (searchValue: string = '') => {
   const projectKey = useSelector(projectKeySelector);
 
   const fetchAllTags = useCallback(async () => {
+    if (!projectKey) {
+      setAllTags([]);
+      return;
+    }
+
     try {
       setLoading(true);
 
-      const keys = await fetch<string[]>(URLS.tmsAttributeKeysSearch(projectKey, {}));
-      setAllTags(convertKeysToTags(keys));
+      const response = await fetch<AttributesResponse>(URLS.tmsAttributes(projectKey, {}));
+      const tagsOnly = (response.content || []).filter((attr) => !attr.value);
+
+      setAllTags(tagsOnly);
     } catch {
       setAllTags([]);
     } finally {
@@ -46,6 +53,11 @@ export const useTagSearch = (searchValue: string = '') => {
   }, [projectKey]);
 
   const fetchFilteredTags = useCallback(async () => {
+    if (!projectKey) {
+      setTags([]);
+      return;
+    }
+
     try {
       setLoading(true);
       setError(null);
@@ -56,14 +68,18 @@ export const useTagSearch = (searchValue: string = '') => {
         }),
       );
 
-      setTags(convertKeysToTags(keys));
+      const matchedTags = keys
+        .map((key) => allTags.find((tag) => tag.key === key))
+        .filter(isNotNil);
+
+      setTags(matchedTags);
     } catch {
       setTags([]);
-      setError(null);
+      setError(TagError.TAG_SEARCH_FAILED);
     } finally {
       setLoading(false);
     }
-  }, [projectKey, searchValue]);
+  }, [projectKey, searchValue, allTags]);
 
   const createTag = useCallback(
     (tagKey: string, selectedTags: Tag[] = []) => {
@@ -93,12 +109,10 @@ export const useTagSearch = (searchValue: string = '') => {
   );
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchAllTags();
   }, [fetchAllTags]);
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchFilteredTags();
   }, [fetchFilteredTags]);
 

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/utils.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/utils.ts
@@ -21,7 +21,7 @@ import {
   hasScenarioContent,
 } from 'pages/inside/common/scenarioUtils';
 
-import { ManualScenario, Tag, TestCaseManualScenario } from 'types/testCase';
+import { ManualScenario, TestCaseManualScenario } from 'types/testCase';
 
 export const checkScenario = (manualScenario: ManualScenario | undefined): boolean => {
   if (!manualScenario) return true;
@@ -38,11 +38,4 @@ export const checkScenario = (manualScenario: ManualScenario | undefined): boole
   const hasScenario = hasScenarioContent(manualScenario);
 
   return !hasRequirements && !hasScenario && isEmpty(manualScenario.attachments);
-};
-
-export const convertKeysToTags = (keys: string[]): Tag[] => {
-  return keys.map((key, index) => ({
-    id: -Date.now() - index,
-    key,
-  }));
 };

--- a/app/src/pages/inside/testCaseLibraryPage/types.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/types.ts
@@ -128,6 +128,7 @@ export interface UseTestCaseTagsParams {
 export enum TagError {
   TAG_ALREADY_ADDED = 'tagAlreadyAdded',
   CREATE_TAG_FAILED = 'createTagFailed',
+  TAG_SEARCH_FAILED = 'tagSearchFailed',
 }
 
 export interface AttributesResponse {


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)


## Problem overview 

Problem 1: Duplicate Tag Error (500)
When selecting an existing tag from the dropdown while creating a test case, the system threw a 500 error stating the attribute already exists. The root cause was that the old implementation used the [/tms/attribute/key](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) endpoint which returned only string keys without database IDs. When a user selected an existing tag like "new_af", it was assigned a negative placeholder ID, and the backend payload was sent without the real ID, causing the server to attempt creating a duplicate attribute instead of linking the existing one.

Solution: We switched to using the /tms/attribute endpoint to fetch full tag objects with real database IDs on mount, while keeping [/tms/attribute/key](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for search functionality and matching results with the cached full objects. The [mapAttributesForApi](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) function now properly includes the ID for existing tags, so the backend correctly links existing attributes instead of trying to create duplicates. We also filter results to show only tags without values to avoid mixing them with key-value attributes like "browser=chrome".

Problem 2: Undefined Project Key (404)
When opening the TMS page directly via URL, the project key was not yet loaded into the Redux store, causing API calls to [project/undefined/tms/attribute/key](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) which resulted in 404 errors. This happened because the component rendered and tried to fetch tags before the project information was initialized.

Solution: We added defensive guards in [useTagSearch](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [useTestCaseMutations](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to check if [projectKey](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) exists before making any API calls. If the project key is empty or undefined, the functions return early with empty arrays instead of attempting the request. Once the project key loads, the React useEffect dependencies trigger a refetch automatically, ensuring tags are loaded without any errors.

## Visuals
**BEFORE**

https://github.com/user-attachments/assets/34d11268-eda5-44e9-9e66-b4dcd1314ee1


**AFTER**

https://github.com/user-attachments/assets/cefdbd7b-3062-4105-8db2-67001809f4d6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unnecessary tag-creation API calls when project info is missing.
  * Improves tag search error handling with a specific failure state.

* **Refactor**
  * Introduced a helper to consistently map attributes into API-ready format.
  * Simplified tag fetching/search logic to avoid redundant conversions.

* **Chores**
  * Removed a legacy tag-conversion helper no longer in use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->