### PR TITLE
EPMRPP-117047 || Prevent crash when opening manual launch test execution page

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/types.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/types.ts
@@ -44,3 +44,7 @@ export interface LinkedIssue {
   linkToIssue: string;
   issueId: string;
 }
+
+export interface BTSIssuesModalData {
+  executionId?: number;
+}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/useBTSIssuesModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/useBTSIssuesModal.tsx
@@ -14,22 +14,26 @@
  * limitations under the License.
  */
 
-import { useDispatch } from 'react-redux';
+import { useCallback } from 'react';
 
-import { showModalAction } from 'controllers/modal';
+import { useModal } from 'common/hooks';
+
+import { BTSIssuesModal } from './BTSIssuesModal';
 import { BTS_ISSUES_MODAL } from '../constants';
+import type { BTSIssuesModalData } from './types';
 
 export const useBTSIssuesModal = () => {
-  const dispatch = useDispatch();
+  const { openModal: openRawModal } = useModal<BTSIssuesModalData>({
+    modalKey: BTS_ISSUES_MODAL,
+    renderModal: (data) => <BTSIssuesModal data={data} />,
+  });
 
-  const openModal = (executionId?: number) => {
-    dispatch(
-      showModalAction({
-        id: BTS_ISSUES_MODAL,
-        data: { executionId },
-      }),
-    );
-  };
+  const openModal = useCallback(
+    (executionId?: number) => {
+      openRawModal({ executionId });
+    },
+    [openRawModal],
+  );
 
   return { openModal };
 };

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/useExecutionStatusModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/useExecutionStatusModal.tsx
@@ -14,35 +14,14 @@
  * limitations under the License.
  */
 
-import { useDispatch } from 'react-redux';
-import { showModalAction } from 'controllers/modal';
-import type { ExecutionStatusChangePlace } from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
+import { useModal } from 'common/hooks';
+
+import { ExecutionStatusConfirmModal } from './executionStatusConfirmModal';
 import { EXECUTION_STATUS_CONFIRM_MODAL } from '../constants';
-import type { ExecutionStatusType } from '../types';
+import type { ExecutionStatusConfirmModalData } from '../types';
 
-interface OpenModalParams {
-  executionId: number;
-  status: ExecutionStatusType;
-  currentStatus?: string;
-  place: ExecutionStatusChangePlace;
-}
-
-export const useExecutionStatusModal = () => {
-  const dispatch = useDispatch();
-
-  const openModal = ({ executionId, status, currentStatus, place }: OpenModalParams) => {
-    dispatch(
-      showModalAction({
-        id: EXECUTION_STATUS_CONFIRM_MODAL,
-        data: {
-          executionId,
-          status,
-          currentStatus,
-          place,
-        },
-      }),
-    );
-  };
-
-  return { openModal };
-};
+export const useExecutionStatusModal = () =>
+  useModal<ExecutionStatusConfirmModalData>({
+    modalKey: EXECUTION_STATUS_CONFIRM_MODAL,
+    renderModal: (data) => <ExecutionStatusConfirmModal data={data} />,
+  });

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/manualLaunchExecutionPage.tsx
@@ -48,7 +48,6 @@ import {
 
 import { ExecutionStatusButtons } from './executionStatusButtons';
 import { ExecutionStatusDropdown } from './executionStatusDropdown';
-import { ExecutionStatusConfirmModal } from './executionStatusConfirmModal';
 import { TextBasedContent } from './textBasedContent';
 import { StepsBasedContent } from './stepsBasedContent';
 import { ExecutionCommentSection } from './executionCommentSection/executionCommentSection';
@@ -56,7 +55,6 @@ import { messages } from './messages';
 import { commonMessages } from 'pages/inside/common/common-messages';
 import { messages as manualLaunchesMessages } from '../messages';
 import { hasPersistedExecutionComment } from './utils';
-import { BTSIssuesModal } from './BTSIssuesModal/BTSIssuesModal';
 import { LinkedToBTSSection } from './LinkedToBTSSection/LinkedToBTSSection';
 
 import styles from './manualLaunchExecutionPage.scss';
@@ -249,8 +247,6 @@ export const ManualLaunchExecutionPage = () => {
           </div>
         </div>
       </ScrollWrapper>
-      <ExecutionStatusConfirmModal />
-      <BTSIssuesModal />
     </SettingsLayout>
   );
 };


### PR DESCRIPTION
## Problem

Opening a test execution from **Manual Launches** crashes the page with:

`TypeError: undefined is not an object (evaluating 'el.find')`

**Steps to reproduce:** Manual Launches → open a launch → click a test name.

**Root cause:** `BTSIssuesModal` and `ExecutionStatusConfirmModal` were rendered directly in `ManualLaunchExecutionPage` JSX. That mounted `BTSIssuesModal` on every page load, before the modal was opened. On mount, `getDefaultIssueModalConfig()` ran against an empty `namedBtsIntegrations` object (projects without BTS integrations) and threw when calling `.find()` on `undefined`.

Modals in service-ui are intended to render through `ModalContainer` only when opened, not as persistent children of the page.

## Solution

- Remove `<BTSIssuesModal />` and `<ExecutionStatusConfirmModal />` from `ManualLaunchExecutionPage`.
- Migrate `useBTSIssuesModal` and `useExecutionStatusModal` to `useModal` with `renderModal`, so components mount only when `openModal` is called.
- Preserve existing public hook APIs (`openModal(executionId)` and `openModal({ executionId, status, ... })`).


## Visuals


https://github.com/user-attachments/assets/d68b9d54-dd04-4758-940f-4cb873f08634




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved modal management infrastructure for execution-related dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->