### PR TITLE
EPMRPP-117078 || Migrate Sauce Labs log tab to plugin commands API

### DIFF
--- a/app/src/controllers/log/sauceLabs/sagas.js
+++ b/app/src/controllers/log/sauceLabs/sagas.js
@@ -18,8 +18,10 @@ import { takeEvery, put, call, all, select, take } from 'redux-saga/effects';
 import { URLS } from 'common/urls';
 import { SAUCE_LABS } from 'common/constants/pluginNames';
 import { availableIntegrationsByPluginNameSelector } from 'controllers/plugins';
+import { buildPluginCommandRQ } from 'controllers/plugins/utils';
 import { fetchDataAction, createFetchPredicate } from 'controllers/fetch';
-import { projectKeySelector } from 'controllers/project';
+import { activeOrganizationIdSelector } from 'controllers/organization';
+import { projectKeySelector, projectInfoIdSelector } from 'controllers/project';
 import {
   EXECUTE_SAUCE_LABS_COMMAND_ACTION,
   BULK_EXECUTE_SAUCE_LABS_COMMAND_ACTION,
@@ -29,11 +31,22 @@ import { updateLoadingAction } from './actionCreators';
 
 function* executeSauceLabsCommand({ payload: { command, integrationId, data = {} } }) {
   const projectKey = yield select(projectKeySelector);
+  const projectId = yield select(projectInfoIdSelector);
+  const organizationId = yield select(activeOrganizationIdSelector);
 
   yield put(
     fetchDataAction(SAUCE_LABS_COMMANDS_NAMESPACES_MAP[command])(
-      URLS.projectIntegrationByIdCommand(projectKey, integrationId, command),
-      { data, method: 'put' },
+      URLS.pluginsCommandsCommon(SAUCE_LABS, command),
+      {
+        data: buildPluginCommandRQ({
+          integrationId,
+          projectKey,
+          projectId,
+          organizationId,
+          arguments: data,
+        }),
+        method: 'post',
+      },
     ),
   );
 }


### PR DESCRIPTION
## Problem

Opening the Sauce Labs tab on the log view fails with multiple 400 errors:

`Command 'token' is not found in plugin saucelabs` (same for `logs`, `jobInfo`, `assets`).

**Steps to reproduce:** Launches → log view → Sauce Labs tab (test item with a valid SLID attribute and a configured Sauce Labs integration).

**Root cause:** Sauce Labs was the last consumer of the deprecated integration command endpoint (`PUT /api/v1/integration/{projectKey}/{integrationId}/{command}`). After the Sauce Labs plugin moved commands to `ExtensionCommand` (EPMRPP-114588), they are only available via the common plugin commands API (`POST /api/plugins/{pluginName}/commands/{command}`). Other integrations were already migrated in EPMRPP-115266; Sauce Labs log sagas were not.

## Solution

Update Sauce Labs command execution sagas to call `URLS.pluginsCommandsCommon` with `POST` and wrap the payload in `buildPluginCommandRQ` (integration context + command arguments), matching the pattern used by Jira Cloud, GitLab, Monday, and other plugins.

Command arguments (`jobId`, `dataCenter`) are passed in the `arguments` field; project and organization context is resolved from Redux selectors.

## Visuals

https://github.com/user-attachments/assets/ce01f70e-ba67-49a5-9061-2e0530146bd6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the way Sauce Labs commands are sent, helping command execution work more reliably across projects and integrations.
  * Enhanced how project context is included so requests use the correct workspace information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->