### PR TITLE
EPMRPP-115157 || Migrate integration test connection to plugin commands endpoint

### DIFF
--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -168,8 +168,6 @@ export const URLS = {
     `${urlCommonBase}organizations/${organizationId}/integrations${getQueryParams({ type })}`,
   organizationIntegrationById: (organizationId, integrationId) =>
     `${urlCommonBase}organizations/${organizationId}/integrations/${integrationId}`,
-  testOrganizationIntegrationConnection: (organizationId, integrationId) =>
-    `${urlCommonBase}organizations/${organizationId}/integrations/${integrationId}/connection`,
 
   projectByName: (projectKey) => `${urlBase}project/${projectKey}`,
   project: (ids = []) => `${urlBase}project?ids=${ids.join(',')}`,
@@ -367,10 +365,6 @@ export const URLS = {
   globalIntegration: (integrationId) => `${urlBase}integration/${integrationId}`,
   removeProjectIntegrationByType: (projectKey, type) =>
     `${urlBase}integration/${projectKey}/all/${type}`,
-  testIntegrationConnection: (projectKey, integrationId) =>
-    `${urlBase}integration/${projectKey}/${integrationId}/connection/test`,
-  testGlobalIntegrationConnection: (integrationId) =>
-    `${urlBase}integration/${integrationId}/connection/test`,
   pluginFileImport: (projectKey, pluginName) =>
     `${urlBase}plugin/${projectKey}/${pluginName}/import`,
 

--- a/app/src/components/integrations/elements/integrationSettings/integrationSettings.jsx
+++ b/app/src/components/integrations/elements/integrationSettings/integrationSettings.jsx
@@ -19,8 +19,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import { BubblesLoader } from '@reportportal/ui-kit';
-import { fetch } from 'common/utils';
-import { URLS } from 'common/urls';
 import { LDAP } from 'common/constants/pluginNames';
 import { omit } from 'common/utils/omit';
 import {
@@ -28,12 +26,14 @@ import {
   querySelector,
   PROJECT_SETTINGS_TAB_PAGE,
 } from 'controllers/pages';
-import { projectKeySelector } from 'controllers/project';
+import { projectInfoIdSelector, projectKeySelector } from 'controllers/project';
+import { activeOrganizationIdSelector } from 'controllers/organization';
 import {
   removeIntegrationAction,
   namedGlobalIntegrationsSelector,
   namedProjectIntegrationsSelector,
 } from 'controllers/plugins';
+import { getTestIntegrationConnection } from 'controllers/plugins/utils';
 import { INTEGRATIONS } from 'common/constants/settingsTabs';
 import { redirect } from 'redux-first-router';
 import { INTEGRATION_FORM } from './integrationForm/constants';
@@ -45,12 +45,28 @@ import { useUserPermissions } from 'hooks/useUserPermissions';
 const cx = classNames.bind(styles);
 
 export const IntegrationSettings = (props) => {
+  const {
+    data,
+    onUpdate,
+    formFieldsComponent,
+    editAuthConfig,
+    isEmptyConfiguration,
+    formKey,
+    isGlobal,
+    goToPreviousPage,
+    isOrganizational = false,
+    preventTestConnection = false,
+  } = props;
+  const pluginName = data.integrationType?.name;
+
   const [connected, setConnected] = useState(true);
-  const [loading, setLoading] = useState(!props.data.isNew && !props.preventTestConnection);
+  const [loading, setLoading] = useState(!data.isNew && !preventTestConnection);
   const globalIntegrations = useSelector(namedGlobalIntegrationsSelector);
   const projectIntegrations = useSelector(namedProjectIntegrationsSelector);
   const { organizationSlug, projectSlug } = useSelector(urlOrganizationAndProjectSelector);
+  const projectId = useSelector(projectInfoIdSelector);
   const projectKey = useSelector(projectKeySelector);
+  const organizationId = useSelector(activeOrganizationIdSelector);
   const { canUpdateSettings } = useUserPermissions();
   const query = useSelector(querySelector);
   const dispatch = useDispatch();
@@ -74,14 +90,17 @@ export const IntegrationSettings = (props) => {
   );
 
   const testIntegrationConnection = useCallback(() => {
-    if ('id' in props.data && !props.preventTestConnection) {
+    if ('id' in data && !preventTestConnection && pluginName) {
       setLoading(true);
-      const { isGlobal } = props;
-      const fetchConnection = isGlobal
-        ? fetch(URLS.testGlobalIntegrationConnection(props.data.id))
-        : fetch(URLS.testIntegrationConnection(projectKey, props.data.id));
 
-      fetchConnection
+      const fetchConnection = getTestIntegrationConnection({
+        pluginName,
+        isGlobal,
+        isOrganizational,
+        context: { projectId, projectKey, organizationId },
+      });
+
+      fetchConnection(data.id)
         .then(() => {
           setConnected(true);
           setLoading(false);
@@ -91,7 +110,16 @@ export const IntegrationSettings = (props) => {
           setConnected(false);
         });
     }
-  }, [props.data, projectKey, props.preventTestConnection]);
+  }, [
+    data,
+    preventTestConnection,
+    isGlobal,
+    isOrganizational,
+    pluginName,
+    projectKey,
+    projectId,
+    organizationId,
+  ]);
 
   useEffect(() => {
     const hasId = groupedIntegrations.some((value) => value.id === +query.id);
@@ -101,31 +129,15 @@ export const IntegrationSettings = (props) => {
   }, [query, groupedIntegrations, dispatch, namedSubPage]);
 
   useEffect(() => {
-    if (query.id || props.data) {
+    if (query.id || data) {
       testIntegrationConnection();
     }
-  }, [query.id, props.data, testIntegrationConnection]);
+  }, [query.id, data, testIntegrationConnection]);
 
   const removeIntegration = () => {
-    const {
-      data: { id },
-      isGlobal,
-      goToPreviousPage,
-    } = props;
-
-    dispatch(removeIntegrationAction(id, isGlobal, goToPreviousPage));
+    dispatch(removeIntegrationAction(data.id, isGlobal, goToPreviousPage));
   };
 
-  const {
-    data,
-    onUpdate,
-    formFieldsComponent,
-    editAuthConfig,
-    isEmptyConfiguration,
-    formKey,
-    isGlobal,
-  } = props;
-  const pluginName = data.integrationType?.name;
   const isLdap = pluginName === LDAP;
 
   return (
@@ -172,6 +184,7 @@ IntegrationSettings.propTypes = {
   preventTestConnection: PropTypes.bool,
   isEmptyConfiguration: PropTypes.bool,
   isGlobal: PropTypes.bool,
+  isOrganizational: PropTypes.bool,
   formKey: PropTypes.string,
 };
 IntegrationSettings.defaultProps = {
@@ -179,5 +192,6 @@ IntegrationSettings.defaultProps = {
   preventTestConnection: false,
   isEmptyConfiguration: false,
   isGlobal: false,
+  isOrganizational: false,
   formKey: INTEGRATION_FORM,
 };

--- a/app/src/components/integrations/integrationProviders/emailIntegration/emailSettings/emailSettings.tsx
+++ b/app/src/components/integrations/integrationProviders/emailIntegration/emailSettings/emailSettings.tsx
@@ -31,7 +31,7 @@ import {
   pageLevelSelector,
   APP_LEVEL,
 } from 'controllers/pages';
-import { projectKeySelector } from 'controllers/project';
+import { projectInfoIdSelector, projectKeySelector } from 'controllers/project';
 import { activeOrganizationIdSelector } from 'controllers/organization';
 import {
   removeIntegrationAction,
@@ -107,6 +107,7 @@ export function EmailSettings({
   const projectIntegrations: NamedIntegrations = useSelector(namedProjectIntegrationsSelector);
   const organizationSlug = useSelector(urlOrganizationSlugSelector);
   const projectSlug = useSelector(urlProjectSlugSelector);
+  const projectId = useSelector(projectInfoIdSelector);
   const projectKey = useSelector(projectKeySelector);
   const organizationId = useSelector(activeOrganizationIdSelector);
   const { canUpdateSettings, canUpdateOrganizationSettings } = useUserPermissions();
@@ -138,14 +139,17 @@ export function EmailSettings({
     [organizationSlug, projectSlug, query, pageLevel],
   );
 
+  const pluginName = data.integrationType?.name ?? query.subPage;
+
   const testConnection = useMemo(
     () =>
       getTestIntegrationConnection({
+        pluginName,
         isGlobal,
         isOrganizational,
-        context: { projectKey, organizationId },
+        context: { projectId, projectKey, organizationId },
       }),
-    [projectKey, organizationId, isGlobal, isOrganizational],
+    [pluginName, projectId, projectKey, organizationId, isGlobal, isOrganizational],
   );
 
   const integrationId = data.id;

--- a/app/src/controllers/plugins/uiExtensions/constants.js
+++ b/app/src/controllers/plugins/uiExtensions/constants.js
@@ -49,6 +49,7 @@ export const COMMAND_GET_ISSUE_FIELDS = 'getIssueFields';
 export const COMMAND_POST_ISSUE = 'postTicket';
 export const COMMAND_GET_ISSUE = 'getIssue';
 export const COMMAND_GET_CLUSTERS = 'getClusters';
+export const COMMAND_TEST_CONNECTION = 'testConnection';
 
 // core files keys
 export const MANIFEST_FILE_KEY = 'metadata';

--- a/app/src/controllers/plugins/utils.js
+++ b/app/src/controllers/plugins/utils.js
@@ -24,6 +24,7 @@ import { AUTHORIZATION_GROUP_TYPE } from 'common/constants/pluginsGroupTypes';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
 import {
+  COMMAND_TEST_CONNECTION,
   PLUGIN_TYPE_EXTENSION,
   PLUGIN_TYPE_REMOTE,
 } from 'controllers/plugins/uiExtensions/constants';
@@ -156,24 +157,24 @@ export const getAddIntegrationSuccessAction = ({ isGlobal, isOrganizational }) =
 };
 
 export const getTestIntegrationConnection = ({
+  pluginName,
   isGlobal = false,
   isOrganizational = false,
   context = {},
 }) => {
-  const { projectKey, organizationId } = context;
+  const { projectId, projectKey, organizationId } = context;
 
-  return (integrationId) => {
-    switch (true) {
-      case isGlobal:
-        return fetch(URLS.testGlobalIntegrationConnection(integrationId));
-      case isOrganizational:
-        return fetch(URLS.testOrganizationIntegrationConnection(organizationId, integrationId), {
-          method: 'POST',
-        });
-      default:
-        return fetch(URLS.testIntegrationConnection(projectKey, integrationId));
-    }
-  };
+  return (integrationId) =>
+    fetch(URLS.pluginsCommandsCommon(pluginName, COMMAND_TEST_CONNECTION), {
+      method: 'POST',
+      data: buildPluginCommandRQ({
+        integrationId,
+        projectId: isOrganizational ? undefined : projectId,
+        projectKey: isOrganizational || isGlobal ? undefined : projectKey,
+        organizationId: isGlobal ? undefined : organizationId,
+        isGlobal,
+      }),
+    });
 };
 
 export const getIntegrationByIdUrl = ({ isGlobal, isOrganizational, id, context }) => {

--- a/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/content/integrations/integrationsList/integrationInfo/integrationInfo.jsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { redirect } from 'redux-first-router';
 import classNames from 'classnames/bind';
@@ -48,10 +48,8 @@ import { PROJECT_SETTINGS_INTEGRATION } from 'analyticsEvents/projectSettingsPag
 import { IntegrationAnalyticsContext } from 'components/integrations/integrationAnalyticsContext';
 import { INTEGRATIONS } from 'common/constants/settingsTabs';
 import { EMAIL } from 'common/constants/pluginNames';
-import { combineNameAndEmailToFrom, fetch } from 'common/utils';
-import { URLS } from 'common/urls';
-import { projectKeySelector } from 'controllers/project';
-import { activeProjectKeySelector } from 'controllers/user';
+import { combineNameAndEmailToFrom } from 'common/utils';
+import { projectInfoIdSelector, projectKeySelector } from 'controllers/project';
 import { useUserPermissions } from 'hooks/useUserPermissions';
 import { IntegrationHeader } from 'pages/inside/common/integrations/integrationHeader';
 import { AvailableIntegrations } from 'pages/inside/common/integrations/availableIntegrations';
@@ -80,8 +78,8 @@ export const IntegrationInfo = (props) => {
   const globalIntegrations = useSelector(namedGlobalIntegrationsSelector);
   const organizationIntegrations = useSelector(namedOrganizationIntegrationsSelector);
   const projectIntegrations = useSelector(namedProjectIntegrationsSelector);
+  const projectId = useSelector(projectInfoIdSelector);
   const projectKey = useSelector(projectKeySelector);
-  const activeProjectKey = useSelector(activeProjectKeySelector);
   const { organizationSlug, projectSlug } = useSelector(urlOrganizationAndProjectSelector);
   const organizationId = useSelector(activeOrganizationIdSelector);
   const dispatch = useDispatch();
@@ -125,15 +123,28 @@ export const IntegrationInfo = (props) => {
     ? formatMessage(messages.projectIntegrationAddLimited)
     : undefined;
 
-  const testIntegrationConnection = useCallback(
-    (integrationId) =>
-      fetch(URLS.testIntegrationConnection(projectKey || activeProjectKey, integrationId)),
-    [projectKey, activeProjectKey],
+  const testProjectIntegrationConnection = useMemo(
+    () =>
+      getTestIntegrationConnection({
+        pluginName,
+        context: { projectId, projectKey, organizationId },
+      }),
+    [pluginName, projectId, projectKey, organizationId],
   );
 
   const testOrganizationIntegrationConnection = useMemo(
-    () => getTestIntegrationConnection({ isOrganizational: true, context: { organizationId } }),
-    [organizationId],
+    () =>
+      getTestIntegrationConnection({
+        pluginName,
+        isOrganizational: true,
+        context: { organizationId },
+      }),
+    [pluginName, organizationId],
+  );
+
+  const testGlobalIntegrationConnection = useMemo(
+    () => getTestIntegrationConnection({ pluginName, isGlobal: true }),
+    [pluginName],
   );
 
   useEffect(() => {
@@ -363,7 +374,7 @@ export const IntegrationInfo = (props) => {
             text={formatMessage(messages.projectIntegrationText)}
             integrations={availableProjectIntegrations}
             openIntegration={openIntegration}
-            testConnection={testIntegrationConnection}
+            testConnection={testProjectIntegrationConnection}
             withEmptyState
             hasUpdatePermission={canUpdateSettings}
             onCreateClick={onAddProjectIntegration}
@@ -391,7 +402,7 @@ export const IntegrationInfo = (props) => {
               openIntegration={openIntegration}
               inactive={Boolean(availableProjectIntegrations.length)}
               inactiveTooltip={formatMessage(messages.inactiveGlobalIntegrations)}
-              testConnection={testIntegrationConnection}
+              testConnection={testGlobalIntegrationConnection}
             />
           )}
         </div>

--- a/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationInfo/integrationInfo.tsx
+++ b/app/src/pages/organization/organizationSettingsPage/content/integrationsTab/integrationInfo/integrationInfo.tsx
@@ -133,13 +133,18 @@ export const IntegrationInfo = ({ plugin, integrationId = '' }: IntegrationInfoP
     : undefined;
 
   const testOrganizationIntegrationConnection = useMemo(
-    () => getTestIntegrationConnection({ isOrganizational: true, context: { organizationId } }),
-    [organizationId],
+    () =>
+      getTestIntegrationConnection({
+        pluginName,
+        isOrganizational: true,
+        context: { organizationId },
+      }),
+    [pluginName, organizationId],
   );
 
   const testGlobalIntegrationConnection = useMemo(
-    () => getTestIntegrationConnection({ isGlobal: true }),
-    [],
+    () => getTestIntegrationConnection({ pluginName, isGlobal: true }),
+    [pluginName],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
Migrated **integration test connection** from legacy per-scope URLs to the unified plugin command endpoint `POST /api/plugins/{pluginName}/commands/testConnection`.

**Core**
- `getTestIntegrationConnection` now requires `pluginName`, calls `pluginsCommandsCommon` with `COMMAND_TEST_CONNECTION`, and builds the request body via `buildPluginCommandRQ` (project / org / global scope via `isGlobal` / `isOrganizational`).
- Removed obsolete URL helpers: `testIntegrationConnection`, `testGlobalIntegrationConnection`, `testOrganizationIntegrationConnection`.
- Added `COMMAND_TEST_CONNECTION` constant.

**Call sites**
- `integrationSettings.jsx` — uses `getTestIntegrationConnection` instead of direct `fetch`; supports org level via `isOrganizational`.
- `emailSettings.tsx` — passes `pluginName` and `projectId` into the helper.
- `integrationInfo.jsx` (project settings) — separate handlers per scope; **fixes global list** using `testGlobalIntegrationConnection` instead of the project handler.
- `integrationInfo.tsx` (org settings) — passes `pluginName` to org/global handlers.

## Links
[EPMRPP-115157](https://jiraeu.epam.com/browse/EPMRPP-115157)

## Visuals
**_Some integrations test connection:_**
<img width="1800" height="622" alt="Screenshot 2026-06-24 161231" src="https://github.com/user-attachments/assets/9e526bce-9dda-4d9e-88d5-2ae80e612d16" />
<img width="1700" height="734" alt="Screenshot 2026-06-24 161252" src="https://github.com/user-attachments/assets/793c0b19-7d29-48f4-a3ac-517ef2c91275" />

**_Test connection for non-admins:_**
<img width="1713" height="944" alt="Screenshot 2026-06-24 161356" src="https://github.com/user-attachments/assets/d223c711-69f4-442a-88d3-4ea8de0226e5" />
<img width="1862" height="941" alt="Screenshot 2026-06-24 161434" src="https://github.com/user-attachments/assets/cc69ed19-cd65-4c6e-beb7-6d3645603977" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration connection checks now work through a shared testing flow across project, organization, and global settings.
  * Email integration testing now uses the current project context for more accurate results.

* **Bug Fixes**
  * Improved connection-test behavior for integrations by handling project, organization, and global scopes more reliably.
  * Updated integration settings and lists to use the same testing behavior, reducing inconsistencies across screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->