### PR TITLE
EPMRPP-116093 || 'Create project' modal window with entered data can be closed by clicking outside

### DIFF
--- a/app/src/pages/organization/organizationProjectsPage/modals/addProjectModal/addProjectModal.jsx
+++ b/app/src/pages/organization/organizationProjectsPage/modals/addProjectModal/addProjectModal.jsx
@@ -32,7 +32,7 @@ import { messages } from '../../messages';
 
 const PROJECT_NAME_FIELD = 'projectName';
 
-export const AddProjectModal = ({ data = {}, handleSubmit, anyTouched, invalid }) => {
+export const AddProjectModal = ({ data = {}, handleSubmit, anyTouched, invalid, dirty }) => {
   const dispatch = useDispatch();
   const { trackEvent } = useTracking();
   const { formatMessage } = useIntl();
@@ -57,6 +57,7 @@ export const AddProjectModal = ({ data = {}, handleSubmit, anyTouched, invalid }
         children: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
       }}
       onClose={hideModal}
+      allowCloseOutside={!dirty}
     >
       <FieldProvider name={PROJECT_NAME_FIELD}>
         <FieldErrorHint provideHint={false}>
@@ -77,6 +78,7 @@ AddProjectModal.propTypes = {
   handleSubmit: PropTypes.func,
   anyTouched: PropTypes.bool.isRequired,
   invalid: PropTypes.bool.isRequired,
+  dirty: PropTypes.bool.isRequired,
 };
 
 export default withModal('addProjectModal')(


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Links
[EPMRPP-116093](https://jiraeu.epam.com/browse/EPMRPP-116093)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Add Project modal to prevent accidental closure when the form contains unsaved changes, protecting user input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->