### PR TITLE
EPMRPP-117180 || Enable scrollable layout in BaseLaunchModal to keep footer inside modal

### DIFF
--- a/app/src/pages/inside/common/launchFormFields/baseLaunchModal.tsx
+++ b/app/src/pages/inside/common/launchFormFields/baseLaunchModal.tsx
@@ -102,6 +102,7 @@ export const BaseLaunchModal = ({
 
   return (
     <Modal
+      scrollable
       title={modalTitle}
       okButton={okButton}
       className={className}


### PR DESCRIPTION
## Problem

In Test Case Library, the Add to Launch modal footer (Cancel and Add buttons) can render outside the modal card. On viewports where the full form does not fit (launch mode switcher, checkbox, launch name, description, test plan, attributes), the footer is pushed beyond the modal `max-height` and gets clipped by the overlay.

**Steps to reproduce:** Test Case Library → select a folder or test cases → Add to Launch → open Create new launch tab with the full form visible → observe the footer on a shorter viewport.

**Root cause:** `BaseLaunchModal` uses ui-kit `Modal` without the `scrollable` prop. Header, form body, and footer are laid out in a single column with no internal scroll, while `.modal-window` is capped at `90%` viewport height. Tall content overflows and the footer ends up outside the visible modal area.

## Solution

Enable `scrollable` on `Modal` in `BaseLaunchModal`. Form content scrolls inside the modal; the footer stays pinned at the bottom of the modal card.

This applies to all consumers of `BaseLaunchModal`: Add to Launch (Test Case Library), Create Launch, and Add Test Cases to Launch (Test Plans).