### PR TITLE
EPMRPP-116863 || Show ellipsis for long test names in side panels and manual launch executions table

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.scss
@@ -22,26 +22,26 @@
   & [class*='bubbles-loader']:nth-child(2) {
     padding: 24px;
   }
-}
 
-.title-wrapper {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-
-  .title-business-id {
-    flex-shrink: 0;
-    font-family: $FONT-ROBOTO-MEDIUM;
-    font-size: 13px;
-    font-weight: 500;
-    line-height: 20px;
-    padding-left: 1px;
-    letter-spacing: 0;
-    color: var(--Text-Secondary, var(--rp-ui-base-e-400));
+  .header-title-wrapper {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+    max-width: 100%;
   }
 
-  .title-name {
+  .priority-icon {
+    flex-shrink: 0;
+  }
+
+  .header-title {
+    flex: 1;
+    min-width: 0;
     font-size: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 
@@ -80,7 +80,7 @@
 
   &:hover {
     text-decoration: none;
-    color: var(--rp-ui-base-topaz-hover)
+    color: var(--rp-ui-base-topaz-hover);
   }
 }
 

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
@@ -148,13 +148,18 @@ export const ExecutionSidePanel = ({ executionId, onClose }: ExecutionSidePanelP
     );
   };
 
-  const titleComponent = (
-    <div className={cx('title-wrapper')}>
+  const headerComponent = (
+    <div className={cx('header-title-wrapper')}>
       {executionDetails?.testCasePriority && (
-        <PriorityIcon priority={executionDetails.testCasePriority} />
+        <PriorityIcon
+          priority={executionDetails.testCasePriority}
+          className={cx('priority-icon')}
+        />
       )}
       {executionDetails?.testCaseName && (
-        <span className={cx('title-name')}>{executionDetails.testCaseName}</span>
+        <span className={cx('header-title')} title={executionDetails.testCaseName}>
+          {executionDetails.testCaseName}
+        </span>
       )}
     </div>
   );
@@ -341,7 +346,7 @@ export const ExecutionSidePanel = ({ executionId, onClose }: ExecutionSidePanelP
     <div ref={sidePanelRef}>
       <SidePanel
         className={cx('execution-side-panel')}
-        title={isLoading ? <BubblesLoader /> : titleComponent}
+        headerComponent={isLoading ? <BubblesLoader /> : headerComponent}
         descriptionComponent={isLoading ? <BubblesLoader /> : descriptionComponent}
         contentComponent={isLoading ? <BubblesLoader /> : contentComponent}
         footerComponent={isLoading ? <BubblesLoader /> : footerComponent}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.scss
@@ -108,6 +108,10 @@ $sidebar-width: calc(100vw - 408px);
   }
 
   :global([class*='_cell_']) {
+    &:first-child {
+      min-width: 0;
+    }
+
     &:not(:first-child) {
       display: flex;
       align-items: center;
@@ -124,16 +128,27 @@ $sidebar-width: calc(100vw - 408px);
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .first-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
-.test-name,
+.priority-icon {
+  flex-shrink: 0;
+}
+
 .test-name-link {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: var(--rp-ui-base-font-family);
   font-weight: var(--rp-ui-base-fw-medium);
   font-size: 13px;
@@ -141,6 +156,10 @@ $sidebar-width: calc(100vw - 408px);
   color: var(--rp-ui-base-almost-black);
   cursor: pointer;
   transition: color 0.2s ease-in-out;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
 
   &:hover {
     color: var(--rp-ui-base-topaz);
@@ -149,13 +168,6 @@ $sidebar-width: calc(100vw - 408px);
   &:active {
     color: var(--rp-ui-base-topaz-pressed);
   }
-}
-
-.test-name-link {
-  background: none;
-  border: none;
-  padding: 0;
-  text-align: left;
 
   &:focus-visible {
     outline: 2px solid var(--rp-ui-base-topaz-focused);
@@ -213,6 +225,8 @@ $sidebar-width: calc(100vw - 408px);
   cursor: pointer;
   display: block;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .execution-status-cell {

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.tsx
@@ -214,11 +214,15 @@ export const ManualLaunchExecutions = ({
           >
             <div className={cx('first-row')}>
               {execution.testCasePriority && (
-                <PriorityIcon priority={execution.testCasePriority as TestCasePriority} />
+                <PriorityIcon
+                  priority={execution.testCasePriority as TestCasePriority}
+                  className={cx('priority-icon')}
+                />
               )}
               <button
                 type="button"
                 className={cx('test-name-link')}
+                title={execution.testCaseName}
                 onClick={handleTestNameLinkClick}
               >
                 {execution.testCaseName}

--- a/app/src/pages/inside/testPlansPage/testPlanSidePanel/testPlanSidePanel.scss
+++ b/app/src/pages/inside/testPlansPage/testPlanSidePanel/testPlanSidePanel.scss
@@ -24,26 +24,28 @@
     }
   }
 
-  .priority-icon {
-    flex-shrink: 0;
-    margin-top: 8px;
-  }
-
-  .test-plan-title {
+  .header-title-wrapper {
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
+    max-width: 100%;
+  }
 
-    .priority-icon {
-      margin-top: 0;
-    }
+  .header-title {
+    flex: 1;
+    min-width: 0;
+    font-family: $FONT-REGULAR;
+    font-size: 20px;
+    line-height: 31px;
+    color: var(--rp-ui-base-almost-black);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    span {
-      font-family: $FONT-REGULAR;
-      font-size: 20px;
-      line-height: 31px;
-      color: var(--rp-ui-base-almost-black);
-    }
+  .priority-icon {
+    flex-shrink: 0;
   }
 
   .description-wrapper {

--- a/app/src/pages/inside/testPlansPage/testPlanSidePanel/testPlanSidePanel.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanSidePanel/testPlanSidePanel.tsx
@@ -169,10 +169,12 @@ export const TestPlanSidePanel = memo(
       });
     };
 
-    const titleComponent = (
-      <div className={cx('test-plan-title')}>
+    const headerComponent = (
+      <div className={cx('header-title-wrapper')}>
         <PriorityIcon priority={testCaseDetails?.priority} className={cx('priority-icon')} />
-        <span>{testPlan.name}</span>
+        <span className={cx('header-title')} title={testPlan.name}>
+          {testPlan.name}
+        </span>
       </div>
     );
 
@@ -301,7 +303,7 @@ export const TestPlanSidePanel = memo(
       <div ref={sidePanelRef}>
         <SidePanel
           className={cx('test-plan-side-panel')}
-          title={titleComponent}
+          headerComponent={headerComponent}
           descriptionComponent={isLoading ? <BubblesLoader /> : descriptionComponent}
           contentComponent={isLoading ? <BubblesLoader /> : contentComponent}
           footerComponent={footerComponent}


### PR DESCRIPTION
## Problem

Long test case names were clipped without an ellipsis (`...`) in TMS views:

- **Milestones** — opening a test case in the test plan side panel
- **Manual Launches** — execution list on the launch details page and the execution side panel

The test case table on Milestones already used `TestCaseNameCell` with correct truncation. Manual Launches uses a custom name cell and side panel headers with a priority icon, where flex layout prevented `text-overflow: ellipsis` from applying.

## Solution

Apply the same truncation pattern used elsewhere in TMS (`min-width: 0` on flex children + `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap`):

- **Side panels** — render the title via `SidePanel` `headerComponent` with local `header-title-wrapper` / `header-title` classes (ui-kit Storybook pattern) instead of a custom React node in `title`, which bypasses built-in ellipsis when a priority icon is present
- **Manual launch executions table** — add ellipsis styles to `.test-name-link` and allow the name column to shrink in the table layout
- Add native `title` tooltips on truncated names so the full text remains available on hover

## Visuals

**Manual Launches**
<img width="1550" height="985" alt="image" src="https://github.com/user-attachments/assets/0c431dcf-821c-46ee-85f5-6a6f2878c804" />

**Milestones**
<img width="1280" height="983" alt="image" src="https://github.com/user-attachments/assets/ec441eb3-5c78-4131-a936-9285948954d7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text truncation and layout constraints in side panel headers for better handling of long names.
  * Enhanced tooltip behavior for test case and test plan names in execution details.
  * Refined priority icon styling and alignment in header sections.
  * Optimized text overflow handling to prevent layout disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->