### PR TITLE
EPMRPP-114990 || Add Log tab extension

### DIFF
--- a/app/src/controllers/plugins/uiExtensions/constants.js
+++ b/app/src/controllers/plugins/uiExtensions/constants.js
@@ -39,6 +39,7 @@ export const EXTENSION_TYPE_MAKE_DECISION_DEFECT_TYPE_ADDON =
   'uiExtension:makeDecisionDefectTypeAddon';
 export const EXTENSION_TYPE_LOG_STACKTRACE_ADDON = 'uiExtension:logStacktraceAddon';
 export const EXTENSION_TYPE_TEST_ITEM_DETAILS_ADDON = 'uiExtension:testItemDetailsAddon';
+export const EXTENSION_TYPE_LOG_TAB = 'uiExtension:logTab';
 export const EXTENSION_TYPE_PROJECT_PAGE = 'uiExtension:projectPage';
 
 export const REMOTE_EXTENSION_POINT_PROJECT_PAGE = 'projectPages';

--- a/app/src/controllers/plugins/uiExtensions/index.js
+++ b/app/src/controllers/plugins/uiExtensions/index.js
@@ -19,6 +19,7 @@ export {
   makeDecisionDefectTypeAddonSelector,
   logStackTraceAddonSelector,
   testItemDetailsAddonSelector,
+  uiExtensionLogTabSelector,
   uiExtensionProjectPagesSelector,
   extensionManifestSelector,
   extensionManifestsLoadPendingSelector,

--- a/app/src/controllers/plugins/uiExtensions/selectors.js
+++ b/app/src/controllers/plugins/uiExtensions/selectors.js
@@ -39,6 +39,7 @@ import {
   EXTENSION_TYPE_MAKE_DECISION_DEFECT_COMMENT_ADDON,
   EXTENSION_TYPE_MAKE_DECISION_DEFECT_TYPE_ADDON,
   EXTENSION_TYPE_LOG_STACKTRACE_ADDON,
+  EXTENSION_TYPE_LOG_TAB,
   EXTENSION_TYPE_TEST_ITEM_DETAILS_ADDON,
   EXTENSION_TYPE_PROJECT_PAGE,
   PLUGIN_TYPE_REMOTE,
@@ -170,6 +171,9 @@ export const logStackTraceAddonSelector = createExtensionSelectorByExtensionPoin
 ]);
 export const testItemDetailsAddonSelector = createExtensionSelectorByExtensionPoints([
   EXTENSION_TYPE_TEST_ITEM_DETAILS_ADDON,
+]);
+export const uiExtensionLogTabSelector = createExtensionSelectorByExtensionPoints([
+  EXTENSION_TYPE_LOG_TAB,
 ]);
 
 export const extensionManifestSelector = (state, pluginName) => {

--- a/app/src/pages/inside/logsPage/logItemInfo/infoTabs/infoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/infoTabs/infoTabs.jsx
@@ -108,7 +108,9 @@ export class InfoTabs extends Component {
               <button
                 className={cx('tab', { active: this.isActiveTab(tab), stroked: tab.stroked })}
                 onClick={() => {
-                  tracking.trackEvent(tab.eventInfo);
+                  if (tab.eventInfo) {
+                    tracking.trackEvent(tab.eventInfo);
+                  }
                   setActiveTab(tab.id);
                 }}
               >

--- a/app/src/pages/inside/logsPage/logItemInfo/infoTabs/infoTabs.scss
+++ b/app/src/pages/inside/logsPage/logItemInfo/infoTabs/infoTabs.scss
@@ -53,7 +53,7 @@
     stroke: $COLOR--charcoal-grey;
   }
 
-  &:after {
+  &:not(:last-child):after {
     content: '';
     width: 1px;
     height: 20px;

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -20,6 +20,7 @@ import { connect } from 'react-redux';
 import { defineMessages, injectIntl } from 'react-intl';
 import classNames from 'classnames/bind';
 import track from 'react-tracking';
+import { ExtensionLoader } from 'components/extensionLoader';
 import {
   lastLogActivitySelector,
   activeRetrySelector,
@@ -40,6 +41,7 @@ import ClockIcon from 'common/img/clock-inline.svg';
 import LogIcon from 'common/img/log-view-inline.svg';
 import { getSauceLabsConfig } from 'components/integrations/integrationProviders/sauceLabsIntegration/utils';
 import { availableIntegrationsByPluginNameSelector } from 'controllers/plugins';
+import { uiExtensionLogTabSelector } from 'controllers/plugins/uiExtensions';
 import { StackTrace } from 'pages/inside/common/stackTrace';
 import { SauceLabsIntegrationButton } from './sauceLabsIntegrationButton';
 import { InfoTabs } from '../infoTabs';
@@ -89,6 +91,7 @@ const ATTACHMENTS_TAB_ID = 'attachments';
     attachments: attachmentItemsSelector(state),
     activeTabId: activeTabIdSelector(state),
     noLogsCollapsing: noLogsCollapsingSelector(state),
+    logTabExtensions: uiExtensionLogTabSelector(state),
   }),
   {
     fetchFirstAttachments: fetchFirstAttachmentsAction,
@@ -117,6 +120,7 @@ export class LogItemInfoTabs extends Component {
     }).isRequired,
     activeTabId: PropTypes.string,
     noLogsCollapsing: PropTypes.bool,
+    logTabExtensions: PropTypes.array,
   };
 
   static defaultProps = {
@@ -126,6 +130,7 @@ export class LogItemInfoTabs extends Component {
     activeTabId: 'logs',
     setActiveTabId: () => {},
     noLogsCollapsing: false,
+    logTabExtensions: [],
   };
 
   state = {
@@ -191,6 +196,7 @@ export class LogItemInfoTabs extends Component {
       activeRetry,
       logItem,
       noLogsCollapsing,
+      logTabExtensions,
     } = this.props;
     const history = {
       id: 'history',
@@ -248,6 +254,29 @@ export class LogItemInfoTabs extends Component {
     if (this.isHistoryTabVisible()) {
       tabs.push(history);
     }
+
+    logTabExtensions.forEach((extension) => {
+      const isVisible = logItem.attributes?.some(
+        (attr) => attr.key === extension.payload.visibilityAttributeKey
+      );
+
+      if (!isVisible) {
+        return;
+      }
+
+      const tabId = `log-tab:${extension.pluginName}:${extension.name}`;
+      tabs.push({
+        id: tabId,
+        label: extension.name,
+        icon: extension.payload.icon,
+        component: ExtensionLoader,
+        componentProps: {
+          extension,
+          logItem,
+        },
+      });
+    });
+
     return tabs;
   };
 


### PR DESCRIPTION
Related PR in plugin - https://github.com/reportportal/plugin-mobitru/pull/13

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
<img width="924" height="568" alt="Screenshot 2026-05-20 at 18 11 00" src="https://github.com/user-attachments/assets/15776f52-e592-43fb-9919-a43cb617be06" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins can now extend the log information view with custom tabs.

* **Bug Fixes**
  * Fixed tracking being triggered with undefined event data.
  * Fixed tab separators appearing on the final tab.

* **Security**
  * Updated content security policies for enhanced protection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->