### PR TITLE
EPMRPP-116819 || Trigger validation display on Create click when only partial fields are filled

### DIFF
--- a/app/src/components/fields/fieldProvider.jsx
+++ b/app/src/components/fields/fieldProvider.jsx
@@ -38,7 +38,7 @@ const InnerComponent = ({
     name,
     error: error || submitError,
     active,
-    touched: touched || (!!submitError && submitFailed),
+    touched: touched || submitFailed,
     asyncValidating,
     ...rest,
   });

--- a/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.jsx
+++ b/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.jsx
@@ -65,8 +65,6 @@ const AddIntegrationModal = ({
   change,
   handleSubmit,
   dirty,
-  anyTouched,
-  invalid,
 }) => {
   const [metaData, setMetaData] = useState({});
   const fieldsExtensions = useSelector(uiExtensionIntegrationFormFieldsSelector);
@@ -171,8 +169,6 @@ AddIntegrationModal.propTypes = {
   change: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   dirty: PropTypes.bool.isRequired,
-  anyTouched: PropTypes.bool.isRequired,
-  invalid: PropTypes.bool.isRequired,
 };
 
 export default withModal('addIntegrationModal')(

--- a/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.jsx
+++ b/app/src/components/integrations/modals/addIntegrationModal/addIntegrationModal.jsx
@@ -106,7 +106,7 @@ const AddIntegrationModal = ({
         : formatMessage(COMMON_LOCALE_KEYS.CREATE)),
     onClick: () => handleSubmit(onSubmit)(),
     'data-automation-id': 'submitButton',
-    disabled: !hasFormFields || (anyTouched && invalid),
+    disabled: !hasFormFields,
   };
   const cancelButton = {
     children: formatMessage(COMMON_LOCALE_KEYS.CANCEL),


### PR DESCRIPTION
## Problem

When creating an integration (global or project), if the user fills only one of the required fields and clicks **Create**, the button becomes disabled but no validation error is shown for the empty field. The error only appears after the user manually focuses and blurs the empty field.

This affects all integration plugins that use `FieldElement` + `FieldErrorHint` + `FieldText` pattern (jira-cloud, sauceLabs, mobitru, etc.).

**Root cause — two issues combined:**

1. `addIntegrationModal` disables the Create button when `anyTouched && invalid`, so `handleSubmit` never fires, and redux-form never sets `submitFailed=true` on fields.

2. `FieldProvider` only passed `touched=true` to children when `submitError` (async) was present, ignoring sync `submitFailed`. Even if `handleSubmit` had fired, `FieldText` would still not display the error.

## Solution

**`FieldProvider`** — propagate `touched=true` on any `submitFailed`, not only for async errors:

```js
// before
touched: touched || (!!submitError && submitFailed),
// after
touched: touched || submitFailed,
```

**`addIntegrationModal`** — remove the premature disable so `handleSubmit` can fire and set `submitFailed` on all fields:

```js
// before
disabled: !hasFormFields || (anyTouched && invalid),
// after
disabled: !hasFormFields,
```

After both changes: clicking Create with empty required fields fires `handleSubmit`, redux-form sets `submitFailed=true` on every field, `FieldProvider` propagates `touched=true`, and `FieldText` displays the validation error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fields are now marked as touched when a submission fails, improving validation visibility during submit.
  * Add Integration modal's submit button is enabled under more conditions when form fields are present, streamlining the integration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->