### PR TITLE
EPMRPP-116403 || Fix redirect to Not found on Organization integration page reload

### DIFF
--- a/app/src/components/integrations/integrationProviders/emailIntegration/emailSettings/emailSettings.tsx
+++ b/app/src/components/integrations/integrationProviders/emailIntegration/emailSettings/emailSettings.tsx
@@ -23,7 +23,8 @@ import { BubblesLoader, Button, DeleteIcon } from '@reportportal/ui-kit';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { omit } from 'common/utils/omit';
 import {
-  urlOrganizationAndProjectSelector,
+  urlOrganizationSlugSelector,
+  urlProjectSlugSelector,
   querySelector,
   PROJECT_SETTINGS_TAB_PAGE,
   ORGANIZATION_SETTINGS_TAB_PAGE,
@@ -104,9 +105,8 @@ export function EmailSettings({
     namedOrganizationIntegrationsSelector,
   );
   const projectIntegrations: NamedIntegrations = useSelector(namedProjectIntegrationsSelector);
-  const { organizationSlug, projectSlug } = useSelector(
-    urlOrganizationAndProjectSelector,
-  ) as Record<string, string>;
+  const organizationSlug = useSelector(urlOrganizationSlugSelector);
+  const projectSlug = useSelector(urlProjectSlugSelector);
   const projectKey = useSelector(projectKeySelector);
   const organizationId = useSelector(activeOrganizationIdSelector);
   const { canUpdateSettings, canUpdateOrganizationSettings } = useUserPermissions();

--- a/app/src/controllers/organization/actionCreators.js
+++ b/app/src/controllers/organization/actionCreators.js
@@ -24,6 +24,7 @@ import {
   CREATE_ORGANIZATION,
   RENAME_ORGANIZATION,
   FETCH_ORGANIZATION_INTEGRATIONS,
+  SET_ORGANIZATION_INTEGRATIONS_LOADING,
 } from './constants';
 
 export const prepareActiveOrganizationProjectsAction = (payload) => ({
@@ -69,4 +70,9 @@ export const renameOrganizationAction = (organizationId, newOrganizationName, on
 export const fetchOrganizationIntegrationsAction = (organizationId) => ({
   type: FETCH_ORGANIZATION_INTEGRATIONS,
   payload: { organizationId },
+});
+
+export const setOrganizationIntegrationsLoadingAction = (loading) => ({
+  type: SET_ORGANIZATION_INTEGRATIONS_LOADING,
+  payload: loading,
 });

--- a/app/src/controllers/organization/constants.js
+++ b/app/src/controllers/organization/constants.js
@@ -33,6 +33,7 @@ export const CREATE_ORGANIZATION = 'createOrganization';
 export const RENAME_ORGANIZATION = 'renameOrganization';
 
 export const FETCH_ORGANIZATION_INTEGRATIONS = 'fetchOrganizationIntegrations';
+export const SET_ORGANIZATION_INTEGRATIONS_LOADING = 'setOrganizationIntegrationsLoading';
 
 export const ERROR_CODES = {
   ORGANIZATION_EXISTS: [4091, 4095, 40016],

--- a/app/src/controllers/organization/index.ts
+++ b/app/src/controllers/organization/index.ts
@@ -28,6 +28,7 @@ export {
   activeOrganizationIdSelector,
   activeOrganizationSettingsSelector,
   activeOrganizationLoadingSelector,
+  organizationIntegrationsLoadingSelector,
   activeOrganizationTypeSelector,
 } from './selectors';
 export { organizationSagas } from './sagas';

--- a/app/src/controllers/organization/reducer.js
+++ b/app/src/controllers/organization/reducer.js
@@ -24,6 +24,7 @@ import {
   FETCH_ORGANIZATION_BY_SLUG,
   FETCH_ORGANIZATION_SETTINGS,
   SET_ACTIVE_ORGANIZATION,
+  SET_ORGANIZATION_INTEGRATIONS_LOADING,
   UPDATE_ORGANIZATION_SETTINGS_SUCCESS,
 } from './constants';
 
@@ -45,6 +46,15 @@ const updateOrganizationSettingsReducer = (state = [], { type = '', payload = {}
   }
 };
 
+const organizationIntegrationsLoadingReducer = (state = false, { type = '', payload = false }) => {
+  switch (type) {
+    case SET_ORGANIZATION_INTEGRATIONS_LOADING:
+      return payload;
+    default:
+      return state;
+  }
+};
+
 export const organizationReducer = combineReducers({
   activeOrganization: queueReducers(
     fetchReducer(FETCH_ORGANIZATION_BY_SLUG, {
@@ -55,6 +65,7 @@ export const organizationReducer = combineReducers({
     setActiveOrganizationReducer,
   ),
   organizationLoading: loadingReducer(FETCH_ORGANIZATION_BY_SLUG),
+  organizationIntegrationsLoading: organizationIntegrationsLoadingReducer,
   projects: projectsReducer,
   users: usersReducer,
   settings: queueReducers(

--- a/app/src/controllers/organization/sagas.js
+++ b/app/src/controllers/organization/sagas.js
@@ -47,6 +47,7 @@ import { withActiveOrganization } from './withActiveOrganizationSaga';
 import {
   fetchOrganizationIntegrationsAction,
   updateOrganizationSettingsSuccessAction,
+  setOrganizationIntegrationsLoadingAction,
 } from './actionCreators';
 import { activeOrganizationIdSelector } from './selectors';
 
@@ -192,12 +193,15 @@ function* watchRenameOrganization() {
 
 function* fetchOrganizationIntegrations({ payload: { organizationId } }) {
   try {
+    yield put(setOrganizationIntegrationsLoadingAction(true));
     const response = yield call(fetch, URLS.organizationIntegrations(organizationId));
     const rawItems = Array.isArray(response?.items) ? response.items : [];
     const items = rawItems.map((item) => normalizeIntegrationItem(item));
     yield put(setOrganizationIntegrationsAction(items));
   } catch (error) {
     yield put(showDefaultErrorNotification(error));
+  } finally {
+    yield put(setOrganizationIntegrationsLoadingAction(false));
   }
 }
 

--- a/app/src/controllers/organization/selectors.js
+++ b/app/src/controllers/organization/selectors.js
@@ -24,6 +24,9 @@ export const activeOrganizationSelector = (state) =>
 export const activeOrganizationLoadingSelector = (state) =>
   organizationSelector(state).organizationLoading || false;
 
+export const organizationIntegrationsLoadingSelector = (state) =>
+  organizationSelector(state).organizationIntegrationsLoading || false;
+
 export const activeOrganizationNameSelector = (state) => activeOrganizationSelector(state)?.name;
 
 export const activeOrganizationIdSelector = (state) => activeOrganizationSelector(state)?.id;

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrations.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrations.jsx
@@ -29,6 +29,7 @@ import {
   querySelector,
   urlOrganizationAndProjectSelector,
 } from 'controllers/pages';
+import { organizationIntegrationsLoadingSelector } from 'controllers/organization';
 import { INTEGRATIONS } from 'common/constants/settingsTabs';
 import { redirect } from 'redux-first-router';
 import { IntegrationInfo } from './integrationsList/integrationInfo';
@@ -39,6 +40,7 @@ const cx = classNames.bind(styles);
 
 export const Integrations = () => {
   const loading = useSelector(pluginsLoadingSelector);
+  const integrationsLoading = useSelector(organizationIntegrationsLoadingSelector);
   const availableGroupedPlugins = useSelector(availableGroupedPluginsSelector);
   const plugins = useSelector(availablePluginsSelector);
   const { organizationSlug, projectSlug } = useSelector(urlOrganizationAndProjectSelector);
@@ -58,7 +60,7 @@ export const Integrations = () => {
   );
 
   useEffect(() => {
-    if (loading || !query.subPage) {
+    if (loading || integrationsLoading || !query.subPage) {
       return undefined;
     }
 
@@ -70,12 +72,12 @@ export const Integrations = () => {
       } else {
         dispatch(redirect(initialPage));
       }
-    }
+    };
 
     definePlugin();
-  }, [query, plugins, loading, dispatch, initialPage]);
+  }, [query, plugins, loading, integrationsLoading, dispatch, initialPage]);
 
-  if (loading) {
+  if (loading || integrationsLoading) {
     return <BubblesLoader className={cx('preloader')} />;
   }
   const onItemClick = (pluginData) => {

--- a/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationsTab.jsx
+++ b/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationsTab.jsx
@@ -39,7 +39,10 @@ import {
   urlOrganizationSlugSelector,
 } from 'controllers/pages';
 import { INTEGRATIONS } from 'common/constants/settingsTabs';
-import { activeOrganizationLoadingSelector } from 'controllers/organization';
+import {
+  activeOrganizationLoadingSelector,
+  organizationIntegrationsLoadingSelector,
+} from 'controllers/organization';
 
 import { messages } from './messages';
 import { IntegrationInfo } from './integrationInfo';
@@ -56,6 +59,7 @@ export const IntegrationsTab = () => {
   const availableGroupedPlugins = useSelector(availableGroupedPluginsSelector);
   const loading = useSelector(pluginsLoadingSelector);
   const organizationLoading = useSelector(activeOrganizationLoadingSelector);
+  const integrationsLoading = useSelector(organizationIntegrationsLoadingSelector);
   const query = useSelector(querySelector);
   const [plugin, setPlugin] = useState({});
 
@@ -85,7 +89,7 @@ export const IntegrationsTab = () => {
   );
 
   useEffect(() => {
-    if (loading || organizationLoading || !query.subPage) {
+    if (loading || organizationLoading || integrationsLoading || !query.subPage) {
       return undefined;
     }
 
@@ -100,7 +104,7 @@ export const IntegrationsTab = () => {
     };
 
     definePlugin();
-  }, [query, plugins, initialPage, dispatch, loading, organizationLoading]);
+  }, [query, plugins, initialPage, dispatch, loading, organizationLoading, integrationsLoading]);
 
   const hasIntegrations = Object.keys(availableIntegrations).length > 0;
 
@@ -117,7 +121,7 @@ export const IntegrationsTab = () => {
     setPlugin(pluginData);
   };
 
-  if (loading || organizationLoading) {
+  if (loading || organizationLoading || integrationsLoading) {
     return (
       <div className={cx('loader')}>
         <BubblesLoader variant="large" />


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
Refreshing an email integration card on Org Settings redirected to not-found. Two separate root causes:

**1. Broken redirect target (where).**
`EmailSettings` built the redirect via `urlOrganizationAndProjectSelector`, which returns slugs only when both org and project slugs are in the URL. At org level there's no `projectSlug`, so it fell back to `activeProject` and `organizationSlug` became `undefined` → broken URL → not-found.
Fix: read slugs directly via `urlOrganizationSlugSelector` / `urlProjectSlugSelector`.

**2. Load race (when).**
Org integrations are fetched lazily (after `fetchOrganizationBySlug`) and the org route isn't held during navigation, so the card mounted before they loaded. `groupedIntegrations` was already non-empty (global loads eagerly) → false "not found" → redirect.
Fix: added an `organizationIntegrationsLoading` flag in the `organization` controller (saga sets `true` on start, `false` in `finally`). `IntegrationsTab` gates its loader on it next to `organizationLoading`, so `EmailSettings` mounts only after org integrations are in state. Removed the workaround guard; simplified the redirect effect.

## Links
[EPMRPP-116403](https://jiraeu.epam.com/browse/EPMRPP-116403)

## Visuals

https://github.com/user-attachments/assets/dcd72052-45f3-4ff1-984b-b105f21971ce




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced loading state tracking for organization integrations across settings pages, ensuring loading indicators display properly while fetching integrations data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->