### PR TITLE
EPMRPP-115652 || Collapse empty sections by default

### DIFF
--- a/app/src/components/collapsibleSection/collapsibleSection.tsx
+++ b/app/src/components/collapsibleSection/collapsibleSection.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactNode, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { ChevronDownDropdownIcon } from '@reportportal/ui-kit';
 
 import { createClassnames } from 'common/utils';
@@ -37,6 +37,10 @@ export const CollapsibleSection = ({
   isInitiallyExpanded = true,
 }: CollapsibleSectionProps) => {
   const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded);
+
+  useEffect(() => {
+    setIsExpanded(isInitiallyExpanded);
+  }, [isInitiallyExpanded]);
 
   const handleToggle = () => {
     setIsExpanded((prevState) => !prevState);
@@ -80,6 +84,10 @@ export const CollapsibleSectionWithHeaderControl = ({
   isInitiallyExpanded = true,
 }: CollapsibleSectionWithHeaderControlProps) => {
   const [isExpanded, setIsExpanded] = useState(isInitiallyExpanded);
+
+  useEffect(() => {
+    setIsExpanded(isInitiallyExpanded);
+  }, [isInitiallyExpanded]);
 
   const handleToggle = () => {
     setIsExpanded((prevState) => !prevState);

--- a/app/src/pages/inside/common/testCaseList/testCaseSidePanel/testCaseSidePanel.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseSidePanel/testCaseSidePanel.tsx
@@ -331,6 +331,7 @@ export const TestCaseSidePanel = memo(
               key={titleKey}
               title={safeGetMessage(titleKey, formatMessage)}
               defaultMessage={safeGetMessage(defaultMessageKey, formatMessage)}
+              isInitiallyExpanded={!!childComponent}
             >
               {childComponent}
             </CollapsibleSection>

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/testCaseDetailsPage.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/testCaseDetailsPage.tsx
@@ -240,6 +240,7 @@ export const TestCaseDetailsPage = () => {
         key={titleKey}
         title={formatMessage(commonMessages[titleKey])}
         defaultMessage={formatMessage(defaultMessage)}
+        isInitiallyExpanded={!!childComponent}
       >
         {childComponent}
       </CollapsibleSectionWithHeaderControl>
@@ -272,6 +273,7 @@ export const TestCaseDetailsPage = () => {
                 title={formatMessage(commonMessages[titleKey])}
                 defaultMessage={formatMessage(defaultMessage)}
                 headerControlComponent={headerControl}
+                isInitiallyExpanded={!!childComponent}
               >
                 {childComponent}
               </CollapsibleSectionWithHeaderControl>


### PR DESCRIPTION
## Summary

Empty **Tags**, **Attachments**, and **Description** sections in the test case side panel and details page were always rendered expanded, consuming vertical space and showing only a placeholder message.

Now sections with no content are collapsed by default. Sections with data remain expanded as before.

## Visuals

**Before**

<img width="678" height="778" alt="image" src="https://github.com/user-attachments/assets/cd824be7-4b14-477e-af0f-028818ca27c6" />

**After**

<img width="675" height="783" alt="image" src="https://github.com/user-attachments/assets/02b47186-e1b6-4792-8a68-2dc861011f85" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test case display: collapsible sections now automatically expand when containing content and collapse when empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->