### PR TITLE
EPMRPP-116461 || Eliminate empty space below table when switching page size

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,7 +13,7 @@
         "@formatjs/intl-pluralrules": "1.3.9",
         "@formatjs/intl-relativetimeformat": "4.5.1",
         "@formatjs/intl-utils": "1.6.0",
-        "@reportportal/ui-kit": "^0.0.1-alpha.236",
+        "@reportportal/ui-kit": "^0.0.1-alpha.237",
         "@tanstack/react-virtual": "^3.13.23",
         "axios": "^1.16.0",
         "c3": "0.7.20",
@@ -5092,9 +5092,9 @@
       "license": "MIT"
     },
     "node_modules/@reportportal/ui-kit": {
-      "version": "0.0.1-alpha.236",
-      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.236.tgz",
-      "integrity": "sha512-2JpGGBRU09XrESM51ftIySH+WeK7Vk4hN1sGOYM5B7pIonhLOdDyU6cRE4vcp8YL16zWpVq4s0/I/0QODfZisA==",
+      "version": "0.0.1-alpha.237",
+      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.237.tgz",
+      "integrity": "sha512-toCyozvbQqUp90QyRa9fLnY7MQZLulwvyYP+V0L9l1LESK/xuR//QFqAnj4UFALy9ox4mybhsykL9yyA16UJTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "@formatjs/intl-pluralrules": "1.3.9",
     "@formatjs/intl-relativetimeformat": "4.5.1",
     "@formatjs/intl-utils": "1.6.0",
-    "@reportportal/ui-kit": "^0.0.1-alpha.236",
+    "@reportportal/ui-kit": "^0.0.1-alpha.237",
     "@tanstack/react-virtual": "^3.13.23",
     "axios": "^1.16.0",
     "c3": "0.7.20",

--- a/app/src/components/main/paginationWrapper/paginationWrapper.jsx
+++ b/app/src/components/main/paginationWrapper/paginationWrapper.jsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useState, useEffect, useRef } from 'react';
 import { useTracking } from 'react-tracking';
 import { Pagination, BulkPanel } from '@reportportal/ui-kit';
 import classNames from 'classnames/bind';
@@ -42,6 +43,16 @@ export const PaginationWrapper = ({
   const isBulkPanelVisible = bulkPanelProps?.items?.length > 0;
   const bulkPanelPortalRoot = document.getElementById('modal-root') || document.body;
 
+  const [resetScroll, setResetScroll] = useState(false);
+  const prevActivePageRef = useRef(paginationProps.activePage);
+
+  useEffect(() => {
+    if (prevActivePageRef.current !== paginationProps.activePage) {
+      prevActivePageRef.current = paginationProps.activePage;
+      setResetScroll(true);
+    }
+  }, [paginationProps.activePage]);
+
   const changePageSizeHandle = (newSize) => {
     changePageSize(newSize);
     trackEvent(changePageSizeEvent(newSize));
@@ -49,7 +60,14 @@ export const PaginationWrapper = ({
 
   return (
     <div className={cx('pagination-wrapper', className)}>
-      <ScrollWrapper withBackToTop className={cx('scroll')} classNameBackToTop={cx('back-to-top')}>
+      <ScrollWrapper
+        key={paginationProps.pageSize}
+        withBackToTop
+        className={cx('scroll')}
+        classNameBackToTop={cx('back-to-top')}
+        resetRequired={resetScroll}
+        onReset={() => setResetScroll(false)}
+      >
         {children}
       </ScrollWrapper>
       {showPagination && (

--- a/app/src/pages/common/users/membersListTable/membersListTable.jsx
+++ b/app/src/pages/common/users/membersListTable/membersListTable.jsx
@@ -65,6 +65,8 @@ export const MembersListTable = ({
       <div className={cx('members-list-table-wrapper')}>
         <Table
           className={cx('members-list-table')}
+          wrapperClassName={cx('table-wrapper-fix')}
+          checkboxColumnClassName={cx('checkbox-column-fix')}
           headerClassName={cx('table-header')}
           rowClassName={cx('table-row')}
           data={data}

--- a/app/src/pages/common/users/membersListTable/membersListTable.scss
+++ b/app/src/pages/common/users/membersListTable/membersListTable.scss
@@ -24,6 +24,15 @@
   box-sizing: border-box;
 }
 
+.table-wrapper-fix {
+  height: auto;
+  align-items: flex-start;
+}
+
+.checkbox-column-fix {
+  max-height: none;
+}
+
 .members-list-table {
   max-width: inherit;
 }


### PR DESCRIPTION
## Problem

When navigating to the All Users page, changing the items-per-page to 50, then switching back to 20 and scrolling down — an empty space was visible below the last row of the table.

Two issues combined to cause this:

1. **Scroll position was not reset** when page size changed. The `ScrollWrapper` retained its `scrollTop` from the 50-item view, so the user could scroll into empty space.

2. **CSS circular height dependency** in the `@reportportal/ui-kit` `Table` component. The `.table-wrapper` element had `height: 100%` and `.checkbox-column` had `max-height: 100%`. Inside a scroll container, these resolved relative to the scroll content height — causing the elements to stay sized at the old (50-item) height even after data updated to 20 items.

## Solution

**Scroll reset** (`PaginationWrapper`):
- Added `key={paginationProps.pageSize}` on `ScrollWrapper` — forces a full remount when page size changes, giving a fresh scroll container with `scrollTop = 0`
- Added `resetRequired`/`onReset` with a `useEffect` tracking `activePage` — resets scroll position on page navigation

**CSS fix** (`MembersListTable`):
- Used `wrapperClassName` and `checkboxColumnClassName` props (available in `@reportportal/ui-kit`) to apply targeted overrides:
  - `height: auto` on `.table-wrapper` — breaks the circular `height: 100%` reference
  - `align-items: flex-start` on `.table-wrapper` — prevents flex-stretch from propagating the stale height
  - `max-height: none` on `.checkbox-column` — removes the circular `max-height: 100%` reference

Note: the root CSS issue is in `@reportportal/ui-kit`. A separate ticket should be raised to fix `table.module.scss` properly without breaking `isHeaderFixed` table layouts.

## Changes

- `src/components/main/paginationWrapper/paginationWrapper.jsx` — scroll reset on page size and page number change
- `src/pages/common/users/membersListTable/membersListTable.jsx` — added `wrapperClassName` and `checkboxColumnClassName` props
- `src/pages/common/users/membersListTable/membersListTable.scss` — added `.table-wrapper-fix` and `.checkbox-column-fix` classes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll position to reset properly when navigating between pages in paginated lists.
  * Improved Members List Table layout and styling for better visual consistency across different page sizes.
* **Chores**
  * Updated UI Kit dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->