### PR TITLE
EPMRPP-117003 || Treat all selected priorities as no priority filter on Manual Launch

### DIFF
--- a/app/src/controllers/manualLaunch/sagas.ts
+++ b/app/src/controllers/manualLaunch/sagas.ts
@@ -265,8 +265,10 @@ function* getManualLaunchFolders(action: GetManualLaunchFoldersAction): Generato
       limit,
     };
 
-    if (filterPriorities) {
-      params[FOLDER_FILTER_KEYS.priority] = filterPriorities.toUpperCase();
+    const normalizedFolderPriorities = normalizePrioritiesForExecutionApi(filterPriorities);
+
+    if (normalizedFolderPriorities) {
+      params[FOLDER_FILTER_KEYS.priority] = normalizedFolderPriorities;
     }
 
     if (filterTags) {
@@ -457,8 +459,10 @@ function* getManualLaunchFilteredFolders(action: GetManualLaunchFilteredFoldersA
         [MANUAL_LAUNCH_FOLDER_SEARCH_FILTER_KEY]: searchQuery,
       };
 
-      if (filterPriorities) {
-        folderListParams[FOLDER_FILTER_KEYS.priority] = filterPriorities.toUpperCase();
+      const normalizedFolderPriorities = normalizePrioritiesForExecutionApi(filterPriorities);
+
+      if (normalizedFolderPriorities) {
+        folderListParams[FOLDER_FILTER_KEYS.priority] = normalizedFolderPriorities;
       }
 
       if (filterTags) {

--- a/app/src/pages/inside/common/testCaseList/filterSidePanel/utils.ts
+++ b/app/src/pages/inside/common/testCaseList/filterSidePanel/utils.ts
@@ -15,11 +15,14 @@
  */
 
 import {
+  STATUS_TYPES,
   TEST_CASE_FILTER_KEYS,
   FOLDER_FILTER_KEYS,
   MANUAL_LAUNCH_EXECUTION_FILTER_KEYS,
   type FilterKeyMap,
 } from '../constants';
+
+const ALL_PRIORITY_VALUES = Object.values(STATUS_TYPES);
 
 export const ensureArray = <T>(value?: T | T[] | null): T[] => {
   if (value === null || value === undefined) {
@@ -35,6 +38,16 @@ export const normalizeSelection = (values: string[]) => {
 
 export const toBackendPriority = (priorities: string[]): string =>
   priorities.map((priority) => priority.toUpperCase()).join(',');
+
+export const isAllPrioritiesSelected = (priorities: string[]): boolean => {
+  if (priorities.length !== ALL_PRIORITY_VALUES.length) {
+    return false;
+  }
+
+  const normalized = normalizeSelection(priorities.map((priority) => priority.toLowerCase()));
+
+  return ALL_PRIORITY_VALUES.every((priority) => normalized.includes(priority));
+};
 
 const buildFilterParams = (
   keys: FilterKeyMap,
@@ -58,21 +71,34 @@ export const parseTagsFromQuery = (raw?: string): string[] =>
   raw ? raw.split(',') : [];
 
 export const buildTestCaseFilterParams = (filterPriorities?: string, filterTags?: string) =>
-  buildFilterParams(TEST_CASE_FILTER_KEYS, filterPriorities, filterTags);
+  buildFilterParams(
+    TEST_CASE_FILTER_KEYS,
+    normalizePrioritiesForExecutionApi(filterPriorities),
+    filterTags,
+  );
 
 export const buildFolderFilterParams = (filterPriorities?: string, filterTags?: string) =>
-  buildFilterParams(FOLDER_FILTER_KEYS, filterPriorities, filterTags);
+  buildFilterParams(
+    FOLDER_FILTER_KEYS,
+    normalizePrioritiesForExecutionApi(filterPriorities),
+    filterTags,
+  );
 
 export const normalizePrioritiesForExecutionApi = (filterPriorities?: string): string | undefined => {
   if (!filterPriorities?.trim()) {
     return undefined;
   }
 
-  const normalized = filterPriorities
+  const parsedPriorities = filterPriorities
     .split(',')
-    .map((priority) => priority.trim().toUpperCase())
-    .filter(Boolean)
-    .join(',');
+    .map((priority) => priority.trim())
+    .filter(Boolean);
+
+  if (isAllPrioritiesSelected(parsedPriorities)) {
+    return undefined;
+  }
+
+  const normalized = parsedPriorities.map((priority) => priority.toUpperCase()).join(',');
 
   return normalized || undefined;
 };

--- a/app/src/pages/inside/common/testCaseList/filterSidePanel/utils.ts
+++ b/app/src/pages/inside/common/testCaseList/filterSidePanel/utils.ts
@@ -40,13 +40,15 @@ export const toBackendPriority = (priorities: string[]): string =>
   priorities.map((priority) => priority.toUpperCase()).join(',');
 
 export const isAllPrioritiesSelected = (priorities: string[]): boolean => {
-  if (priorities.length !== ALL_PRIORITY_VALUES.length) {
+  const uniqueNormalized = normalizeSelection(
+    priorities.map((priority) => priority.toLowerCase().trim()),
+  );
+
+  if (uniqueNormalized.length !== ALL_PRIORITY_VALUES.length) {
     return false;
   }
 
-  const normalized = normalizeSelection(priorities.map((priority) => priority.toLowerCase()));
-
-  return ALL_PRIORITY_VALUES.every((priority) => normalized.includes(priority));
+  return ALL_PRIORITY_VALUES.every((priority) => uniqueNormalized.includes(priority));
 };
 
 const buildFilterParams = (


### PR DESCRIPTION
## Problem

On the Manual Launch details page, selecting **all** priority values in the Filter drawer (Blocker, Critical, High, Medium, Low, Unspecified) and clicking **Apply** returns fewer test executions than leaving the priority filter empty.

Selecting every available priority should be equivalent to having no priority filter. Instead, the UI sent `filter.in.priority=BLOCKER,CRITICAL,HIGH,MEDIUM,LOW,UNSPECIFIED` to the API, which applied a real filter and excluded rows that do not match the `IN (...)` condition.

## Solution

Split UI state from API filtering:

- **URL / UI state** — keep selected priorities in `filterPriorities` when the user applies the filter (including when all six values are selected). This preserves the filled filter icon, active filter count, and the "All" selection when reopening the drawer.
- **API requests** — normalize priorities at the request boundary via `normalizePrioritiesForExecutionApi`: if all `STATUS_TYPES` values are present, omit `filter.in.priority` / `filter.in.testCasePriority` from the request (same as no priority filter).

Applied in execution and folder sagas, and in shared `buildTestCaseFilterParams` / `buildFolderFilterParams` helpers.


## Visuals


https://github.com/user-attachments/assets/c66c9745-31ca-4c94-a670-1d1500a91d59



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected priority filter behavior when all priorities are selected so the filter no longer applies unintentionally.
  * Standardized how priority filters are normalized and sent in both manual-launch folder filtering and the test case list/filter side panel, improving consistency across screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->