### PR TITLE
EPMRPP-115023 || Render dashboard name as plain text in delete confirmation modal

### DIFF
--- a/app/src/pages/inside/common/modals/deleteDashboardConfirmationMessage/deleteDashboardConfirmationMessage.jsx
+++ b/app/src/pages/inside/common/modals/deleteDashboardConfirmationMessage/deleteDashboardConfirmationMessage.jsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage, defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  deleteModalConfirmationText: {
+    id: 'DashboardPage.modal.deleteModalConfirmationText',
+    defaultMessage:
+      "Are you sure you want to delete dashboard ''<b>{name}</b>''? It will no longer exist.",
+  },
+});
+
+export const DeleteDashboardConfirmationMessage = ({ name }) => (
+  <FormattedMessage
+    {...messages.deleteModalConfirmationText}
+    values={{
+      name,
+      b: (chunks) => <b>{chunks}</b>,
+    }}
+  />
+);
+
+DeleteDashboardConfirmationMessage.propTypes = {
+  name: PropTypes.string.isRequired,
+};

--- a/app/src/pages/inside/common/modals/deleteDashboardConfirmationMessage/index.js
+++ b/app/src/pages/inside/common/modals/deleteDashboardConfirmationMessage/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DeleteDashboardConfirmationMessage } from './deleteDashboardConfirmationMessage';

--- a/app/src/pages/inside/common/modals/deleteItemsModal/deleteItemsModal.jsx
+++ b/app/src/pages/inside/common/modals/deleteItemsModal/deleteItemsModal.jsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Parser from 'html-react-parser';
 import classNames from 'classnames/bind';
