### PR TITLE
EPMRPP-116705 || Hide header when QG plugin is installed and no rules created

### DIFF
--- a/app/src/pages/inside/projectSettingsPageContainer/projectSettingsPageContainer.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/projectSettingsPageContainer.jsx
@@ -214,7 +214,7 @@ export const ProjectSettingsPageContainer = () => {
       <SettingsLayout navigation={navigation}>
         <ScrollWrapper resetRequired>
           <div className={cx('settings-page-content-wrapper')}>
-            {!subPage && !config[activeTab]?.hideHeader && !headerNodes.hideHeader && (
+            {!subPage && !config[activeTab]?.hideHeader && !headerNodes?.hideHeader && (
               <div className={cx('header')}>
                 <Header title={config[activeTab]?.name} titleNode={headerNodes.titleNode}>
                   {headerNodes.children}

--- a/app/src/pages/inside/projectSettingsPageContainer/projectSettingsPageContainer.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/projectSettingsPageContainer.jsx
@@ -214,7 +214,7 @@ export const ProjectSettingsPageContainer = () => {
       <SettingsLayout navigation={navigation}>
         <ScrollWrapper resetRequired>
           <div className={cx('settings-page-content-wrapper')}>
-            {!subPage && !config[activeTab]?.hideHeader && (
+            {!subPage && !config[activeTab]?.hideHeader && !headerNodes.hideHeader && (
               <div className={cx('header')}>
                 <Header title={config[activeTab]?.name} titleNode={headerNodes.titleNode}>
                   {headerNodes.children}


### PR DESCRIPTION
## Summary

Add fix to allow hiding header.

## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header visibility in Project Settings: the page header will now also be hidden when a child/tab sets headerNodes.hideHeader. This extends existing suppression rules (sub-pages and per-tab hideHeader), giving embedded tabs and child content reliable control over whether the header is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->