### PR TITLE
EPMRPP-116953 || Correct spacing before Documentation link on Organization Integrations empty state

### DIFF
--- a/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationsTab.jsx
+++ b/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationsTab.jsx
@@ -140,6 +140,8 @@ export const IntegrationsTab = () => {
         description={formatMessage(messages.noPluginsDescription)}
         documentationLink={docsReferences.emptyStateOrgIntegrationsDocs}
         handleDocumentationClick={handleDocumentationClick}
+        descriptionClassName={cx('no-plugins-empty-description')}
+        documentationLinkClassName={cx('no-plugins-empty-link')}
         imageType="plugins"
       />
     );

--- a/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationsTab.scss
+++ b/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationsTab.scss
@@ -47,3 +47,11 @@
   flex-direction: column;
   gap: 16px;
 }
+
+.no-plugins-empty-description {
+  margin-bottom: 0;
+}
+
+.no-plugins-empty-link {
+  margin-top: 16px;
+}


### PR DESCRIPTION
## Problem

On **Organization Settings → Integrations**, when no plugins are available (e.g. Email Server plugin is disabled), the empty state shows incorrect spacing between the description text and the **Documentation** link.

**Actual:** 42px (24px `margin-bottom` on description + 18px `margin-top` on link from shared `EmptyStatePage` styles).

**Expected:** 16px per Figma.

## Solution

Apply a local spacing override on the Organization Integrations empty state only, without changing the shared `EmptyStatePage` component. This avoids unintended layout changes on other pages that reuse the same component.

- Reset description bottom margin to `0`
- Set Documentation link top margin to `16px`

## Visuals

<img width="1493" height="870" alt="image" src="https://github.com/user-attachments/assets/5a60d524-ed70-4b41-856f-dd262e8a760a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and visual alignment in the integrations tab empty state, with refined margin adjustments for descriptive text and documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->