### PR TITLE
EPMRPP-116867 || Component Health Check widget: support Owner as a grouping level

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -190,6 +190,7 @@
   "AttributesFieldArrayControl.attributeKeyFieldPlaceholder": "Калі ласка, увядзіце ключ атрибута",
   "AttributesFieldArrayControl.levelCanBeAddedMessage": "1 ўзровень можа быць дададзены",
   "AttributesFieldArrayControl.levelsCanBeAddedMessage": "{amount} узроўняў можна дадаць",
+  "AttributesFieldArrayControl.ownerLevelOption": "Уладальнік",
   "AutoAnalysis.AutoAnalysisMode": "Аўта-Аналіз на аснове",
   "AutoAnalysis.AutoAnalysisModeDescription": "Вы можаце вызначыць запускі, якія будуць выкарыстоўвацца ў якасці асновы для аўтаматычнага аналізу. <a>Дакументацыя</a>",
   "AutoAnalysis.allLaunchesCaption": "Усе папярэднія запускі",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -190,6 +190,7 @@
   "AttributesFieldArrayControl.attributeKeyFieldPlaceholder": "Ingrese la clave del atributo",
   "AttributesFieldArrayControl.levelCanBeAddedMessage": "Se puede agregar 1 nivel",
   "AttributesFieldArrayControl.levelsCanBeAddedMessage": "Se pueden agregar {amount} niveles",
+  "AttributesFieldArrayControl.ownerLevelOption": "Propietario",
   "AutoAnalysis.AutoAnalysisMode": "Modo de análisis automático",
   "AutoAnalysis.AutoAnalysisModeDescription": "Puedes especificar las ejecuciones que se utilizarán como base para el análisis automático. Consulta la <a>documentación</a>.",
   "AutoAnalysis.allLaunchesCaption": "Todas las ejecuciones anteriores",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -190,6 +190,7 @@
   "AttributesFieldArrayControl.attributeKeyFieldPlaceholder": "Введить ключ атрибута",
   "AttributesFieldArrayControl.levelCanBeAddedMessage": "1 уровень может быть добавлен",
   "AttributesFieldArrayControl.levelsCanBeAddedMessage": "{amount} уровней могут быть добавлены",
+  "AttributesFieldArrayControl.ownerLevelOption": "Владелец",
   "AutoAnalysis.AutoAnalysisMode": "Авто-Анализ на основе",
   "AutoAnalysis.AutoAnalysisModeDescription": "Вы можете указать запуски, которые будут использоваться в качестве основы для автоматического анализа. <a>Документация</a>",
   "AutoAnalysis.allLaunchesCaption": "Все предыдущие запуски",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -190,6 +190,7 @@
   "AttributesFieldArrayControl.attributeKeyFieldPlaceholder": "Введить ключ атрибуту",
   "AttributesFieldArrayControl.levelCanBeAddedMessage": "1 рівень може бути доданий",
   "AttributesFieldArrayControl.levelsCanBeAddedMessage": "{amount} рівнів можуть бути додані",
+  "AttributesFieldArrayControl.ownerLevelOption": "Власник",
   "AutoAnalysis.AutoAnalysisMode": "Авто-Аналіз на основі",
   "AutoAnalysis.AutoAnalysisModeDescription": "Ви можете вказати запуски, які будуть використовуватися як основа для автоматичного аналізу. <a>Документація</a>",
   "AutoAnalysis.allLaunchesCaption": "Всі попередні запуски",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -190,6 +190,7 @@
   "AttributesFieldArrayControl.attributeKeyFieldPlaceholder": "请输入属性名",
   "AttributesFieldArrayControl.levelCanBeAddedMessage": "可以再增加1层",
   "AttributesFieldArrayControl.levelsCanBeAddedMessage": "可以再增加{amount}层",
+  "AttributesFieldArrayControl.ownerLevelOption": "所有者",
   "AutoAnalysis.AutoAnalysisMode": "自动分析服务基于的数据",
   "AutoAnalysis.AutoAnalysisModeDescription": "您可以指定将用作自动分析基础的启动。 <a>文档</a>",
   "AutoAnalysis.allLaunchesCaption": "所有之前的发布",

