### PR TITLE
EPMRPP-115952 || Fix Global integration connection test on Project level

### DIFF
--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
@@ -93,15 +93,10 @@ export const IntegrationInfo = (props) => {
     ? formatMessage(messages.projectIntegrationAddLimited)
     : undefined;
 
-  const testProjectIntegrationConnection = useCallback(
+  const testIntegrationConnection = useCallback(
     (integrationId) =>
       fetch(URLS.testIntegrationConnection(projectKey || activeProjectKey, integrationId)),
     [projectKey, activeProjectKey],
-  );
-
-  const testGlobalIntegrationConnection = useCallback(
-    (integrationId) => fetch(URLS.testGlobalIntegrationConnection(integrationId)),
-    [],
   );
 
   useEffect(() => {
@@ -300,7 +295,7 @@ export const IntegrationInfo = (props) => {
             text={formatMessage(messages.projectIntegrationText)}
             integrations={availableProjectIntegrations}
             openIntegration={openIntegration}
-            testConnection={testProjectIntegrationConnection}
+            testConnection={testIntegrationConnection}
             withEmptyState
             hasUpdatePermission={canUpdateSettings}
             onCreateClick={onAddProjectIntegration}
@@ -316,7 +311,7 @@ export const IntegrationInfo = (props) => {
               openIntegration={openIntegration}
               inactive={Boolean(availableProjectIntegrations.length)}
               inactiveTooltip={formatMessage(messages.inactiveGlobalIntegrations)}
-              testConnection={testGlobalIntegrationConnection}
+              testConnection={testIntegrationConnection}
             />
           )}
         </div>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

https://github.com/user-attachments/assets/d2973f7e-e29b-4294-955e-0be79006ab9f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined integration connection testing with unified handling for project and global integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->