### PR TITLE
EPMRPP-115872 || Wrong tooltip on locked dashboard

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -1536,7 +1536,7 @@
   "LocalizationBlock.russian": "Рускі",
   "LocalizationBlock.spanish": "Iспанська",
   "LocalizationBlock.ukrainian": "Ukrainian",
-  "LockedDashboardTooltip.lockedDashboard": "Гэты дашборд заблакіраваны менеджэрам праекта або адміністратарам і не можа быць зменены",
+  "LockedDashboardTooltip.lockedDashboard": "Гэты дашборд заблакіраваны карыстальнікам з правамі рэдактара або адміністратарам і не можа быць зменены",
   "LockedDashboardTooltip.lockedWidget": "Гэты віджэт з'яўляецца часткай заблакаванага дашборда. Можна змяняць толькі налады фільтраў.",
   "LogItemActivity.changedByAnalyzer": "АА змяніў тып дэфекту",
   "LogItemActivity.issueLoadByAnalyzer": "AA прывязаў памылку",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -1538,7 +1538,7 @@
   "LocalizationBlock.russian": "Ruso",
   "LocalizationBlock.spanish": "Español",
   "LocalizationBlock.ukrainian": "Ucraniano",
-  "LockedDashboardTooltip.lockedDashboard": "This dashboard is locked by a project manager or administrator and cannot be modified",
+  "LockedDashboardTooltip.lockedDashboard": "Este panel está bloqueado por un usuario con permisos de editor o un administrador y no se puede modificar",
   "LockedDashboardTooltip.lockedWidget": "Este widget forma parte de un panel bloqueado. Solo se pueden modificar los ajustes de los filtros.",
   "LogItemActivity.changedByAnalyzer": "AA cambió el tipo de error",
   "LogItemActivity.issueLoadByAnalyzer": "AA cargó el error",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -1537,7 +1537,7 @@
   "LocalizationBlock.russian": "Русский",
   "LocalizationBlock.spanish": "Испанский",
   "LocalizationBlock.ukrainian": "Ukrainian",
-  "LockedDashboardTooltip.lockedDashboard": "Этот дашборд заблокирован менеджером проекта или администратором и не может быть изменён",
+  "LockedDashboardTooltip.lockedDashboard": "Этот дашборд заблокирован пользователем с правами редактора или администратором и не может быть изменён",
   "LockedDashboardTooltip.lockedWidget": "Этот виджет является частью заблокированного дашборда. Можно изменять только настройки фильтров.",
   "LogItemActivity.changedByAnalyzer": "АА изменил тип дефекта",
   "LogItemActivity.issueLoadByAnalyzer": "AA привязал ошибку",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -1537,7 +1537,7 @@
   "LocalizationBlock.russian": "Російська",
   "LocalizationBlock.spanish": "Iспанська",
   "LocalizationBlock.ukrainian": "Українська",
-  "LockedDashboardTooltip.lockedDashboard": "Цей дашборд заблоковано менеджером проєкту або адміністратором і його не можна змінювати",
+  "LockedDashboardTooltip.lockedDashboard": "Цей дашборд заблоковано користувачем із правами редактора або адміністратором і його не можна змінювати",
   "LockedDashboardTooltip.lockedWidget": "Цей віджет є частиною заблокованого дашборду. Можна змінювати лише налаштування фільтрів.",
   "LogItemActivity.changedByAnalyzer": "АА змінив тип дефекту",
   "LogItemActivity.issueLoadByAnalyzer": "АА прив’язав помилку",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -1537,7 +1537,7 @@
   "LocalizationBlock.russian": "俄语",
   "LocalizationBlock.spanish": "西班牙语",
   "LocalizationBlock.ukrainian": "乌克兰语",
-  "LockedDashboardTooltip.lockedDashboard": "This dashboard is locked by a project manager or administrator and cannot be modified",
+  "LockedDashboardTooltip.lockedDashboard": "此仪表板已被具有编辑权限的用户或管理员锁定，无法修改",
   "LockedDashboardTooltip.lockedWidget": "该小组件属于已锁定的仪表板。只能修改筛选器设置。",
   "LogItemActivity.changedByAnalyzer": "自动分析服务已更改缺陷类型",
   "LogItemActivity.issueLoadByAnalyzer": "自动分析服务已关联问题",

--- a/app/src/pages/inside/common/lockedDashboardTooltip/messages.js
+++ b/app/src/pages/inside/common/lockedDashboardTooltip/messages.js
@@ -20,7 +20,7 @@ export const messages = defineMessages({
   lockedDashboard: {
     id: 'LockedDashboardTooltip.lockedDashboard',
     defaultMessage:
-      'This dashboard is locked by a project manager or administrator and cannot be modified',
+      'This dashboard is locked by a user with editor permissions or an administrator and cannot be modified',
   },
   lockedWidget: {
     id: 'LockedDashboardTooltip.lockedWidget',


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Links
[EPMRPP-115872](https://jiraeu.epam.com/browse/EPMRPP-115872)

## Visuals
<img width="911" height="496" alt="image" src="https://github.com/user-attachments/assets/24f2648b-44b4-4a82-963f-09e89b116638" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected locked dashboard tooltip messaging to accurately reflect who has permissions to lock dashboards: users with editor rights and administrators. Updated across all supported language translations, replacing the previous inaccurate reference to project managers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->