### PR TITLE
EPMRPP-116698 || Clear Email Server password in Edit integration modal

### DIFF
--- a/app/src/components/integrations/integrationProviders/emailIntegration/emailFormFields/emailFormFields.jsx
+++ b/app/src/components/integrations/integrationProviders/emailIntegration/emailFormFields/emailFormFields.jsx
@@ -28,6 +28,7 @@ import {
 } from 'common/utils/validation';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { Dropdown, FieldText, Radio } from '@reportportal/ui-kit';
+import { SECRET_FIELDS_KEY } from 'controllers/plugins';
 import { INTEGRATION_FORM } from 'components/integrations/elements';
 import { FieldElement } from 'pages/inside/projectSettingsPageContainer/content/elements';
 import { separateFromIntoNameAndEmail } from 'common/utils';
@@ -199,6 +200,8 @@ export class EmailFormFields extends Component {
     tlsEnabled: PropTypes.bool,
     sslEnabled: PropTypes.bool,
     initialData: PropTypes.object,
+    editAuthMode: PropTypes.bool,
+    updateMetaData: PropTypes.func,
   };
 
   static defaultProps = {
@@ -207,6 +210,8 @@ export class EmailFormFields extends Component {
     tlsEnabled: false,
     sslEnabled: false,
     initialData: DEFAULT_FORM_CONFIG,
+    editAuthMode: false,
+    updateMetaData: () => {},
   };
 
   constructor(props) {
@@ -215,12 +220,18 @@ export class EmailFormFields extends Component {
   }
 
   componentDidMount() {
-    const { initialData } = this.props;
+    const { initialData, editAuthMode, updateMetaData } = this.props;
     const preparedData = separateFromIntoNameAndEmail(initialData);
+    if (editAuthMode) {
+      preparedData[PASSWORD_KEY] = '';
+    }
     this.props.initialize(preparedData);
     if (preparedData[TLS_KEY] && preparedData[SSL_KEY]) {
       this.props.change(SSL_KEY, false);
     }
+    updateMetaData({
+      [SECRET_FIELDS_KEY]: [PASSWORD_KEY],
+    });
   }
 
   onChangeAuthAvailability = (...args) => {


### PR DESCRIPTION
## Summary

- Fix a client-side issue where the Email Server integration **Password** field was prefilled in the **Edit integration** modal immediately after create/update, even though the API does not return the password.
- Align Email Server form behavior with existing integration patterns (Jira, GitHub, LDAP): register `password` as a secret field via `SECRET_FIELDS_KEY`, so Redux state does not persist it after save, and clear the field when opening the edit modal (`editAuthMode`).
- Applies to **Project**, **Organization**, and **Global** Email Server integrations through the shared `EmailFormFields` component.

## Problem

**Steps to reproduce:**
1. Create an Email Server integration with **Authorization = ON** and a password.
2. Stay on the integration details page (no reload).
3. Open **Edit integration**.

**Actual:** Password field contains the previously entered value.  
**Expected:** Password field is empty.

**Root cause:** Email integration did not register `password` in integration form metadata (`SECRET_FIELDS_KEY`), unlike other integrations. After create/update, the password remained in client state and was passed to the edit form via `initialData`.

## Solution

In `EmailFormFields`:
- on mount, call `updateMetaData({ [SECRET_FIELDS_KEY]: [PASSWORD_KEY] })` so create/update sagas omit the password from Redux state;
- when `editAuthMode` is `true`, clear `password` before form initialization.

`editAuthMode` is already set by `emailSettings.tsx` in the edit flow.  
`updateMetaData` is provided by `AddIntegrationModal`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the email authentication credential editor with improved password field handling. Password fields are now properly marked as sensitive information when editing credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->