### PR TITLE
 EPMRPP-117068 || Migrate issue tooltip getIssue to POST /api/plugins/.../commands

### DIFF
--- a/app/src/pages/inside/common/adaptiveIssueList/hooks.js
+++ b/app/src/pages/inside/common/adaptiveIssueList/hooks.js
@@ -17,7 +17,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { pluginByNameSelector, isPluginSupportsCommonCommand } from 'controllers/plugins';
+import { buildPluginCommandRQ } from 'controllers/plugins/utils';
 import { COMMAND_GET_ISSUE } from 'controllers/plugins/uiExtensions/constants';
+import { activeOrganizationIdSelector } from 'controllers/organization';
 import { projectInfoIdSelector, projectKeySelector } from 'controllers/project';
 import { getStorageItem, updateStorageItem } from 'common/utils';
 import { ERROR_CANCELED, fetch } from 'common/utils/fetch';
@@ -36,6 +38,7 @@ const getStoredIssueData = (projectKey, btsProject, ticketId) => {
 export const useIssueInfo = (issue, pluginName) => {
   const projectKey = useSelector(projectKeySelector);
   const projectId = useSelector(projectInfoIdSelector);
+  const organizationId = useSelector(activeOrganizationIdSelector);
   const plugin = useSelector((state) => pluginByNameSelector(state, pluginName));
 
   const { ticketId, btsProject, btsUrl } = issue;
@@ -73,25 +76,30 @@ export const useIssueInfo = (issue, pluginName) => {
     const isCommonCommandSupported =
       plugin && isPluginSupportsCommonCommand(plugin, COMMAND_GET_ISSUE);
     let url;
-    let data;
+    let requestParams = { abort: cancelRequestFunc };
 
     if (isCommonCommandSupported) {
-      url = URLS.pluginCommandCommon(projectKey, plugin.name, COMMAND_GET_ISSUE);
-      data = {
-        ticketId,
-        url: btsUrl,
-        project: btsProject,
-        projectId,
+      url = URLS.pluginsCommandsCommon(plugin.name, COMMAND_GET_ISSUE);
+      requestParams = {
+        ...requestParams,
+        method: 'POST',
+        data: buildPluginCommandRQ({
+          organizationId,
+          projectId,
+          projectKey,
+          arguments: {
+            ticketId,
+            url: btsUrl,
+            project: btsProject,
+          },
+        }),
       };
     } else {
       url = URLS.btsTicket(projectKey, ticketId, btsProject, btsUrl);
+      requestParams = { ...requestParams, method: 'GET' };
     }
 
-    fetch(url, {
-      method: isCommonCommandSupported ? 'PUT' : 'GET',
-      data,
-      abort: cancelRequestFunc,
-    })
+    fetch(url, requestParams)
       .then((fetchedIssue) => {
         updateIssueInStorage({ issue: fetchedIssue, lastTime: Date.now() });
         setState({ issueInfo: fetchedIssue, loading: false, error: false });
@@ -103,7 +111,16 @@ export const useIssueInfo = (issue, pluginName) => {
         updateIssueInStorage({ lastTime: Date.now() });
         setState((prev) => ({ ...prev, loading: false, error: true }));
       });
-  }, [projectKey, btsProject, btsUrl, plugin, projectId, ticketId, updateIssueInStorage]);
+  }, [
+    projectKey,
+    btsProject,
+    btsUrl,
+    plugin,
+    projectId,
+    organizationId,
+    ticketId,
+    updateIssueInStorage,
+  ]);
 
   useEffect(() => {
     if (shouldFetchRef.current) {

--- a/app/src/pages/inside/stepPage/stepGrid/defectType/issueList/issue/issueInfoTooltip/issueInfoTooltip.jsx
+++ b/app/src/pages/inside/stepPage/stepGrid/defectType/issueList/issue/issueInfoTooltip/issueInfoTooltip.jsx
@@ -21,7 +21,9 @@ import { connect } from 'react-redux';
 import { defineMessages, injectIntl } from 'react-intl';
 import { URLS } from 'common/urls';
 import { pluginByNameSelector, isPluginSupportsCommonCommand } from 'controllers/plugins';
+import { buildPluginCommandRQ } from 'controllers/plugins/utils';
 import { COMMAND_GET_ISSUE } from 'controllers/plugins/uiExtensions/constants';
+import { activeOrganizationIdSelector } from 'controllers/organization';
 import { projectInfoIdSelector, projectKeySelector } from 'controllers/project';
 import { getStorageItem, updateStorageItem } from 'common/utils';
 import { ERROR_CANCELED, fetch } from 'common/utils/fetch';
@@ -60,12 +62,14 @@ const FETCH_ISSUE_INTERVAL = 900000; // min request interval = 15 min
   projectKey: projectKeySelector(state),
   plugin: pluginByNameSelector(state, ownProps.pluginName),
   projectId: projectInfoIdSelector(state),
+  organizationId: activeOrganizationIdSelector(state),
 }))
 @injectIntl
 export class IssueInfoTooltip extends Component {
   static propTypes = {
     intl: PropTypes.object.isRequired,
     projectId: PropTypes.number.isRequired,
+    organizationId: PropTypes.number,
     ticketId: PropTypes.string.isRequired,
     btsProject: PropTypes.string.isRequired,
     btsUrl: PropTypes.string.isRequired,
@@ -75,6 +79,7 @@ export class IssueInfoTooltip extends Component {
 
   static defaultProps = {
     plugin: null,
+    organizationId: null,
   };
 
   constructor(props) {
@@ -126,7 +131,8 @@ export class IssueInfoTooltip extends Component {
   };
 
   fetchData = () => {
-    const { projectId, ticketId, btsProject, btsUrl, plugin, projectKey } = this.props;
+    const { projectId, ticketId, btsProject, btsUrl, plugin, projectKey, organizationId } =
+      this.props;
     const cancelRequestFunc = (cancel) => {
       this.cancelRequest = cancel;
     };
@@ -134,25 +140,30 @@ export class IssueInfoTooltip extends Component {
     const isCommonCommandSupported =
       plugin && isPluginSupportsCommonCommand(plugin, COMMAND_GET_ISSUE);
     let url;
-    let data;
+    let requestParams = { abort: cancelRequestFunc };
 
     if (isCommonCommandSupported) {
-      url = URLS.pluginCommandCommon(projectKey, plugin.name, COMMAND_GET_ISSUE);
-      data = {
-        ticketId,
-        url: btsUrl,
-        project: btsProject,
-        projectId,
+      url = URLS.pluginsCommandsCommon(plugin.name, COMMAND_GET_ISSUE);
+      requestParams = {
+        ...requestParams,
+        method: 'POST',
+        data: buildPluginCommandRQ({
+          organizationId,
+          projectId,
+          projectKey,
+          arguments: {
+            ticketId,
+            url: btsUrl,
+            project: btsProject,
+          },
+        }),
       };
     } else {
       url = URLS.btsTicket(projectKey, ticketId, btsProject, btsUrl);
+      requestParams = { ...requestParams, method: 'GET' };
     }
 
-    fetch(url, {
-      method: isCommonCommandSupported ? 'PUT' : 'GET',
-      data,
-      abort: cancelRequestFunc,
-    })
+    fetch(url, requestParams)
       .then((issue) => {
         this.updateIssueInStorage({ issue, lastTime: Date.now() });
         this.setState({ loading: false, issue });


### PR DESCRIPTION
## Summary

Migrates `getIssue` calls in the issue tooltip and adaptive issue list from the deprecated plugin common-command endpoint to the new plugin commands API introduced in EPMRPP-115266.

After BTS plugins dropped legacy `getCommonCommand` handlers, hovering over an Issue ID on the Step page returned "Issue not found" because the UI still called `PUT /api/v1/plugin/{projectKey}/{pluginName}/common/getIssue`, which responds with `Command 'getIssue' is not found`.

This change aligns the remaining `getIssue` consumers with the migration already done for post-issue flows, autocomplete fields, and BTS properties form.

## Changes

- Replace `URLS.pluginCommandCommon` + `PUT` with `URLS.pluginsCommandsCommon` + `POST`
- Build request body via `buildPluginCommandRQ` with `context` (`project_id`, `org_id`) and command `arguments` (`ticketId`, `url`, `project`)
- Pass `organizationId` from Redux where required by `buildPluginCommandRQ`
- Keep the existing `btsTicket` GET fallback for plugins that do not expose the `getIssue` common command

## Related tickets

- EPMRPP-117068
- EPMRPP-115266 (parent story: UI migration to plugin commands API)

## Dependencies

Requires the companion service-api fix that enriches `arguments.projectId` from `context.project_id` as `Long` before plugin execution. Without it, the new endpoint returns HTTP 500 (`Integer cannot be cast to Long`) for BTS plugins that read `projectId` from command arguments.
