### PR TITLE
EPMRPP-115024 || Improve the Owner option in CHC widgets

### DIFF
--- a/app/src/common/constants/launchOwnerLevel.js
+++ b/app/src/common/constants/launchOwnerLevel.js
@@ -16,7 +16,7 @@
 
 import { defineMessages } from 'react-intl';
 
-export const LAUNCH_OWNER_LEVEL_KEY = 'owner';
+export const LAUNCH_OWNER_LEVEL_KEY = '$launchOwner';
 
 export const launchOwnerLevelMessages = defineMessages({
   ownerLevelOption: {

--- a/app/src/components/inputs/autocompletes/common/autocompleteOptions.jsx
+++ b/app/src/components/inputs/autocompletes/common/autocompleteOptions.jsx
@@ -35,6 +35,7 @@ export class AutocompleteOptions extends Component {
     async: PropTypes.bool,
     notFoundPrompt: PropTypes.node,
     isOptionUnique: PropTypes.func,
+    isOptionExist: PropTypes.func,
     pinnedOptions: PropTypes.array,
     createNewAtBottom: PropTypes.bool,
   };
@@ -55,6 +56,7 @@ export class AutocompleteOptions extends Component {
       <FormattedMessage id={'AsyncAutocomplete.notFound'} defaultMessage={'No matches found'} />
     ),
     isOptionUnique: null,
+    isOptionExist: null,
     pinnedOptions: [],
     createNewAtBottom: false,
   };
@@ -87,7 +89,9 @@ export class AutocompleteOptions extends Component {
   };
 
   isOptionExist = (inputValue, options) =>
-    options.some((option) => this.props.parseValueToString(option) === inputValue);
+    this.props.isOptionExist
+      ? this.props.isOptionExist(inputValue, options)
+      : options.some((option) => this.props.parseValueToString(option) === inputValue);
 
   isOptionUnique = (inputValue, options) =>
     !this.props.isOptionUnique || this.props.isOptionUnique(inputValue, options);

--- a/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.jsx
@@ -41,7 +41,8 @@ export class Breadcrumbs extends PureComponent {
   };
 
   render() {
-    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs, getKeyLabel, getKeyIcon } = this.props;
+    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs, getKeyLabel, getKeyIcon } =
+      this.props;
     const actualBreadcrumbs = activeBreadcrumbs || breadcrumbs;
 
     return (
@@ -54,7 +55,11 @@ export class Breadcrumbs extends PureComponent {
               {!item.isStatic && !item.isActive ? (
                 <a className={cx('link')} onClick={() => onClickBreadcrumbs(item.id)}>
                   <span className={cx('link-key')} title={keyLabel}>
-                    {keyIcon && <i className={cx('key-icon')}>{keyIcon}</i>}
+                    {keyIcon && (
+                      <i className={cx('key-icon')} aria-hidden="true">
+                        {keyIcon}
+                      </i>
+                    )}
                     {keyLabel}
                   </span>
                   <span className={cx('link-value')}>
@@ -70,7 +75,11 @@ export class Breadcrumbs extends PureComponent {
                 </a>
               ) : (
                 <span className={cx('item-name')} title={keyLabel}>
-                  {keyIcon && <i className={cx('key-icon')}>{keyIcon}</i>}
+                  {keyIcon && (
+                    <i className={cx('key-icon')} aria-hidden="true">
+                      {keyIcon}
+                    </i>
+                  )}
                   {keyLabel}
                 </span>
               )}

--- a/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.jsx
@@ -29,6 +29,7 @@ export class Breadcrumbs extends PureComponent {
     activeBreadcrumbs: PropTypes.array,
     onClickBreadcrumbs: PropTypes.func,
     getKeyLabel: PropTypes.func,
+    getKeyIcon: PropTypes.func,
   };
 
   static defaultProps = {
@@ -36,21 +37,24 @@ export class Breadcrumbs extends PureComponent {
     activeBreadcrumbs: [],
     onClickBreadcrumbs: () => {},
     getKeyLabel: (key) => key,
+    getKeyIcon: () => null,
   };
 
   render() {
-    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs, getKeyLabel } = this.props;
+    const { breadcrumbs, activeBreadcrumbs, onClickBreadcrumbs, getKeyLabel, getKeyIcon } = this.props;
     const actualBreadcrumbs = activeBreadcrumbs || breadcrumbs;
 
     return (
       <ul className={cx('breadcrumbs')}>
         {actualBreadcrumbs?.map((item, i) => {
           const keyLabel = getKeyLabel(item.key);
+          const keyIcon = getKeyIcon(item.key);
           return (
             <li className={cx('item', { active: item.isActive })} key={item.key}>
               {!item.isStatic && !item.isActive ? (
                 <a className={cx('link')} onClick={() => onClickBreadcrumbs(item.id)}>
                   <span className={cx('link-key')} title={keyLabel}>
+                    {keyIcon && <i className={cx('key-icon')}>{keyIcon}</i>}
                     {keyLabel}
                   </span>
                   <span className={cx('link-value')}>
@@ -66,6 +70,7 @@ export class Breadcrumbs extends PureComponent {
                 </a>
               ) : (
                 <span className={cx('item-name')} title={keyLabel}>
+                  {keyIcon && <i className={cx('key-icon')}>{keyIcon}</i>}
                   {keyLabel}
                 </span>
               )}

--- a/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.scss
+++ b/app/src/components/widgets/multiLevelWidgets/common/breadcrumbs/breadcrumbs.scss
@@ -30,12 +30,22 @@
   line-height: normal;
   color: $COLOR--gray-60;
 
+  .key-icon svg path {
+    fill: $COLOR--gray-60;
+  }
+
   &.active {
     color: $COLOR--topaz;
+
+    .key-icon svg path {
+      fill: $COLOR--topaz;
+    }
   }
 }
 
 .item-name {
+  display: flex;
+  align-items: center;
   max-width: 70px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -73,7 +83,23 @@
 }
 
 .link-key {
+  display: flex;
+  align-items: center;
   font-size: 11px;
+}
+
+.key-icon {
+  display: inline-flex;
+  align-items: center;
+  width: 13px;
+  height: 13px;
+  margin-right: 8px;
+  flex-shrink: 0;
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
 }
 
 .icon {

--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheck/legend/componentHealthCheckLegend.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheck/legend/componentHealthCheckLegend.jsx
@@ -18,6 +18,8 @@ import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { injectIntl } from 'react-intl';
+import Parser from 'html-react-parser';
+import OwnerIcon from 'common/img/owner-icon-inline.svg';
 import { Breadcrumbs } from 'components/widgets/multiLevelWidgets/common/breadcrumbs';
 import {
   LAUNCH_OWNER_LEVEL_KEY,
@@ -65,6 +67,7 @@ export class ComponentHealthCheckLegend extends PureComponent {
               ? formatMessage(launchOwnerLevelMessages.ownerLevelOption)
               : key
           }
+          getKeyIcon={(key) => (key === LAUNCH_OWNER_LEVEL_KEY ? Parser(OwnerIcon) : null)}
         />
         <ComponentHealthCheckColorScheme passingRate={passingRate} />
       </div>

--- a/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/componentHealthCheckTable.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/componentHealthCheckTable/componentHealthCheckTable.jsx
@@ -19,6 +19,8 @@ import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import classNames from 'classnames/bind';
 import { connect } from 'react-redux';
+import Parser from 'html-react-parser';
+import OwnerIcon from 'common/img/owner-icon-inline.svg';
 import {
   STATS_TOTAL,
   STATS_SKIPPED,
@@ -361,6 +363,7 @@ export class ComponentHealthCheckTable extends Component {
                 ? formatMessage(launchOwnerLevelMessages.ownerLevelOption)
                 : key
             }
+            getKeyIcon={(key) => (key === LAUNCH_OWNER_LEVEL_KEY ? Parser(OwnerIcon) : null)}
           />
         </div>
         {data && state === STATE_READY && !isLoading ? (

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.jsx
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.jsx
@@ -102,12 +102,6 @@ export class AttributesFieldArrayControl extends Component {
       ? this.props.intl.formatMessage(launchOwnerLevelMessages.ownerLevelOption)
       : value || '';
 
-  // keep the stored value as the 'owner' key even when onBlur commits the displayed label
-  normalizeLevelValue = (value) =>
-    value === this.props.intl.formatMessage(launchOwnerLevelMessages.ownerLevelOption)
-      ? LAUNCH_OWNER_LEVEL_KEY
-      : value;
-
   renderLevelOption = (item, index, isNew, getItemProps) =>
     item === LAUNCH_OWNER_LEVEL_KEY ? (
       <AutocompleteOption key={item} {...getItemProps({ item, index })}>
@@ -122,6 +116,17 @@ export class AttributesFieldArrayControl extends Component {
       </AutocompleteOption>
     );
 
+  getOwnerLevelBlurHandler = (index) => (e) => {
+    const { intl } = this.props;
+    const attributes = this.getAttributes();
+    if (
+      attributes[index] === LAUNCH_OWNER_LEVEL_KEY &&
+      e.target.value === intl.formatMessage(launchOwnerLevelMessages.ownerLevelOption)
+    ) {
+      e.preventDefault();
+    }
+  };
+
   getOwnerLevelProps = (index) => {
     const { withOwnerLevel } = this.props;
     if (!withOwnerLevel) return {};
@@ -130,6 +135,12 @@ export class AttributesFieldArrayControl extends Component {
       pinnedOptions: this.isOwnerLevelAvailable(index) ? [LAUNCH_OWNER_LEVEL_KEY] : [],
       renderOption: this.renderLevelOption,
       parseValueToString: this.parseLevelValueToString,
+      isOptionExist: (inputValue, options) =>
+        options.some(
+          (option) =>
+            option !== LAUNCH_OWNER_LEVEL_KEY &&
+            this.parseLevelValueToString(option) === inputValue,
+        ),
       createNewAtBottom: true,
     };
   };
@@ -164,23 +175,31 @@ export class AttributesFieldArrayControl extends Component {
               className={cx('attribute-modal-field')}
             >
               <div className={cx({ 'attr-selector': !isFirstItem && !disabled })}>
-                <FieldProvider
-                  name={item}
-                  validate={fieldValidator(attributes)}
-                  normalize={withOwnerLevel ? this.normalizeLevelValue : undefined}
-                >
-                  <FieldErrorHint hintType="top">
-                    <AsyncAutocomplete
-                      getURI={getURI}
-                      minLength={1}
-                      placeholder={formatMessage(messages.attributeKeyFieldPlaceholder)}
-                      creatable
-                      filterOption={this.filterAttribute}
-                      disabled={disabled}
-                      {...this.getOwnerLevelProps(index)}
-                    />
-                  </FieldErrorHint>
-                </FieldProvider>
+                <div className={cx('owner-value-wrap')}>
+                  {withOwnerLevel && attributes[index] === LAUNCH_OWNER_LEVEL_KEY && (
+                    <div className={cx('owner-selected-overlay')}>
+                      <i className={cx('owner-icon')}>{Parser(OwnerIcon)}</i>
+                      {formatMessage(launchOwnerLevelMessages.ownerLevelOption)}
+                    </div>
+                  )}
+                  <FieldProvider
+                    name={item}
+                    validate={fieldValidator(attributes)}
+                    onBlur={withOwnerLevel ? this.getOwnerLevelBlurHandler(index) : undefined}
+                  >
+                    <FieldErrorHint hintType="top">
+                      <AsyncAutocomplete
+                        getURI={getURI}
+                        minLength={1}
+                        placeholder={formatMessage(messages.attributeKeyFieldPlaceholder)}
+                        creatable
+                        filterOption={this.filterAttribute}
+                        disabled={disabled}
+                        {...this.getOwnerLevelProps(index)}
+                      />
+                    </FieldErrorHint>
+                  </FieldProvider>
+                </div>
               </div>
               {!isFirstItem && !disabled && (
                 <span

--- a/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.scss
+++ b/app/src/pages/inside/dashboardItemPage/modals/common/widgetControls/controls/attributesFieldArrayControl/attributesFieldArrayControl.scss
@@ -60,6 +60,35 @@
   align-items: center;
 }
 
+.owner-value-wrap {
+  position: relative;
+
+  &:focus-within .owner-selected-overlay {
+    display: none;
+  }
+}
+
+.owner-selected-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 22px 0 10px;
+  background-color: $COLOR--white-two;
+  font-size: 13px;
+  font-family: $FONT-REGULAR;
+  color: $COLOR--charcoal-grey;
+  border: 1px solid $COLOR--gray-80;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  z-index: 1;
+  pointer-events: none;
+}
+
 .owner-icon {
   display: inline-flex;
   width: 13px;


### PR DESCRIPTION
The PR is related to [EPMRPP-116867](https://jiraeu.epam.com/browse/EPMRPP-116867)

## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**`launchOwnerLevel.js`** — Changed `LAUNCH_OWNER_LEVEL_KEY` from `'owner'` to `'$launchOwner'` to avoid collision with real user-created attributes named "Owner".

**`autocompleteOptions.jsx`** — Added `isOptionExist` prop (optional override for the built-in duplicate-check logic). Used to exclude the pinned `$launchOwner` option from blocking "+ New Item" when user types "Owner".

**`breadcrumbs.jsx` / `breadcrumbs.scss`** — Added `getKeyIcon` prop to `Breadcrumbs`. When provided, renders an icon before the key label. Styled with `display: flex` on key containers and color-inherited SVG fill.

**`componentHealthCheckLegend.jsx` / `componentHealthCheckTable.jsx`** — Pass `getKeyIcon` to `Breadcrumbs` to render the owner icon next to the breadcrumb label when the active level is `$launchOwner`.

**attributesFieldArrayControl.jsx**:
- Removed `normalizeLevelValue` (was incorrectly converting any real "Owner" attribute to `$launchOwner`).
- Added `owner-selected-overlay` — an absolutely-positioned visual overlay showing the owner icon + "Owner" label on top of the input when `$launchOwner` is selected; hidden on `:focus-within` so the user can still interact with the field.
- Added `getOwnerLevelBlurHandler` — passed as `onBlur` to `FieldProvider`. Calls `e.preventDefault()` when the stored value is `$launchOwner` and `e.target.value === "Owner"`, which prevents redux-form from dispatching blur and overwriting the store with the display string.
- Added `isOptionExist` override in `getOwnerLevelProps` to allow "+ New Item" when typing "Owner" (skips the pinned option from the duplicate check).

**`attributesFieldArrayControl.scss`** — Added `.owner-value-wrap`, `.owner-selected-overlay` and `.owner-icon` styles.

## Links
[EPMRPP-116867](https://jiraeu.epam.com/browse/EPMRPP-116867)

## Visuals

https://github.com/user-attachments/assets/fe1009d4-4c67-4210-815f-e9a7d5ecd73e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation components now support rendering optional icons next to each item label, providing improved visual distinction
  * Owner-level breadcrumb items display a dedicated icon indicator for enhanced clarity and identification

* **UI/Style Updates**
  * Enhanced breadcrumb styling to properly align and render icons alongside breadcrumb text and labels
  * Added visual feedback overlay to owner-level attribute input controls for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->