### PR TITLE
EPMRPP-114877 || Sort plugins

### DIFF
--- a/app/src/common/constants/pluginsFilter.jsx
+++ b/app/src/common/constants/pluginsFilter.jsx
@@ -37,6 +37,10 @@ const PLUGINS_FILTER_LIST = [
     label: <FormattedMessage id={'PluginsFilter.installed'} defaultMessage={'Installed'} />,
   },
   {
+    value: AUTHORIZATION_GROUP_TYPE,
+    label: <FormattedMessage id={'PluginsFilter.auth'} defaultMessage={'Authorization'} />,
+  },
+  {
     value: BTS_GROUP_TYPE,
     label: <FormattedMessage id={'PluginsFilter.bts'} defaultMessage={'Bug Tracking Systems'} />,
   },
@@ -47,10 +51,6 @@ const PLUGINS_FILTER_LIST = [
   {
     value: IMPORT_GROUP_TYPE,
     label: <FormattedMessage id={'PluginsFilter.import'} defaultMessage={'Launches Import'} />,
-  },
-  {
-    value: AUTHORIZATION_GROUP_TYPE,
-    label: <FormattedMessage id={'PluginsFilter.auth'} defaultMessage={'Authorization'} />,
   },
   {
     value: OTHER_GROUP_TYPE,

--- a/app/src/pages/instance/pluginsPage/pluginsTabs/installedTab/installedTab.jsx
+++ b/app/src/pages/instance/pluginsPage/pluginsTabs/installedTab/installedTab.jsx
@@ -21,7 +21,11 @@ import { injectIntl, defineMessages } from 'react-intl';
 import classNames from 'classnames/bind';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
-import { getPluginsFilter, INSTALLED_GROUP_TYPE } from 'common/constants/pluginsFilter';
+import {
+  getPluginsFilter,
+  INSTALLED_GROUP_TYPE,
+  PLUGIN_FILTER_GROUP_VALUES,
+} from 'common/constants/pluginsFilter';
 import { ALL_GROUP_TYPE, AVAILABLE_PLUGINS_TYPE } from 'common/constants/pluginsGroupTypes';
 import { updatePluginSuccessAction } from 'controllers/plugins';
 import { disablePluginPopupContentSelector } from 'controllers/plugins/uiExtensions';
@@ -45,9 +49,23 @@ import styles from './installedTab.scss';
 import { PluginsFilter } from '../../pluginsFilter';
 import { PluginsListItems } from '../../pluginsListItems';
 import { ActionPanel } from '../../actionPanel';
-import { AVAILABLE_PLUGINS_CATALOG } from '../../availablePluginsCatalog';
+import { AVAILABLE_PLUGINS_CATALOG, PLUGIN_TIERS } from '../../availablePluginsCatalog';
 
 const cx = classNames.bind(styles);
+
+const groupRank = (groupType) => {
+  const idx = PLUGIN_FILTER_GROUP_VALUES.indexOf(groupType);
+  return idx < 0 ? PLUGIN_FILTER_GROUP_VALUES.length : idx;
+};
+
+const getDisplayName = ({ details, name }) => details?.name || name || '';
+
+const sortByGroupAndName = (a, b) =>
+  groupRank(a.groupType) - groupRank(b.groupType) ||
+  getDisplayName(a).localeCompare(getDisplayName(b));
+
+const sortByTierGroupAndName = (a, b) =>
+  (a.tier !== PLUGIN_TIERS.PREMIUM) - (b.tier !== PLUGIN_TIERS.PREMIUM) || sortByGroupAndName(a, b);
 
 const messages = defineMessages({
   disabledPluginMessage: {
@@ -287,11 +305,12 @@ export class InstalledTab extends Component {
   getInstalledPluginsList = (activeFilterItem) => {
     const { plugins } = this.props;
 
-    if (activeFilterItem === ALL_GROUP_TYPE || activeFilterItem === INSTALLED_GROUP_TYPE) {
-      return plugins;
-    }
+    const filtered =
+      activeFilterItem === ALL_GROUP_TYPE || activeFilterItem === INSTALLED_GROUP_TYPE
+        ? plugins
+        : plugins.filter((item) => item.groupType === activeFilterItem);
 
-    return plugins.filter((item) => item.groupType === activeFilterItem);
+    return [...filtered].sort(sortByGroupAndName);
   };
 
   getAvailablePluginsList = (activeFilterItem) => {
@@ -301,11 +320,13 @@ export class InstalledTab extends Component {
 
     const installedNames = this.props.plugins.map((plugin) => plugin.name);
 
-    return AVAILABLE_PLUGINS_CATALOG.filter(
+    const filtered = AVAILABLE_PLUGINS_CATALOG.filter(
       (entry) =>
         !installedNames.includes(entry.name) &&
         (activeFilterItem === ALL_GROUP_TYPE || entry.groupType === activeFilterItem),
     );
+
+    return [...filtered].sort(sortByTierGroupAndName);
   };
 
   generateOptions = () =>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**`pluginsFilter.jsx`**
- Reordered `PLUGINS_FILTER_LIST` to: All → Installed → Authorization → BTS → Notifications → Launches Import → Other.
- `PLUGIN_FILTER_GROUP_VALUES` (derived from the same list) now reflects this order automatically.

**`installedTab.jsx`**
- Added two sort comparators driven by `PLUGIN_FILTER_GROUP_VALUES` as the single source of truth for group order:
  - `sortByGroupAndName` — group order → alphabetical (used for **Installed**).
  - `sortByTierGroupAndName` — Premium first → group order → alphabetical (used for **Available to install**).
 
## Links
[EPMRPP-114877](https://jiraeu.epam.com/browse/EPMRPP-114877)

## Visuals
<img width="1428" height="932" alt="Screenshot 2026-06-23 100657" src="https://github.com/user-attachments/assets/9959069a-0b33-42a7-9888-d5bbe22a45e6" />
<img width="1400" height="764" alt="Screenshot 2026-06-23 100732" src="https://github.com/user-attachments/assets/c81e694c-538b-485d-84d4-ffc7d6830a67" />
<img width="1392" height="641" alt="Screenshot 2026-06-23 100745" src="https://github.com/user-attachments/assets/a6b2575c-b772-4971-8d77-fc82e39ea433" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized plugin filter options for improved navigation
  * Implemented sorting for installed and available plugins by category and name
  * Available plugins now sorted by tier to prioritize premium options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->