### PR TITLE
EPMRPP-116095 || Prevent duplicate delete user requests from bulk delete User modal

### DIFF
--- a/app/src/pages/instance/allUsersPage/allUsersListTable/modals/deleteUserModal/deleteUserModal.tsx
+++ b/app/src/pages/instance/allUsersPage/allUsersListTable/modals/deleteUserModal/deleteUserModal.tsx
@@ -101,6 +101,7 @@ export const DeleteUserModal = ({ user, onSuccess }: DeleteUserModalProps) => {
       title={formatMessage(messages.title)}
       okButton={okButton}
       cancelButton={cancelButton}
+      allowCloseOutside={!isLoading}
       onClose={() => dispatch(hideModalAction())}
     >
       {formatMessage(messages.description, {

--- a/app/src/pages/instance/allUsersPage/allUsersListTable/modals/deleteUsersModal/deleteUsersModal.tsx
+++ b/app/src/pages/instance/allUsersPage/allUsersListTable/modals/deleteUsersModal/deleteUsersModal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useIntl, defineMessages } from 'react-intl';
 import { Modal } from '@reportportal/ui-kit';
@@ -42,22 +42,30 @@ const Bold = (chunks: ReactNode) => <b>{chunks}</b>;
 
 interface DeleteUsersModalProps {
   count: number;
-  onConfirm: () => void;
+  onConfirm: () => Promise<void>;
 }
 
 export const DeleteUsersModal = ({ count, onConfirm }: DeleteUsersModalProps) => {
   const dispatch = useDispatch();
   const { formatMessage } = useIntl();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = () => {
+    setIsLoading(true);
+    onConfirm().finally(() => setIsLoading(false));
+  };
 
   const okButton: ModalButtonProps = {
     text: formatMessage(COMMON_LOCALE_KEYS.DELETE),
     children: formatMessage(COMMON_LOCALE_KEYS.DELETE),
     variant: 'danger',
-    onClick: onConfirm,
+    onClick: handleConfirm,
+    disabled: isLoading,
   };
 
   const cancelButton: ModalButtonProps = {
     children: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
+    disabled: isLoading,
   };
 
   return (
@@ -66,6 +74,7 @@ export const DeleteUsersModal = ({ count, onConfirm }: DeleteUsersModalProps) =>
       title={formatMessage(messages.title)}
       okButton={okButton}
       cancelButton={cancelButton}
+      allowCloseOutside={!isLoading}
       onClose={() => dispatch(hideModalAction())}
     >
       {formatMessage(messages.description, {

--- a/app/src/pages/instance/allUsersPage/hooks/useDeleteUsersAction.tsx
+++ b/app/src/pages/instance/allUsersPage/hooks/useDeleteUsersAction.tsx
@@ -46,10 +46,10 @@ export const useDeleteUsersAction = ({ onSuccess }: UseDeleteUsersActionProps): 
   const { trackEvent } = useTracking();
 
   const deleteUsers = useCallback(
-    (items: BulkPanelItem[]) => {
+    (items: BulkPanelItem[]): Promise<void> => {
       const ids = items.map((item) => item.id).join(',');
 
-      fetch(URLS.deleteUsers(ids), { method: 'delete' })
+      return fetch(URLS.deleteUsers(ids), { method: 'delete' })
         .then(() => {
           dispatch(hideModalAction());
           dispatch(
@@ -68,9 +68,9 @@ export const useDeleteUsersAction = ({ onSuccess }: UseDeleteUsersActionProps): 
 
   const handleProceed = useCallback(
     (eligibleItems: BulkPanelItem[]) => {
-      const onConfirm = () => {
+      const onConfirm = (): Promise<void> => {
         trackEvent(ALL_USERS_PAGE_EVENTS.bulkDeleteUsersModal(eligibleItems.length));
-        deleteUsers(eligibleItems);
+        return deleteUsers(eligibleItems);
       };
 
       trackEvent(ALL_USERS_PAGE_EVENTS.BULK_DELETE_USERS);


### PR DESCRIPTION

## Summary

Fixes [EPMRPP-116095](https://jiraeu.epam.com/browse/EPMRPP-116095): Delete buttons in the "Delete user" and "Delete users" (bulk) modals on the All Users page remained clickable while the delete request was being processed, allowing the same action to be triggered multiple times.

## Changes

### Single user delete (`DeleteUserModal`)
Replaced the Redux saga dispatch (`deleteUserAccountAction`) with a direct `fetch` call, adding an `isLoading` state to disable both the ok and cancel buttons for the duration of the request. On error, the modal stays open and buttons are re-enabled. On success, behavior is unchanged (success notification, modal close, `onSuccess` callback, GA4 event).

`deleteUserAccountAction` and its saga remain untouched — they are still used by `deleteAccountModal` on the Profile page.

### Bulk user delete (`DeleteUsersModal` + `useDeleteUsersAction`)
Made `deleteUsers` return the fetch Promise and `onConfirm` propagate it. `DeleteUsersModal` now holds `isLoading` state internally, setting it on confirm click and clearing it in `finally` (no-op on success since the modal closes via `hideModalAction`). Both ok and cancel buttons are disabled while the request is in flight.


## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Delete confirmation dialogs can no longer be accidentally dismissed while the deletion operation is in progress.
* Delete action buttons remain disabled during the deletion process to prevent duplicate submissions and ensure operations complete successfully.
* User interactions that could interfere with ongoing deletion operations are now properly controlled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reportportal/service-ui/pull/5433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->