-import { injectIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import DOMPurify from 'dompurify';
 import { withModal, ModalLayout } from 'components/main/modal';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
@@ -26,58 +26,56 @@ import styles from './deleteItemsModal.scss';
 
 const cx = classNames.bind(styles);
 
-@withModal('deleteItemsModal')
-@injectIntl
-export class DeleteItemsModal extends Component {
-  static propTypes = {
-    intl: PropTypes.object.isRequired,
-    data: PropTypes.shape({
-      onConfirm: PropTypes.func,
-      items: PropTypes.array,
-      header: PropTypes.string,
-      mainContent: PropTypes.string,
-      eventsInfo: PropTypes.object,
-      warning: PropTypes.string,
-    }),
-  };
+const renderMainContent = (mainContent) => {
+  if (typeof mainContent === 'string') {
+    return Parser(DOMPurify.sanitize(mainContent));
+  }
 
-  static defaultProps = {
-    data: {
-      items: [],
-      onConfirm: () => {},
-      eventsInfo: {},
-    },
-  };
-  confirmAndClose = (closeModal) => {
-    this.props.data.onConfirm(this.props.data.items);
+  return mainContent;
+};
+
+const DeleteItemsModalComponent = ({ data = { items: [], onConfirm: () => {}, eventsInfo: {} } }) => {
+  const { formatMessage } = useIntl();
+  const { header, mainContent, eventsInfo, warning } = data;
+
+  const confirmAndClose = (closeModal) => {
+    data.onConfirm(data.items);
     closeModal();
   };
 
-  render() {
-    const {
-      intl: { formatMessage },
-      data: { header, mainContent, eventsInfo, warning },
-    } = this.props;
-    const okButton = {
-      text: formatMessage(COMMON_LOCALE_KEYS.DELETE),
-      danger: true,
-      onClick: this.confirmAndClose,
-      eventInfo: eventsInfo.deleteBtn,
-    };
-    const cancelButton = {
-      text: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
-      eventInfo: eventsInfo.cancelBtn,
-    };
-    return (
-      <ModalLayout
-        title={header}
-        okButton={okButton}
-        cancelButton={cancelButton}
-        closeIconEventInfo={eventsInfo.closeIcon}
-        warningMessage={warning}
-      >
-        <p className={cx('message')}>{Parser(DOMPurify.sanitize(mainContent))}</p>
-      </ModalLayout>
-    );
-  }
-}
+  const okButton = {
+    text: formatMessage(COMMON_LOCALE_KEYS.DELETE),
+    danger: true,
+    onClick: confirmAndClose,
+    eventInfo: eventsInfo.deleteBtn,
+  };
+  const cancelButton = {
+    text: formatMessage(COMMON_LOCALE_KEYS.CANCEL),
+    eventInfo: eventsInfo.cancelBtn,
+  };
+
+  return (
+    <ModalLayout
+      title={header}
+      okButton={okButton}
+      cancelButton={cancelButton}
+      closeIconEventInfo={eventsInfo.closeIcon}
+      warningMessage={warning}
+    >
+      <p className={cx('message')}>{renderMainContent(mainContent)}</p>
+    </ModalLayout>
+  );
+};
+
+DeleteItemsModalComponent.propTypes = {
+  data: PropTypes.shape({
+    onConfirm: PropTypes.func,
+    items: PropTypes.array,
+    header: PropTypes.string,
+    mainContent: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    eventsInfo: PropTypes.object,
+    warning: PropTypes.string,
+  }),
+};
+
+export const DeleteItemsModal = withModal('deleteItemsModal')(DeleteItemsModalComponent);

--- a/app/src/pages/inside/dashboardItemPage/dashboardItemPage.jsx
+++ b/app/src/pages/inside/dashboardItemPage/dashboardItemPage.jsx
@@ -17,7 +17,6 @@
 import React, { useCallback } from 'react';
 import { useTracking } from 'react-tracking';
 import { useDispatch, useSelector } from 'react-redux';
-import DOMPurify from 'dompurify';
 import { Fullscreen } from 'components/containers/fullscreen';
 import Parser from 'html-react-parser';
 import classNames from 'classnames/bind';
@@ -49,6 +48,7 @@ import Link from 'redux-first-router-link';
 import { PageLayout, PageHeader, PageSection } from 'layouts/pageLayout';
 import { DASHBOARD_PAGE_EVENTS } from 'components/main/analytics/events';
 import { DashboardPageHeader } from 'pages/inside/common/dashboardPageHeader';
+import { DeleteDashboardConfirmationMessage } from 'pages/inside/common/modals/deleteDashboardConfirmationMessage';
 import AddWidgetIcon from 'common/img/add-widget-inline.svg';
 import ExportIcon from 'common/img/export-inline.svg';
 import { DASHBOARD_EVENTS } from 'analyticsEvents/dashboardsPageEvents';
@@ -99,11 +99,6 @@ const messages = defineMessages({
   deleteModalTitle: {
     id: 'DashboardPage.modal.deleteModalTitle',
     defaultMessage: 'Delete Dashboard',
-  },
-  deleteModalConfirmationText: {
-    id: 'DashboardPage.modal.deleteModalConfirmationText',
-    defaultMessage:
-      "Are you sure you want to delete dashboard ''<b>{name}</b>''? It will no longer exist.",
   },
   print: {
     id: 'DashboardPage.print',
@@ -164,10 +159,7 @@ export const DashboardItemPage = () => {
           items: [dashboard],
           onConfirm: () => dispatch(deleteDashboardAction(dashboard)),
           header: formatMessage(messages.deleteModalTitle),
-          mainContent: formatMessage(messages.deleteModalConfirmationText, {
-            b: (data) => DOMPurify.sanitize(`<b>${data}</b>`),
-            name: `'<b>${dashboard.name}</b>'`,
-          }),
+          mainContent: <DeleteDashboardConfirmationMessage name={dashboard.name} />,
           warning,
           eventsInfo: {
             closeIcon: DASHBOARD_PAGE_EVENTS.CLOSE_ICON_DELETE_DASHBOARD_MODAL,

--- a/app/src/pages/inside/dashboardPage/dashboardPage.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardPage.jsx
@@ -19,7 +19,6 @@ import track from 'react-tracking';
 import { connect } from 'react-redux';
 import { injectIntl, defineMessages } from 'react-intl';
 import PropTypes from 'prop-types';
-import DOMPurify from 'dompurify';
 import { PageLayout, PageHeader, PageSection } from 'layouts/pageLayout';
 import {
   changeVisibilityTypeAction,
@@ -42,6 +41,7 @@ import { userInfoSelector } from 'controllers/user';
 import { showModalAction } from 'controllers/modal';
 import { withFilter } from 'controllers/filter';
 import { DashboardPageHeader } from 'pages/inside/common/dashboardPageHeader';
+import { DeleteDashboardConfirmationMessage } from 'pages/inside/common/modals/deleteDashboardConfirmationMessage';
 import { DashboardList } from './dashboardList';
 import { DashboardPageToolbar } from './dashboardPageToolbar';
 
@@ -66,11 +66,6 @@ const messages = defineMessages({
   deleteModalTitle: {
     id: 'DashboardPage.modal.deleteModalTitle',
     defaultMessage: 'Delete Dashboard',
-  },
-  deleteModalConfirmationText: {
-    id: 'DashboardPage.modal.deleteModalConfirmationText',
-    defaultMessage:
-      "Are you sure you want to delete dashboard ''<b>{name}</b>''? It will no longer exist.",
   },
   deleteModalSubmitButtonText: {
     id: 'DashboardPage.modal.deleteModalSubmitButtonText',
@@ -166,10 +161,7 @@ export class DashboardPage extends Component {
         items: [item],
         onConfirm: () => deleteDashboard(item),
         header: formatMessage(messages.deleteModalTitle),
-        mainContent: formatMessage(messages.deleteModalConfirmationText, {
-          b: (data) => DOMPurify.sanitize(`<b>${data}</b>`),
-          name: item.name,
-        }),
+        mainContent: <DeleteDashboardConfirmationMessage name={item.name} />,
         warning,
         eventsInfo: {
           closeIcon: DASHBOARD_PAGE_EVENTS.CLOSE_ICON_DELETE_DASHBOARD_MODAL,


### PR DESCRIPTION
## Summary

Fixes [EPMRPP-115023](https://jiraeu.epam.com/browse/EPMRPP-115023): dashboard names containing HTML markup were rendered as formatted HTML inside the delete confirmation pop-up, while the same name was displayed as plain text on the dashboard page. This allowed HTML injection (for example, interactive `<form>` elements) in the confirmation dialog.

The delete confirmation message now uses `FormattedMessage` with a React rich-text formatter (`b: (chunks) => <b>{chunks}</b>`), so the dashboard name is escaped by React and always treated as plain text. Bold styling for the name is preserved.

## Changes

- Added `DeleteDashboardConfirmationMessage` and wired it into dashboard delete flows on the dashboards list page and the dashboard item page.
- Extended `DeleteItemsModal` to accept `mainContent` as a React node; legacy string callers still go through the existing DOMPurify + `html-react-parser` path.
- Converted `DeleteItemsModal` from a class component to a functional component.
- Removed manual HTML composition for the dashboard name (including the incorrect pre-wrapped `'<b>${dashboard.name}</b>'` value on the dashboard item page).

## Visuals

### Before

<img width="1591" height="476" alt="image" src="https://github.com/user-attachments/assets/297e396d-6b17-449a-9ce6-8bf247a57d5d" />


### After
<img width="1605" height="515" alt="image" src="https://github.com/user-attachments/assets/8a582880-f08c-46e1-8dd3-d9fa47cc6896" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated confirmation message component for dashboard deletion operations.

* **Refactor**
  * Refactored delete items modal for improved content rendering and flexibility.
  * Enhanced confirmation dialog flows for better modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->