### PR TITLE
EPMRPP-115655 || Handle API test cases with partial manualScenario inside panel

### DIFF
--- a/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.tsx
@@ -49,16 +49,16 @@ export const Scenario = ({ scenario }: ScenarioProps) => {
           <div className={cx('scenario', 'steps-scenario', 'with-attachments')}>
             {preconditionValue && (
               <FieldSection title={formatMessage(messages.precondition)}>
-                <div className={cx('precondition-text')}>{scenario.preconditions.value}</div>
+                <div className={cx('precondition-text')}>{preconditionValue}</div>
               </FieldSection>
             )}
             {hasPreconditionAttachments && (
               <>
                 {preconditionValue && <div className={cx('section-border')} />}
                 <FieldSection
-                  title={`${formatMessage(commonMessages.attachments)} ${scenario.preconditions.attachments?.length}`}
+                  title={`${formatMessage(commonMessages.attachments)} ${scenario.preconditions?.attachments?.length}`}
                 >
-                  <AttachmentList attachments={scenario.preconditions.attachments} />
+                  <AttachmentList attachments={scenario.preconditions?.attachments} />
                 </FieldSection>
               </>
             )}

--- a/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.tsx
@@ -76,12 +76,14 @@ export const Scenario = ({ scenario }: ScenarioProps) => {
     );
   }
 
+  const preconditionValue = scenario.preconditions?.value;
+
   return (
     <div className={cx('scenario-wrapper')}>
       <div className={cx('scenario', 'full-view')}>
-        {scenario.preconditions?.value && (
+        {preconditionValue && (
           <FieldSection title={formatMessage(messages.precondition)} className={cx('sub-header')}>
-            <div className={cx('precondition-text')}>{scenario.preconditions.value}</div>
+            <div className={cx('precondition-text')}>{preconditionValue}</div>
           </FieldSection>
         )}
         {scenario.instructions && (

--- a/app/src/pages/inside/testCaseLibraryPage/addToLaunchButton/addToLaunchButton.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/addToLaunchButton/addToLaunchButton.tsx
@@ -37,7 +37,7 @@ const cx = createClassnames(styles);
 
 interface AddToLaunchButtonProps {
   testCaseId: number;
-  manualScenario: ManualScenario;
+  manualScenario?: ManualScenario;
   place: AddToLaunchPlace;
 }
 
@@ -59,13 +59,16 @@ export const AddToLaunchButton = ({
       !isEmpty(instructions) || !isEmpty(expectedResult) || !isEmpty(attachments);
 
     if (manualScenario.manualScenarioType === TestCaseManualScenario.TEXT) {
-      const {
-        preconditions: { value, attachments },
-        instructions,
-        expectedResult,
-      } = manualScenario;
+      const { preconditions, instructions, expectedResult } = manualScenario;
 
-      return isEmpty(value) && !hasContent({ instructions, expectedResult, attachments });
+      return (
+        isEmpty(preconditions?.value) &&
+        !hasContent({
+          instructions,
+          expectedResult,
+          attachments: preconditions?.attachments,
+        })
+      );
     }
 
     return (

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/precondition/precondition.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/precondition/precondition.tsx
@@ -29,8 +29,8 @@ const cx = createClassnames(styles);
 
 interface PreconditionProps {
   preconditions: {
-    value: string;
-    attachments: Attachment[];
+    value?: string;
+    attachments?: Attachment[];
   };
 }
 
@@ -47,7 +47,7 @@ export const Precondition = ({ preconditions }: PreconditionProps) => {
         {!isEmpty(preconditions.attachments) && (
           <div className={cx('precondition__attachments-wrapper')}>
             <h4>
-              {formatMessage(commonMessages.attachments)} {preconditions.attachments.length}
+              {formatMessage(commonMessages.attachments)} {preconditions.attachments?.length}
             </h4>
             <AttachmentsWithSlider
               attachments={preconditions.attachments}

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/testCaseDetailsPage.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseDetailsPage/testCaseDetailsPage.tsx
@@ -127,9 +127,10 @@ const MAIN_CONTENT_COLLAPSIBLE_SECTIONS_CONFIG = ({
       {
         titleKey: 'precondition',
         defaultMessage: messages.noPrecondition,
-        childComponent: hasStepsPreconditionContent(manualScenario?.preconditions) && (
-          <Precondition preconditions={manualScenario.preconditions} />
-        ),
+        childComponent: hasStepsPreconditionContent(manualScenario?.preconditions) &&
+          manualScenario?.preconditions && (
+            <Precondition preconditions={manualScenario.preconditions} />
+          ),
       },
       {
         titleKey: 'steps',

--- a/app/src/types/testCase.ts
+++ b/app/src/types/testCase.ts
@@ -85,9 +85,9 @@ export interface ManualScenario {
   id: number;
   executionEstimationTime: number;
   requirements: Requirement[];
-  preconditions: {
-    value: string;
-    attachments: Attachment[];
+  preconditions?: {
+    value?: string;
+    attachments?: Attachment[];
   };
   attributes?: Tag[];
   steps: Step[];


### PR DESCRIPTION
## Summary

Fixes a runtime crash when opening an API-created test case from the Test Case Library folder list. The UI no longer assumes `manualScenario.preconditions` is always present for TEXT scenarios.

**Jira:** [EPMRPP-115655](https://jiraeu.epam.com/browse/EPMRPP-115655)

## Problem

After creating a test case via TMS API with only `name` and `testFolderId`, opening the row on `.../testLibrary/folder/{id}` could crash the page:

`TypeError: Cannot read properties of undefined (reading 'value')`

The URL often stayed on the folder route (side panel), not on the details page.

The folder **list** API can return a partial `manualScenario` for TEXT type (type and empty collections set) **without** a `preconditions` object. `AddToLaunchButton` destructured `preconditions: { value, attachments }` unconditionally in `useMemo`, which threw before the panel could render.

## Solution

- **`addToLaunchButton.tsx`**: Use optional access for `preconditions?.value` and `preconditions?.attachments` when evaluating whether Add to Launch should be disabled for TEXT scenarios. Mark `manualScenario` prop as optional to match callers (`testCase?.manualScenario`).
- **`types/testCase.ts`**: Align `ManualScenario.preconditions` (and nested fields) with the API — optional where the backend omits them.
- **`scenario.tsx` (side panel)**: Use safe access for precondition attachments in the STEPS branch (defensive, same payload shape).

## Expected behavior

- Opening a test case with partial or missing `manualScenario` / `preconditions` from the folder list shows the side panel and details flow without a runtime error.
- Add to Launch stays disabled with tooltip when the scenario has no actionable content (unchanged product behavior).
- Fully populated TEXT and STEPS test cases are unaffected.


## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Manual test scenarios now allow missing preconditions; precondition text and attachments are optional and handled gracefully.

* **Bug Fixes**
  * Precondition display and attachments count are more robust (won’t error when absent).
  * “Add to Launch” button enable/disable logic updated so it correctly reflects presence of precondition text or attachments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->