### PR TITLE
EPMRPP-117004 || 403 error when unassigning yourself from an Organization as a Manager

### DIFF
--- a/app/src/pages/organization/organizationUsersPage/organizationUsersListTable/organizationUsersActionMenu/organizationUsersActionMenu.tsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersListTable/organizationUsersActionMenu/organizationUsersActionMenu.tsx
@@ -50,10 +50,10 @@ export const OrganizationUsersActionMenu = ({ user }: OrganizationUsersActionMen
   const canUnassign = useCanUnassignOrganization();
 
   const onUnassign = useCallback(() => {
-    dispatch(fetchOrganizationUsersAction(organization.id));
-
     if (currentUserId === user.id && !isAdmin) {
       dispatch(redirect({ type: ORGANIZATIONS_PAGE }));
+    } else {
+      dispatch(fetchOrganizationUsersAction(organization.id));
     }
   }, [currentUserId, dispatch, organization.id, user.id, isAdmin]);
 


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
The list of organization users is not refreshed when a non-admin user unassigns themselves.

## Links
[EPMRPP-117004](https://jiraeu.epam.com/browse/EPMRPP-117004)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the unassign flow for organization users.
  * When removing the current non-admin user, the app now redirects immediately to the organizations page and avoids an unnecessary refresh.
  * In other cases, organization users continue to refresh as expected after unassigning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->