--- a/app/src/common/constants/launchOwnerLevel.js
+++ b/app/src/common/constants/launchOwnerLevel.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineMessages } from 'react-intl';
+
+export const LAUNCH_OWNER_LEVEL_KEY = 'owner';
+
+export const launchOwnerLevelMessages = defineMessages({
+  ownerLevelOption: {
+    id: 'AttributesFieldArrayControl.ownerLevelOption',
+    defaultMessage: 'Owner',
+  },
+});

--- a/app/src/common/css/variables/colors.scss
+++ b/app/src/common/css/variables/colors.scss
@@ -37,6 +37,7 @@ $COLOR--brownish-grey: #666666;
 $COLOR--gray-47: #777777;
 $COLOR--gray-60: #999999;
 $COLOR--booger: #a3c644;
+$COLOR--lima: #a2c749;
 $COLOR--orange-red: #ff3222;
 $COLOR--steel-grey: #6f898d;
 $COLOR--gray-91: #e9e9e9;

--- a/app/src/common/img/owner-icon-inline.svg
+++ b/app/src/common/img/owner-icon-inline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+    <path fill="#999" fill-rule="evenodd" d="M7 7A3 3 0 1 0 7.002.998 3 3 0 0 0 7 7zm0 1.5c-1.999 0-6 1.001-6 3V13h12v-1.5c0-1.999-4.001-3-6-3z"/>
+</svg>

