### PR TITLE
EPMRPP-116003 Submit Add to Launch — single (funnel end)

### DIFF
--- a/app/src/pages/inside/common/launchFormFields/baseLaunchModal.tsx
+++ b/app/src/pages/inside/common/launchFormFields/baseLaunchModal.tsx
@@ -45,7 +45,7 @@ export const BaseLaunchModal = ({
   hideTestPlanField = false,
   className,
   onClearSelection,
-  onSubmitClick,
+  onSubmitSuccess,
 }: BaseLaunchModalProps & InjectedFormProps<LaunchFormData>) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
@@ -59,6 +59,7 @@ export const BaseLaunchModal = ({
     selectedLaunch?.id,
     folderId,
     onClearSelection,
+    onSubmitSuccess,
   );
 
   const isSubmitDisabled =
@@ -78,10 +79,9 @@ export const BaseLaunchModal = ({
     [activeMode, change],
   );
 
-  const trackedSubmit = handleSubmit((values: LaunchFormData) => {
-    onSubmitClick?.(activeMode);
-    return handleCreateLaunch(values);
-  }) as (event?: FormEvent | MouseEvent<HTMLButtonElement>) => void;
+  const trackedSubmit = handleSubmit((values: LaunchFormData) =>
+    handleCreateLaunch(values),
+  ) as (event?: FormEvent | MouseEvent<HTMLButtonElement>) => void;
 
   const handleOkClick = (event: MouseEvent<HTMLButtonElement>) => {
     trackedSubmit(event);

--- a/app/src/pages/inside/common/launchFormFields/types.ts
+++ b/app/src/pages/inside/common/launchFormFields/types.ts
@@ -122,5 +122,5 @@ export interface BaseLaunchModalProps {
   isUncoveredTestsCheckboxAvailable?: boolean;
   hideTestPlanField?: boolean;
   onClearSelection?: () => void;
-  onSubmitClick?: (mode: LaunchMode) => void;
+  onSubmitSuccess?: (mode: LaunchMode) => void;
 }

--- a/app/src/pages/inside/common/launchFormFields/useCreateManualLaunch.ts
+++ b/app/src/pages/inside/common/launchFormFields/useCreateManualLaunch.ts
@@ -42,6 +42,7 @@ export const useCreateManualLaunch = (
   selectedLaunchId?: number,
   folderId?: number,
   onClearSelection?: () => void,
+  onSubmitSuccess?: (mode: LaunchMode) => void,
 ) => {
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
@@ -151,6 +152,7 @@ export const useCreateManualLaunch = (
           return;
         }
 
+        onSubmitSuccess?.(activeMode);
         onClearSelection?.();
         dispatch(hideModalAction());
       } catch (error: unknown) {
@@ -171,6 +173,7 @@ export const useCreateManualLaunch = (
       selectedLaunchId,
       activeMode,
       onClearSelection,
+      onSubmitSuccess,
       dispatch,
       projectKey,
       formatMessage,

--- a/app/src/pages/inside/common/testLibrarySidePanel/testPlanDropZonesContainer/testPlanDropZonesContainer.tsx
+++ b/app/src/pages/inside/common/testLibrarySidePanel/testPlanDropZonesContainer/testPlanDropZonesContainer.tsx
@@ -23,8 +23,11 @@ import {
   DND_ITEM_COUNT_TYPE,
   DndDropTarget,
   TEST_PLANS_PAGE_EVENTS,
+  ACTION_SOURCE,
+  PLACE_TEST_CASE_LIBRARY_SIDE_PANEL,
 } from 'analyticsEvents/testPlansPageEvents';
 import { useModal } from 'common/hooks';
+import { BULK_ADD_TO_LAUNCH_MIN_SELECTION } from 'pages/inside/common/constants';
 import { TestCase } from 'types/testCase';
 import { TransformedFolder } from 'controllers/testCase';
 import {
@@ -81,6 +84,8 @@ export const TestPlanDropZonesContainer = ({
         selectedRowsIds={data.selectedRowsIds}
         testCases={data.testCases}
         testPlanId={data.testPlanId}
+        source={data.source}
+        place={data.place}
       />
     ),
   });
@@ -155,6 +160,11 @@ export const TestPlanDropZonesContainer = ({
             selectedRowsIds: ids,
             testCases,
             testPlanId: String(testPlanId),
+            source:
+              ids.length >= BULK_ADD_TO_LAUNCH_MIN_SELECTION
+                ? ACTION_SOURCE.BULK
+                : ACTION_SOURCE.SINGLE,
+            place: PLACE_TEST_CASE_LIBRARY_SIDE_PANEL,
           });
         }
       } finally {
@@ -220,6 +230,11 @@ export const TestPlanDropZonesContainer = ({
             selectedRowsIds: ids,
             testCases: getTestCasesFromIds(ids),
             testPlanId: String(testPlanId),
+            source:
+              ids.length >= BULK_ADD_TO_LAUNCH_MIN_SELECTION
+                ? ACTION_SOURCE.BULK
+                : ACTION_SOURCE.SINGLE,
+            place: PLACE_TEST_CASE_LIBRARY_SIDE_PANEL,
           });
         }
       } finally {

--- a/app/src/pages/inside/testCaseLibraryPage/addToLaunchModal/addToLaunchModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/addToLaunchModal/addToLaunchModal.tsx
@@ -86,7 +86,7 @@ const AddToLaunchModalComponent = ({
     [count, isFromFolder, testCases, formatMessage],
   );
 
-  const handleSubmitClick = (mode: LaunchMode) => {
+  const handleSubmitSuccess = (mode: LaunchMode) => {
     if (isBulk) {
       trackEvent(TEST_CASE_LIBRARY_EVENTS.SUBMIT_BULK_ADD_TO_LAUNCH);
       return;
@@ -118,7 +118,7 @@ const AddToLaunchModalComponent = ({
       className={cx('add-to-launch-modal')}
       onClearSelection={onClearSelection}
       isUncoveredTestsCheckboxAvailable={isUncoveredTestsCheckboxAvailable}
-      onSubmitClick={handleSubmitClick}
+      onSubmitSuccess={handleSubmitSuccess}
     />
   );
 };

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/addTestCasesToLaunchModal/addTestCasesToLaunchModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/addTestCasesToLaunchModal/addTestCasesToLaunchModal.tsx
@@ -73,7 +73,7 @@ const AddTestCasesToLaunchModalComponent = ({
         });
   }, [testCases, formatMessage]);
 
-  const handleSubmitClick = useCallback(
+  const handleSubmitSuccess = useCallback(
     (mode: LaunchMode) => {
       if (!source || !place) {
         return;
@@ -104,7 +104,7 @@ const AddTestCasesToLaunchModalComponent = ({
       hideTestPlanField
       className={cx('add-test-cases-to-launch-modal')}
       onClearSelection={onClearSelection}
-      onSubmitClick={handleSubmitClick}
+      onSubmitSuccess={handleSubmitSuccess}
     />
   );
 };

--- a/app/src/pages/inside/testPlansPage/testPlanModals/createLaunchModal/createLaunchModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/createLaunchModal/createLaunchModal.tsx
@@ -14,19 +14,28 @@
  * limitations under the License.
  */
 
+import { useMemo, ReactNode, useCallback } from 'react';
 import { useIntl } from 'react-intl';
 import { InjectedFormProps, reduxForm } from 'redux-form';
-import { useMemo, ReactNode } from 'react';
+import { useTracking } from 'react-tracking';
 
 import { createClassnames } from 'common/utils';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { useActiveTestPlan } from 'hooks/useTypedSelector';
+import { BULK_ADD_TO_LAUNCH_MIN_SELECTION } from 'pages/inside/common/constants';
 import {
   BaseLaunchModal,
   LaunchFormData,
   INITIAL_LAUNCH_FORM_VALUES,
+  LaunchMode,
   messages as launchFormMessages,
 } from 'pages/inside/common/launchFormFields';
+import {
+  TEST_PLANS_PAGE_EVENTS,
+  PLACE_DETAILS,
+  ACTION_SOURCE,
+  ADD_TO_LAUNCH_STATUS,
+} from 'analyticsEvents/testPlansPageEvents';
 
 import { CreateLaunchModalProps } from './types';
 import { messages } from './messages';
@@ -42,6 +51,7 @@ const CreateLaunchModalComponent = ({
   ...reduxFormProps
 }: CreateLaunchModalProps & InjectedFormProps<LaunchFormData>) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const activeTestPlan = useActiveTestPlan();
 
   const testPlanName = activeTestPlan?.name;
@@ -54,6 +64,27 @@ const CreateLaunchModalComponent = ({
     });
   }, [testPlanName, formatMessage]);
 
+  const handleSubmitSuccess = useCallback(
+    (mode: LaunchMode) => {
+      const source =
+        testCases.length >= BULK_ADD_TO_LAUNCH_MIN_SELECTION
+          ? ACTION_SOURCE.BULK
+          : ACTION_SOURCE.SINGLE;
+
+      trackEvent(
+        TEST_PLANS_PAGE_EVENTS.submitAddToTestLaunch({
+          source,
+          place: PLACE_DETAILS,
+          status:
+            mode === LaunchMode.NEW
+              ? ADD_TO_LAUNCH_STATUS.CREATE_NEW_LAUNCH
+              : ADD_TO_LAUNCH_STATUS.ADD_TO_EXISTING_LAUNCH,
+        }),
+      );
+    },
+    [testCases.length, trackEvent],
+  );
+
   return (
     <BaseLaunchModal
       {...reduxFormProps}
@@ -64,6 +95,7 @@ const CreateLaunchModalComponent = ({
       description={descriptionText}
       hideTestPlanField
       className={cx('create-launch-modal')}
+      onSubmitSuccess={handleSubmitSuccess}
     />
   );
 };


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved launch form submission flow by shifting callback execution to trigger after successful form submission rather than on click, ensuring callbacks fire only when submission succeeds.
  * Enhanced analytics tracking for launch operations by adding source and placement metadata to modal flows, providing better visibility into where launches are created or modified from within the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->