### PR TITLE
EPMRPP-117181 || Refresh folder store after duplicate to prevent tree corruption

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/hooks/useFolderOperationUI.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/hooks/useFolderOperationUI.ts
@@ -23,6 +23,7 @@ import { getFoldersAction } from 'controllers/testCase/actionCreators';
 
 interface UseFolderOperationUIParams {
   fromDragDrop: boolean;
+  skipFolderRefresh?: boolean;
   successMessageId?: NotificationMessageKey;
   messageValues?: Record<string, string | number>;
 }
@@ -42,8 +43,13 @@ export const useFolderOperationUI = () => {
   );
 
   const handleOperationSuccess = useCallback(
-    ({ fromDragDrop, successMessageId, messageValues }: UseFolderOperationUIParams) => {
-      if (fromDragDrop) {
+    ({
+      fromDragDrop,
+      skipFolderRefresh,
+      successMessageId,
+      messageValues,
+    }: UseFolderOperationUIParams) => {
+      if (fromDragDrop && !skipFolderRefresh) {
         dispatch(getFoldersAction({ silent: true }));
         if (successMessageId) {
           showSuccessNotification({ messageId: successMessageId, values: messageValues });

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/useDuplicateFolder.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/useDuplicateFolder.ts
@@ -92,6 +92,8 @@ export const useDuplicateFolder = () => {
         dispatch(fetchSuccessAction(NAMESPACE, { content: updatedFolders }));
       } catch {
         handleOperationError({ fromDragDrop: isDragDropOperation });
+
+        return;
       }
 
       const { folderName: originalFolderName, targetFolderName } = getFolderNames(

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/useDuplicateFolder.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/useDuplicateFolder.ts
@@ -16,17 +16,17 @@
 
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { isEmpty, isNil } from 'es-toolkit/compat';
+import { isNil } from 'es-toolkit/compat';
 
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
+import { fetchSuccessAction } from 'controllers/fetch';
 import { projectKeySelector } from 'controllers/project';
-import { createFoldersBatchSuccessAction } from 'controllers/testCase/actionCreators';
+import { NAMESPACE } from 'controllers/testCase/constants';
 import { foldersSelector } from 'controllers/testCase';
 import { Folder } from 'controllers/testCase/types';
 import { fetchAllFolders } from 'controllers/testCase/utils/fetchAllFolders';
 
-import { useFolderActions } from '../../../hooks/useFolderActions';
 import { useNavigateToFolder } from '../../../hooks/useNavigateToFolder';
 import { useFolderOperationUI } from '../../../hooks/useFolderOperationUI';
 import { getFolderNames } from '../../../utils/getFolderNames';
@@ -42,7 +42,6 @@ export const useDuplicateFolder = () => {
   const dispatch = useDispatch();
   const projectKey = useSelector(projectKeySelector);
   const allFolders = useSelector(foldersSelector);
-  const { createNewStoreFolder } = useFolderActions();
   const { navigateToFolderAfterAction } = useNavigateToFolder();
 
   const duplicateFolder = useCallback(
@@ -87,13 +86,13 @@ export const useDuplicateFolder = () => {
         return;
       }
 
-      createNewStoreFolder({
-        id: duplicatedFolder.id,
-        folderName: duplicatedFolder.name,
-        parentFolderId: duplicatedFolder.parentFolderId,
-        countOfTestCases: duplicatedFolder.countOfTestCases,
-        index: duplicatedFolder.index,
-      });
+      try {
+        const updatedFolders = await fetchAllFolders({ projectKey });
+
+        dispatch(fetchSuccessAction(NAMESPACE, { content: updatedFolders }));
+      } catch {
+        handleOperationError({ fromDragDrop: isDragDropOperation });
+      }
 
       const { folderName: originalFolderName, targetFolderName } = getFolderNames(
         allFolders,
@@ -103,25 +102,13 @@ export const useDuplicateFolder = () => {
 
       handleOperationSuccess({
         fromDragDrop: isDragDropOperation,
+        skipFolderRefresh: true,
         successMessageId: 'testCaseFolderDuplicatedSuccess',
         messageValues: {
           folderName: originalFolderName,
           targetFolderName,
         },
       });
-
-      try {
-        const subfolders = await fetchAllFolders({
-          projectKey,
-          filters: { 'filter.eq.parentId': duplicatedFolder.id },
-        });
-
-        if (!isEmpty(subfolders)) {
-          dispatch(createFoldersBatchSuccessAction(subfolders));
-        }
-      } catch {
-        handleOperationError({ fromDragDrop: isDragDropOperation });
-      }
 
       navigateToFolderAfterAction({
         targetFolderId: duplicatedFolder.id,
@@ -137,7 +124,6 @@ export const useDuplicateFolder = () => {
       handleOperationStart,
       handleOperationSuccess,
       handleOperationError,
-      createNewStoreFolder,
       navigateToFolderAfterAction,
       showErrorNotification,
       allFolders,


### PR DESCRIPTION
## Problem

After duplicating a folder that has subfolders in Test Case Library, the folder tree in the left sidebar becomes corrupted: overlapping folder names, broken hierarchy, and duplicate entries. A full page refresh restores the correct tree.

**Steps to reproduce:** Test Case Library → right-click a folder with subfolders → Duplicate folder → Create → observe the Folders tree.

**Root cause:** `useDuplicateFolder` updated the Redux store incrementally: it appended the duplicated root folder via `createNewStoreFolder`, then appended direct children via `createFoldersBatchSuccessAction`. The reducer does not deduplicate by folder ID. For drag-and-drop duplicate, `useFolderOperationUI` also dispatched `getFoldersAction({ silent: true })`, which could race with the batch append and leave duplicate folder IDs in `folders.data`. The virtualized folder tree uses `key={folder.id}`; duplicate IDs in the flat list caused React reconciliation issues and overlapping rows.

## Solution

After a successful duplicate API call, replace the folder list in the store with a full refetch from the server (same outcome as a page refresh). Remove incremental `createNewStoreFolder` and `createFoldersBatchSuccessAction` updates.

For drag-and-drop duplicate, pass `skipFolderRefresh: true` to `handleOperationSuccess` so the hook does not trigger a second concurrent `getFoldersAction`.

## Visuals

https://github.com/user-attachments/assets/d82eaee1-2181-4ebd-bd37-12a8e80b50fe



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder duplication now refreshes the folder list more reliably, helping ensure the copied folder and its contents appear correctly.
  * Drag-and-drop folder actions now avoid unnecessary refreshes in some cases, reducing duplicate updates and improving responsiveness.

* **New Features**
  * Improved folder operation handling so certain actions can skip an automatic refresh when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->