### PR TITLE
EPMRPP-116203 || Incorrect place event is sent to GA on-click "+ Create Organization" button

### DIFF
--- a/app/src/components/main/analytics/events/ga4Events/organizationsPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/organizationsPageEvents.ts
@@ -24,7 +24,7 @@ import { InviteProjectCondition } from 'pages/inside/common/invitations/inviteUs
 const ORGANIZATION_PAGE = 'organization';
 const SETTINGS_PAGE = 'organization_settings';
 const INTEGRATIONS = 'integrations';
-const PROMO = 'organizations_promo';
+const PROMO = 'all_organizations_without_plugin';
 const PREMIUM_FEATURES_POPUP = 'premium_features_popup';
 
 const BASIC_EVENT_PARAMETERS = getBasicClickEventParameters(ORGANIZATION_PAGE);
@@ -188,7 +188,7 @@ export const ORGANIZATION_PAGE_EVENTS = {
   },
   clickCreateOrganization: (element = '') => ({
     ...BASIC_EVENT_PARAMETERS,
-    place: 'all_organizations',
+    place: 'all_organizations_with_plugin',
     element_name: element ? `create_organization_${element}` : 'create_organization',
   }),
   CLICK_CREATE_BUTTON: {


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
changed parameter values of create organization button click GA event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics event tracking parameters for organization-related pages to improve data accuracy and reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->