### PR TITLE
EPMRPP-116207 || Clamp title to two lines for localized layouts

### DIFF
--- a/app/src/components/premiumPromoModal/premiumPromoModal.scss
+++ b/app/src/components/premiumPromoModal/premiumPromoModal.scss
@@ -50,15 +50,22 @@
 }
 
 .title {
+  display: -webkit-box;
   margin-bottom: 15px;
+  overflow: hidden;
+  max-width: 450px;
+  max-height: calc(47px * 2);
   font-family: var(--rp-ui-base-font-family);
   font-weight: var(--rp-ui-base-fw-bold);
   font-size: 39px;
   line-height: 47px;
   color: var(--rp-ui-base-bg-000);
-  max-width: 350px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
 
   @media (max-width: $SCREEN_XS_MAX) {
+    max-height: calc(34px * 2);
     font-size: 28px;
     line-height: 34px;
   }


### PR DESCRIPTION
## Summary

Fixes [EPMRPP-116207](https://jiraeu.epam.com/browse/EPMRPP-116207): in the Premium promo modal, localized titles (Russian, Belarusian, Ukrainian) wrapped to three lines while the English title used two. The extra line pushed the feature list down, and the last bullet ("…and many more") was hidden behind the background illustration.

The modal uses a fixed aspect ratio, so vertical space for the content block is limited. Stabilizing the title height keeps subtitle and feature list aligned across locales.

## Changes

Limited the promo modal title to a maximum of two lines using `-webkit-line-clamp` / `line-clamp` and a fixed `max-height` derived from `line-height` (including the mobile breakpoint). Increased title `max-width` from 350px to 450px so longer localized strings are more likely to fit within two lines without truncation.

## Visuals

<img width="678" height="632" alt="image" src="https://github.com/user-attachments/assets/b0c6398d-4d48-407d-adae-4562d1bc9ecf" />

<img width="667" height="636" alt="image" src="https://github.com/user-attachments/assets/cd059307-6d1f-4137-9f27-1e2727fe9c22" />

<img width="672" height="633" alt="image" src="https://github.com/user-attachments/assets/7e6e910a-7a25-49b2-812a-5e8e2ce10f94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the premium promotion modal with improved title display and text truncation handling. Title now optimizes spacing across screen sizes with better responsive behavior for mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->