### PR TITLE
EPMRPP-115894 || EPMRPP-115895 || add HSTS header to resolve CVE 

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,7 @@ http {
        #fallback
        location / {
             add_header Cache-Control "no-cache";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             add_header X-Frame-Options "DENY";
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
@@ -43,6 +44,7 @@ http {
 
         location /ui/ {
             add_header Cache-Control "no-cache";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             add_header X-Frame-Options "DENY";
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
@@ -53,12 +55,14 @@ http {
         # build info
         location /info {
             add_header Cache-Control "public, must-revalidate";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";
             try_files $uri /buildInfo.json 404;
         }
 
         location /ui/info {
             add_header Cache-Control "public, must-revalidate";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";
             try_files $uri /buildInfo.json 404;
         }
@@ -77,6 +81,7 @@ http {
         # media, fonts
         location ~* ([^/\\&\?]+\.+(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2))$ {
             add_header Cache-Control "public, must-revalidate";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";
@@ -86,6 +91,7 @@ http {
         # assets
         location ~* ([^/\\&\?]+\.+(js|css|ico))$ {
             add_header Cache-Control "public, must-revalidate";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,12 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
+    # HSTS: only set when the request was proxied over HTTPS
+    map $http_x_forwarded_proto $hsts_header {
+        https   "max-age=31536000; includeSubDomains";
+        default "";
+    }
+
     # gzip
     gzip on;
     gzip_vary on;
@@ -34,7 +40,7 @@ http {
        #fallback
        location / {
             add_header Cache-Control "no-cache";
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security $hsts_header always;
             add_header X-Frame-Options "DENY";
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
@@ -44,7 +50,7 @@ http {
 
         location /ui/ {
             add_header Cache-Control "no-cache";
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security $hsts_header always;
             add_header X-Frame-Options "DENY";
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
@@ -55,14 +61,14 @@ http {
         # build info
         location /info {
             add_header Cache-Control "public, must-revalidate";
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security $hsts_header always;
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";
             try_files $uri /buildInfo.json 404;
         }
 
         location /ui/info {
             add_header Cache-Control "public, must-revalidate";
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security $hsts_header always;
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";
             try_files $uri /buildInfo.json 404;
         }
@@ -81,7 +87,7 @@ http {
         # media, fonts
         location ~* ([^/\\&\?]+\.+(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2))$ {
             add_header Cache-Control "public, must-revalidate";
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security $hsts_header always;
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";
@@ -91,7 +97,7 @@ http {
         # assets
         location ~* ([^/\\&\?]+\.+(js|css|ico))$ {
             add_header Cache-Control "public, must-revalidate";
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security $hsts_header always;
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
             add_header Content-Security-Policy "object-src 'none'; default-src 'self' data: *.uservoice.com; script-src 'self' status.reportportal.io www.google-analytics.com www.googletagmanager.com stats.g.doubleclick.net *.saucelabs.com *.epam.com *.uservoice.com *.rawgit.com; worker-src 'self' blob:; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com *.rawgit.com; style-src-elem 'self' data: 'unsafe-inline' *.googleapis.com *.rawgit.com; style-src 'self' 'unsafe-inline' https://tagmanager.google.com; media-src 'self' *.saucelabs.com *.browserstack.com blob:; img-src * 'self' data: blob: http: https: www.google-analytics.com; connect-src 'self' *.google-analytics.com *.analytics.google.com https://stats.g.doubleclick.net; frame-src 'self' https://webto.salesforce.com https://app.mobitru.com https://access.epam.com";


### PR DESCRIPTION
## Add HTTP Strict Transport Security (HSTS) header

Resolves EPMRPP-115894, EPMRPP-115895

### Problem

The `Strict-Transport-Security` response header was missing from all nginx location blocks. This left the application vulnerable to man-in-the-middle attacks, protocol downgrade attacks, and cookie hijacking as reported by the vulnerability scanner for `reportportal.epam.com` and `rp.epam.com`.

### Solution

Added a `map` block in the `http` context that conditionally sets the HSTS value based on the `X-Forwarded-Proto` header sent by the reverse proxy:

```nginx
map $http_x_forwarded_proto $hsts_header {
    https   "max-age=31536000; includeSubDomains";
    default "";
}
```

Each content-serving location block now uses:

```nginx
add_header Strict-Transport-Security $hsts_header always;
```

This means:
- **Production HTTPS** — reverse proxy sets `X-Forwarded-Proto: https`, HSTS header is included in responses.
- **Local HTTP deployments** — no `X-Forwarded-Proto: https` is present, header value resolves to empty string and is not sent. HTTP deployments are not affected.

The `always` flag ensures the header is sent on all response codes, including error responses.