--- a/app/src/components/inputs/autocompletes/common/autocompleteMenu/autocompleteMenu.jsx
+++ b/app/src/components/inputs/autocompletes/common/autocompleteMenu/autocompleteMenu.jsx
@@ -63,14 +63,16 @@ export const AutocompleteMenu = React.forwardRef(
       inputValue,
       beforeSearchPrompt,
       showDynamicSearchPrompt,
+      pinnedOptions,
       ...props
     },
     ref,
   ) => {
-    const menuContent = !isReadyForSearch(minLength, inputValue) ? (
+    const isReady = isReadyForSearch(minLength, inputValue) || pinnedOptions.length > 0;
+    const menuContent = !isReady ? (
       getBeforeSearchPrompt(minLength, inputValue, beforeSearchPrompt, showDynamicSearchPrompt)
     ) : (
-      <AutocompleteOptions inputValue={inputValue} {...props} />
+      <AutocompleteOptions inputValue={inputValue} pinnedOptions={pinnedOptions} {...props} />
     );
 
     return (
@@ -98,6 +100,7 @@ AutocompleteMenu.propTypes = {
   inputValue: PropTypes.string,
   beforeSearchPrompt: PropTypes.node,
   showDynamicSearchPrompt: PropTypes.bool,
+  pinnedOptions: PropTypes.array,
 };
 
 AutocompleteMenu.defaultProps = {
@@ -108,4 +111,5 @@ AutocompleteMenu.defaultProps = {
   inputValue: '',
   beforeSearchPrompt: null,
   showDynamicSearchPrompt: false,
+  pinnedOptions: [],
 };

--- a/app/src/components/inputs/autocompletes/common/autocompleteOptions.jsx
+++ b/app/src/components/inputs/autocompletes/common/autocompleteOptions.jsx
@@ -35,6 +35,8 @@ export class AutocompleteOptions extends Component {
     async: PropTypes.bool,
     notFoundPrompt: PropTypes.node,
     isOptionUnique: PropTypes.func,
+    pinnedOptions: PropTypes.array,
+    createNewAtBottom: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -53,6 +55,8 @@ export class AutocompleteOptions extends Component {
       <FormattedMessage id={'AsyncAutocomplete.notFound'} defaultMessage={'No matches found'} />
     ),
     isOptionUnique: null,
+    pinnedOptions: [],
+    createNewAtBottom: false,
   };
 
   filterStaticOptions = () => {
@@ -115,11 +119,16 @@ export class AutocompleteOptions extends Component {
   };
 
   renderItems = (options) => {
-    const { inputValue, createNewOption } = this.props;
-    let newItem = null;
+    const { inputValue, createNewOption, createNewAtBottom } = this.props;
 
     if (this.canCreateNewItem(options)) {
-      newItem = createNewOption(inputValue);
+      const newItem = createNewOption(inputValue);
+      if (createNewAtBottom) {
+        const items = [...options, newItem];
+        return items.map((item, index) =>
+          this.renderItem(item, index, newItem && index === items.length - 1),
+        );
+      }
       return [newItem, ...options].map((item, index) =>
         this.renderItem(item, index, newItem && index === 0),
       );
@@ -129,7 +138,9 @@ export class AutocompleteOptions extends Component {
   };
 
   render() {
-    const options = this.props.async ? this.props.options : this.filterStaticOptions();
+    const { async, pinnedOptions } = this.props;
+    const loadedOptions = async ? this.props.options : this.filterStaticOptions();
+    const options = [...pinnedOptions, ...loadedOptions];
     const prompt = this.getPrompt(options);
     if (prompt) return prompt;
     return this.renderItems(options);

--- a/app/src/components/inputs/autocompletes/withAsyncLoading.jsx
+++ b/app/src/components/inputs/autocompletes/withAsyncLoading.jsx
@@ -26,6 +26,7 @@ export const WithAsyncLoading = (AutocompleteComponent) =>
       makeOptions: PropTypes.func,
       filterOption: PropTypes.func,
       minLength: PropTypes.number,
+      pinnedOptions: PropTypes.array,
     };
 
     static defaultProps = {
@@ -34,6 +35,7 @@ export const WithAsyncLoading = (AutocompleteComponent) =>
       makeOptions: (values) => values,
       filterOption: () => true,
       minLength: 1,
+      pinnedOptions: [],
     };
 
     state = {

--- a/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.jsx
@@ -28,46 +28,51 @@ export class Breadcrumbs extends PureComponent {
     breadcrumbs: PropTypes.array,
     activeBreadcrumbs: PropTypes.array,
     onClickBreadcrumbs: PropTypes.func,
+    getKeyLabel: PropTypes.func,
   };
 
   static defaultProps = {
     breadcrumbs: [],
     activeBreadcrumbs: [],
     onClickBreadcrumbs: () => {},
+    getKeyLabel: (key) => key,
   };
 
   render() {
-    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs } = this.props;
+    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs, getKeyLabel } = this.props;
     const actualBreadcrumbs = activeBreadcrumbs || breadcrumbs;
 
     return (
       <ul className={cx('breadcrumbs')}>
-        {actualBreadcrumbs?.map((item, i) => (
-          <li className={cx('item', { active: item.isActive })} key={item.key}>
-            {!item.isStatic && !item.isActive ? (
-              <a className={cx('link')} onClick={() => onClickBreadcrumbs(item.id)}>
-                <span className={cx('link-key')} title={item.key}>
-                  {item.key}
-                </span>
-                <span className={cx('link-value')}>
-                  <span
-                    className={cx('link-color')}
-                    style={{ backgroundColor: item.additionalProperties.color }}
-                  />
-                  <span className={cx('link-value-name')} title={item.additionalProperties.value}>
-                    {item.additionalProperties.value}
+        {actualBreadcrumbs?.map((item, i) => {
+          const keyLabel = getKeyLabel(item.key);
+          return (
+            <li className={cx('item', { active: item.isActive })} key={item.key}>
+              {!item.isStatic && !item.isActive ? (
+                <a className={cx('link')} onClick={() => onClickBreadcrumbs(item.id)}>
+                  <span className={cx('link-key')} title={keyLabel}>
+                    {keyLabel}
                   </span>
-                  <span>{`, ${item.additionalProperties.passingRate}%`}</span>
+                  <span className={cx('link-value')}>
+                    <span
+                      className={cx('link-color')}
+                      style={{ backgroundColor: item.additionalProperties.color }}
+                    />
+                    <span className={cx('link-value-name')} title={item.additionalProperties.value}>
+                      {item.additionalProperties.value}
+                    </span>
+                    <span>{`, ${item.additionalProperties.passingRate}%`}</span>
+                  </span>
+                </a>
+              ) : (
+                <span className={cx('item-name')} title={keyLabel}>
+                  {keyLabel}
                 </span>
-              </a>
-            ) : (
-              <span className={cx('item-name')} title={item.key}>
-                {item.key}
-              </span>
-            )}
-            {i + 1 < actualBreadcrumbs.length && <span className={cx('icon')} />}
-          </li>
-        ))}
+              )}
+              {i + 1 < actualBreadcrumbs.length && <span className={cx('icon')} />}
+            </li>
+          );
+        })}
       </ul>
     );
   }

--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheck/legend/componentHealthCheckLegend.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheck/legend/componentHealthCheckLegend.jsx
@@ -17,14 +17,21 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { injectIntl } from 'react-intl';
 import { Breadcrumbs } from 'components/widgets/multiLevelWidgets/common/breadcrumbs';
+import {
+  LAUNCH_OWNER_LEVEL_KEY,
+  launchOwnerLevelMessages,
+} from 'common/constants/launchOwnerLevel';
 import { ComponentHealthCheckColorScheme } from './componentHealthCheckColorScheme';
 import styles from './componentHealthCheckLegend.scss';
 
 const cx = classNames.bind(styles);
 
+@injectIntl
 export class ComponentHealthCheckLegend extends PureComponent {
   static propTypes = {
+    intl: PropTypes.object.isRequired,
     breadcrumbs: PropTypes.array,
     activeBreadcrumbs: PropTypes.array,
     onClickBreadcrumbs: PropTypes.func,
@@ -39,7 +46,13 @@ export class ComponentHealthCheckLegend extends PureComponent {
   };
 
   render() {
-    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs, passingRate } = this.props;
+    const {
+      intl: { formatMessage },
+      breadcrumbs,
+      activeBreadcrumbs,
+      onClickBreadcrumbs,
+      passingRate,
+    } = this.props;
 
     return (
       <div className={cx('legend')}>
@@ -47,6 +60,11 @@ export class ComponentHealthCheckLegend extends PureComponent {
           breadcrumbs={breadcrumbs}
           activeBreadcrumbs={activeBreadcrumbs}
           onClickBreadcrumbs={onClickBreadcrumbs}
+          getKeyLabel={(key) =>
+            key === LAUNCH_OWNER_LEVEL_KEY
+              ? formatMessage(launchOwnerLevelMessages.ownerLevelOption)
+              : key
+          }
         />
         <ComponentHealthCheckColorScheme passingRate={passingRate} />
       </div>

--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/componentHealthCheckTable.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/componentHealthCheckTable.jsx
@@ -43,6 +43,10 @@ import {
   getBreadcrumbs,
   getNewActiveBreadcrumbs,
 } from 'components/widgets/multiLevelWidgets/common/utils';
+import {
+  LAUNCH_OWNER_LEVEL_KEY,
+  launchOwnerLevelMessages,
+} from 'common/constants/launchOwnerLevel';
 import { STATE_READY } from 'components/widgets/common/constants';
 import isEqual from 'fast-deep-equal';
 import {
@@ -337,6 +341,7 @@ export class ComponentHealthCheckTable extends Component {
     const { activeBreadcrumbs, activeBreadcrumbId, isLoading } = this.state;
     const {
       widget: { contentParameters },
+      intl: { formatMessage },
     } = this.props;
     const state = contentParameters?.widgetOptions.state;
     const attributes = contentParameters?.widgetOptions.attributeKeys;
@@ -351,6 +356,11 @@ export class ComponentHealthCheckTable extends Component {
             breadcrumbs={breadcrumbs}
             activeBreadcrumbs={activeBreadcrumbs}
             onClickBreadcrumbs={this.onClickBreadcrumbs}
+            getKeyLabel={(key) =>
+              key === LAUNCH_OWNER_LEVEL_KEY
+                ? formatMessage(launchOwnerLevelMessages.ownerLevelOption)
+                : key
+            }
           />
         </div>
         {data && state === STATE_READY && !isLoading ? (

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckControls.jsx
@@ -152,6 +152,7 @@ export class ComponentHealthCheckControls extends Component {
         fieldValidator={fieldValidator}
         maxAttributesAmount={MAX_ATTRIBUTES_AMOUNT}
         showRemainingLevels
+        withOwnerLevel
         getURI={URLS.itemAttributeKeysAllSearch(
           activeProject,
           filterId,

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckTableViewControls.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/componentHealthCheckTableViewControls.jsx
@@ -199,6 +199,7 @@ export class ComponentHealthCheckTableViewControls extends Component {
         fieldValidator={fieldValidator}
         maxAttributesAmount={MAX_ATTRIBUTES_AMOUNT}
         showRemainingLevels
+        withOwnerLevel
         getURI={url}
         disabled={this.props.isMainControlsDisabled}
       />

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.jsx
@@ -20,10 +20,16 @@ import { injectIntl, defineMessages } from 'react-intl';
 import Parser from 'html-react-parser';
 import classNames from 'classnames/bind';
 import CrossIcon from 'common/img/cross-icon-inline.svg';
+import OwnerIcon from 'common/img/owner-icon-inline.svg';
 import { ModalField } from 'components/main/modal';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { FieldProvider } from 'components/fields/fieldProvider';
 import { AsyncAutocomplete } from 'components/inputs/autocompletes/asyncAutocomplete';
+import { AutocompleteOption } from 'components/inputs/autocompletes/common/autocompleteOption';
+import {
+  LAUNCH_OWNER_LEVEL_KEY,
+  launchOwnerLevelMessages,
+} from 'common/constants/launchOwnerLevel';
 import { FIELD_LABEL_WIDTH } from '../constants';
 import styles from './attributesFieldArrayControl.scss';
 
@@ -63,12 +69,14 @@ export class AttributesFieldArrayControl extends Component {
     attributeKeyFieldViewLabels: PropTypes.array,
     showRemainingLevels: PropTypes.bool,
     disabled: PropTypes.bool,
+    withOwnerLevel: PropTypes.bool,
   };
 
   static defaultProps = {
     attributeKeyFieldViewLabels: [],
     showRemainingLevels: false,
     disabled: false,
+    withOwnerLevel: false,
   };
 
   constructor(props) {
@@ -86,6 +94,46 @@ export class AttributesFieldArrayControl extends Component {
 
   filterAttribute = (item) => !this.getAttributes().includes(item);
 
+  isOwnerLevelAvailable = (index) =>
+    !this.getAttributes().some((value, i) => i !== index && value === LAUNCH_OWNER_LEVEL_KEY);
+
+  parseLevelValueToString = (value) =>
+    value === LAUNCH_OWNER_LEVEL_KEY
+      ? this.props.intl.formatMessage(launchOwnerLevelMessages.ownerLevelOption)
+      : value || '';
+
+  // keep the stored value as the 'owner' key even when onBlur commits the displayed label
+  normalizeLevelValue = (value) =>
+    value === this.props.intl.formatMessage(launchOwnerLevelMessages.ownerLevelOption)
+      ? LAUNCH_OWNER_LEVEL_KEY
+      : value;
+
+  renderLevelOption = (item, index, isNew, getItemProps) =>
+    item === LAUNCH_OWNER_LEVEL_KEY ? (
+      <AutocompleteOption key={item} {...getItemProps({ item, index })}>
+        <span className={cx('owner-option')}>
+          <i className={cx('owner-icon')}>{Parser(OwnerIcon)}</i>
+          {this.props.intl.formatMessage(launchOwnerLevelMessages.ownerLevelOption)}
+        </span>
+      </AutocompleteOption>
+    ) : (
+      <AutocompleteOption key={item} {...getItemProps({ item, index })} isNew={isNew}>
+        {item}
+      </AutocompleteOption>
+    );
+
+  getOwnerLevelProps = (index) => {
+    const { withOwnerLevel } = this.props;
+    if (!withOwnerLevel) return {};
+
+    return {
+      pinnedOptions: this.isOwnerLevelAvailable(index) ? [LAUNCH_OWNER_LEVEL_KEY] : [],
+      renderOption: this.renderLevelOption,
+      parseValueToString: this.parseLevelValueToString,
+      createNewAtBottom: true,
+    };
+  };
+
   render() {
     const {
       intl: { formatMessage },
@@ -96,6 +144,7 @@ export class AttributesFieldArrayControl extends Component {
       attributeKeyFieldViewLabels,
       showRemainingLevels,
       disabled,
+      withOwnerLevel,
     } = this.props;
     const attributes = this.getAttributes();
     const canAddNewItems = fields.length < maxAttributesAmount;
@@ -115,7 +164,11 @@ export class AttributesFieldArrayControl extends Component {
               className={cx('attribute-modal-field')}
             >
               <div className={cx({ 'attr-selector': !isFirstItem && !disabled })}>
-                <FieldProvider name={item} validate={fieldValidator(attributes)}>
+                <FieldProvider
+                  name={item}
+                  validate={fieldValidator(attributes)}
+                  normalize={withOwnerLevel ? this.normalizeLevelValue : undefined}
+                >
                   <FieldErrorHint hintType="top">
                     <AsyncAutocomplete
                       getURI={getURI}
@@ -124,6 +177,7 @@ export class AttributesFieldArrayControl extends Component {
                       creatable
                       filterOption={this.filterAttribute}
                       disabled={disabled}
+                      {...this.getOwnerLevelProps(index)}
                     />
                   </FieldErrorHint>
                 </FieldProvider>

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.scss
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.scss
@@ -54,3 +54,24 @@
   font-size: 13px;
   font-family: $FONT-REGULAR;
 }
+
+.owner-option {
+  display: inline-flex;
+  align-items: center;
+}
+
+.owner-icon {
+  display: inline-flex;
+  width: 13px;
+  height: 13px;
+  margin-right: 8px;
+
+  svg {
+    width: 13px;
+    height: 13px;
+
+    path {
+      fill: $COLOR--lima;
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Goal:** Add a selectable **Owner** level to the CHC widget config (chart + table), stored as the `owner` key, shown only once, with localized display and breadcrumbs.

**Config side (Level field):**
- New `common/constants/launchOwnerLevel.js` holds `LAUNCH_OWNER_LEVEL_KEY = 'owner'` and the localized `ownerLevelOption` message (single owner module).
- `attributesFieldArrayControl.jsx` gained an opt-in `withOwnerLevel` mode: pins an **Owner** option (with icon) at the top of the dropdown, hides it once `owner` is picked in another level, renders the option with `owner-icon-inline.svg`, displays the stored `owner` key as “Owner” (`parseValueToString`), and `normalize`s the label back to `owner` on commit.
- Enabled via `withOwnerLevel` in both `componentHealthCheckControls.jsx` and `componentHealthCheckTableViewControls.jsx`.

**Shared autocomplete (opt-in, non-breaking):**
- Added `pinnedOptions` (top, no API call needed, menu opens on focus) and `createNewAtBottom` (keeps “create new” at the bottom) to `autocompleteOptions`/`autocompleteMenu`/`withAsyncLoading`.

**View side (breadcrumbs):**
- `breadcrumbs.jsx` made generic with a `getKeyLabel` prop (default identity); `item.key`/`item.id` untouched so drill-down logic is unaffected.
- Legend (chart) and `componentHealthCheckTable` inline the `owner → “Owner”` mapping using the shared constant/message.

**Styling/i18n:** added `$COLOR--lima: #a2c749` for the icon; `AttributesFieldArrayControl.ownerLevelOption` translations in ru/be/uk/es/zh.

## Links
[EPMRPP-116867](https://jiraeu.epam.com/browse/EPMRPP-116867)

## Visuals

https://github.com/user-attachments/assets/0cf1e6d5-e25e-4d9c-a656-9ce9d567a53d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added owner level option with multilingual support (Belarusian, Spanish, Russian, Ukrainian, and Chinese)
  * Autocomplete components now support pinned options for streamlined navigation
  * Breadcrumbs display localized key labels for improved readability
  * Component Health Check widgets configuration extended to support owner level attributes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->