### PR TITLE
EPMRPP-116987 || Add async validation on invite user modal

### DIFF
--- a/app/src/common/utils/validation/asyncValidation.js
+++ b/app/src/common/utils/validation/asyncValidation.js
@@ -16,6 +16,7 @@
 
 import { fetch } from 'common/utils/fetch';
 import { URLS } from 'common/urls';
+import { email as isValidEmail } from 'common/utils/validation/validate';
 
 export const projectNameUnique = (projectName) =>
   fetch(URLS.searchProjectNames(), { params: { term: projectName } }).then((names) => {
@@ -38,3 +39,30 @@ export const filterNameUnique = (projectKey, filterId, filterName) =>
       };
     }
   });
+
+export const organizationUserEmailUnique = async (organizationId, email) => {
+  const normalizedEmail = email?.trim() ?? '';
+
+  if (!normalizedEmail || isValidEmail(normalizedEmail) !== true) {
+    return;
+  }
+
+  let response;
+  try {
+    response = await fetch(
+      URLS.organizationUsers(organizationId, {
+        email: normalizedEmail,
+      }),
+    );
+  } catch {
+    // Skip uniqueness check when the validation request fails (e.g. 504), so the form can still be submitted
+    return;
+  }
+
+  const isDuplicate = (response?.items ?? []).length > 0;
+
+  if (isDuplicate) {
+    // eslint-disable-next-line no-throw-literal
+    throw { email: 'duplicationOrganization' };
+  }
+};

--- a/app/src/components/fields/fieldErrorHint/fieldErrorHint.jsx
+++ b/app/src/components/fields/fieldErrorHint/fieldErrorHint.jsx
@@ -22,330 +22,334 @@ import {
   REGISTRATION_NAME_MIN_LENGTH,
   REGISTRATION_NAME_MAX_LENGTH,
 } from 'common/constants/validation';
+import { messages as inviteMessages } from 'common/constants/localization/invitationsLocalization';
 import styles from './fieldErrorHint.scss';
 
 const cx = classNames.bind(styles);
 
-const messages = defineMessages({
-  loginHint: {
-    id: 'RegistrationForm.loginHint',
-    defaultMessage: 'Email is incorrect. Please enter correct email',
-  },
-  nameHint: {
-    id: 'RegistrationForm.nameHint',
-    defaultMessage:
-      'Full name may contain {minLength}-{maxLength} characters, using only Latin letters, numbers, spaces, dots, hyphens, underscores, and apostrophes.',
-  },
-  emailCreateUserHint: {
-    id: 'CreateUserModal.emailCreateUserHint',
-    defaultMessage: 'Email is incorrect. Please enter correct email',
-  },
-  oldPasswordHint: {
-    id: 'RegistrationForm.oldPasswordHint',
-    defaultMessage:
-      'Password should contain at least 4 characters; a special symbol; upper-case (A - Z); lower-case',
-  },
-  emailHint: {
-    id: 'Common.validation.email',
-    defaultMessage: 'Email is incorrect. Please enter correct email.',
-  },
-  confirmPasswordHint: {
-    id: 'RegistrationForm.confirmPasswordHint',
-    defaultMessage: 'The passwords you entered do not match. Please try again.',
-  },
-  filterNameError: {
-    id: 'FiltersPage.filterNameLength',
-    defaultMessage: 'Filter name length should have size from 3 to 128 characters.',
-  },
-  filterNameDuplicateHint: {
-    id: 'FiltersPage.filterNameDuplicateHint',
-    defaultMessage: 'Filter with the same name already exists in system.',
-  },
-  launchNameHint: {
-    id: 'LaunchMergeModal.launchNameHint',
-    defaultMessage: 'Launch name should have size from 1 to 256.',
-  },
-  launchDescriptionHint: {
-    id: 'LaunchMergeModal.launchDescriptionHint',
-    defaultMessage: 'Description should have size not more than 2048 symbols.',
-  },
-  testCaseDescriptionHint: {
-    id: 'DescriptionModal.testCaseDescriptionHint',
-    defaultMessage: 'Description should have size not more than 1000 symbols.',
-  },
-  dashboardNameHint: {
-    id: 'AddEditDashboard.dashboardNameHint',
-    defaultMessage: 'Dashboard name should have size  from 3 to 128.',
-  },
-  dashboardNameExistsHint: {
-    id: 'AddEditDashboard.dashboardNameExistsHint',
-    defaultMessage: 'This name is already in use.',
-  },
-  dashboardNameSearchHint: {
-    id: 'SearchDashboardForm.dashboardNameSearchHint',
-    defaultMessage: 'Dashboard name should have size from 3 to 128',
-  },
-  minShouldMatchHint: {
-    id: 'AccuracyFormBlock.minShouldMatchHint',
-    defaultMessage: 'The parameter should have value from 50 to 100',
-  },
-  searchLogsMinShouldMatch: {
-    id: 'AccuracyFormBlock.searchLogsMinShouldMatch',
-    defaultMessage: 'The parameter should have value from 0 to 100',
-  },
-  profilePassword: {
-    id: 'ChangePasswordModal.profilePassword',
-    defaultMessage: 'Password should have size from 4 to 256 symbols',
-  },
-  profileConfirmPassword: {
-    id: 'ChangePasswordModal.profileConfirmPassword',
-    defaultMessage: 'Passwords do not match',
-  },
-  profileUserName: {
-    id: 'ChangePasswordModal.profileUserName',
-    defaultMessage:
-      'Full name should have size from 3 to 256 symbols, latin, cyrillic, numeric characters, hyphen, underscore, dot, space.',
-  },
-  profileEmail: {
-    id: 'ChangePasswordModal.profileEmail',
-    defaultMessage: 'Email is incorrect.',
-  },
-  itemNameEntityHint: {
-    id: 'LaunchLevelEntities.itemNameEntityHint',
-    defaultMessage: 'At least 3 symbols required',
-  },
-  launchNumericEntityHint: {
-    id: 'LaunchLevelEntities.launchNumberEntityHint',
-    defaultMessage: 'This filter accepts only digits',
-  },
-  descriptionEntityHint: {
-    id: 'LaunchLevelEntities.descriptionEntityHint',
-    defaultMessage: 'Description should have size from 1 to 256',
-  },
-  descriptionStepLevelEntityHint: {
-    id: 'LaunchLevelEntities.descriptionStepLevelEntityHint',
-    defaultMessage: 'Description should have size from 1 to 256',
-  },
-  demoDataPostfixHint: {
-    id: 'DemoDataTabForm.demoDataPostfixHint',
-    defaultMessage: 'Postfix should have size from 1 to 90',
-  },
-  recipientsHint: {
-    id: 'AddEditNotificationCaseModal.recipientsHint',
-    defaultMessage: 'Please enter existent user name on your project or valid email',
-  },
-  ruleNameHint: {
-    id: 'AddEditNotificationModal.ruleNameHint',
-    defaultMessage: "Field is required. Rule name should have size from '1' to '55' characters",
-  },
-  launchesHint: {
-    id: 'AddEditNotificationCaseModal.launchesHint',
-    defaultMessage: 'Launch name should have size from 1 to 256',
-  },
-  urlHint: {
-    id: 'LinkIssueModal.urlHint',
-    defaultMessage: 'Link should match a valid website address',
-  },
-  issueIdHint: {
-    id: 'LinkIssueModal.issueIdHint',
-    defaultMessage: 'Issue ID should have size from 1 to 128',
-  },
-  requirementsLinkHint: {
-    id: 'Common.requirementsLinkHint',
-    defaultMessage: 'Please enter a valid URL using the format: https://example.com.',
-  },
-  requiredFieldHint: {
-    id: 'Common.requiredFieldHint',
-    defaultMessage: 'Field is required',
-  },
-  githubOrganizationNameHint: {
-    id: 'GithubFormFields.organizationNameHint',
-    defaultMessage: 'Organization name may contain only Latin, numeric characters and hyphen',
-  },
-  requiredFieldWithPeriodHint: {
-    id: 'Common.requiredFieldWithPeriodHint',
-    defaultMessage: 'Field is required.',
-  },
-  shortRequiredFieldHint: {
-    id: 'Common.shortRequiredFieldHint',
-    defaultMessage: 'Field is required',
-  },
-  attributeKeyLengthHint: {
-    id: 'AttributeEditor.attributeKeyLengthHint',
-    defaultMessage: 'Key should have size from 1 to 512 symbols',
-  },
-  attributeValueLengthHint: {
-    id: 'AttributeEditor.attributeValueLengthHint',
-    defaultMessage: 'Value should have size not more than 512 symbols',
-  },
-  uniqueAttributeKeyHint: {
-    id: 'AttributeEditor.uniqueAttributeKeyHint',
-    defaultMessage: 'Attribute key should be unique',
-  },
-  defectLongNameHint: {
-    id: 'DefectTypesTab.defectLongNameHint',
-    defaultMessage: "Defect Type name should have size from '3' to '55' characters",
-  },
-  defectShortNameHint: {
-    id: 'DefectTypesTab.defectShortNameHint',
-    defaultMessage: "Defect Type abbreviation should have size from '1' to '4' characters",
-  },
-  projectNamePatternHint: {
-    id: 'ProjectsPage.projectNamePatternHint',
-    defaultMessage:
-      'Project name may contain only Latin, numeric characters, hyphen, underscore, dot. Space is permitted',
-  },
-  projectNameLengthHint: {
-    id: 'ProjectsPage.projectNameLengthHint',
-    defaultMessage: "Project name should have size from '3' to '60' characters",
-  },
-  projectDuplicateHint: {
-    id: 'ProjectsPage.projectDuplicateHint',
-    defaultMessage: 'Project with the same name already exists in this organization',
-  },
-  organizationNameLengthHint: {
-    id: 'OrganizationsPage.organizationNameLengthHint',
-    defaultMessage: "Organization name should have size from '3' to '60' characters",
-  },
-  organizationNamePatternHint: {
-    id: 'OrganizationsPage.organizationNamePatternHint',
-    defaultMessage:
-      'Organization name may contain only Latin, numeric characters, hyphen, underscore, apostrophe, dot. Space is permitted',
-  },
-  btsIntegrationNameHint: {
-    id: 'BtsCommonMessages.btsIntegrationNameHint',
-    defaultMessage: 'Integration name should have size from 1 to 55 characters',
-  },
-  btsUrlHint: {
-    id: 'BtsCommonMessages.btsUrlHint',
-    defaultMessage: 'Please provide a valid BTS link',
-  },
-  btsProjectKeyHint: {
-    id: 'BtsCommonMessages.btsProjectKeyHint',
-    defaultMessage: 'Project key should have size from 1 to 55',
-  },
-  btsBoardIdHint: {
-    id: 'BtsCommonMessages.btsBoardIdHint',
-    defaultMessage: 'Board ID should have size from 1 to 55 characters',
-  },
-  btsProjectIdHint: {
-    id: 'BtsCommonMessages.btsProjectIdHint',
-    defaultMessage: 'Project ID should have size from 1 to 55',
-  },
-  btsUserNameHint: {
-    id: 'BtsCommonMessages.btsUserNameHint',
-    defaultMessage: 'Username should have size from 1 to 55',
-  },
-  btsPasswordHint: {
-    id: 'BtsCommonMessages.btsPasswordHint',
-    defaultMessage: 'Password should have size from 1 to 55',
-  },
-  portFieldHint: {
-    id: 'EmailFormFields.portFieldHint',
-    defaultMessage: "Only numbers from '1' to '65535' are possible.",
-  },
-  patternNameLengthHint: {
-    id: 'PatternAnalysis.patternNameLengthHint',
-    defaultMessage: 'Pattern name should have size from 1 to 55',
-  },
-  patternNameDuplicateHint: {
-    id: 'PatternAnalysis.patternNameDuplicateHint',
-    defaultMessage: 'Pattern with the same name already exists in the project',
-  },
-  ruleNameDuplicateHint: {
-    id: 'Notifications.ruleNameDuplicateHint',
-    defaultMessage: 'Rule with the same name already exists for this communication channel',
-  },
-  footerLinkNameLengthHint: {
-    id: 'FooterLink.footerLinkNameLengthHint',
-    defaultMessage: "Link name should have a size from '3' to 30' characters",
-  },
-  footerLinkNameDuplicateHint: {
-    id: 'FooterLink.footerLinkNameDuplicateHint',
-    defaultMessage: 'Link with the same name already exists',
-  },
-  footerLinkURLDuplicateHint: {
-    id: 'FooterLink.footerLinkURLDuplicateHint',
-    defaultMessage: 'Link with the same URL or Email already exists',
-  },
-  footerLinkUrlHint: {
-    id: 'FooterLink.footerLinkUrlHint',
-    defaultMessage: 'Please provide a valid URL or Email',
-  },
-  footerLinkURLLengthHint: {
-    id: 'FooterLink.footerLinkURLLengthHint',
-    defaultMessage: 'URL or Email should have size not more than 1024 symbols',
-  },
-  customColumnsDuplicationHint: {
-    id: 'ProductStatusControls.customColumnsDuplicationHint',
-    defaultMessage: 'Duplicated column names are prohibited',
-  },
-  booleanFieldHint: {
-    id: 'PostIssueModal.booleanFieldHint',
-    defaultMessage: 'This field must have only true/false values',
-  },
-  doubleFieldHint: {
-    id: 'PostIssueModal.doubleFieldHint',
-    defaultMessage: "This field must be of 'double' type",
-  },
-  membersSearchHint: {
-    id: 'MembersPageToolbar.membersSearchHint',
-    defaultMessage: 'Member name must not be empty',
-  },
-  descriptionHint: {
-    id: 'EditItemModal.descriptionHint',
-    defaultMessage: "Description should have size from '0' to '2048' symbols",
-  },
-  apiKeyNameWrongSizeHint: {
-    id: 'GenerateApiKeyModal.apiKeyNameWrongSizeHint',
-    defaultMessage: 'API Key name should have size from 1 to 40 characters',
-  },
-  apiKeyNameUniqueHint: {
-    id: 'GenerateApiKeyModal.apiKeyNameUniqueHint',
-    defaultMessage: 'API Key with the same name already exists',
-  },
-  apiKeyNameShouldMatch: {
-    id: 'GenerateApiKeyModal.apiKeyNameShouldMatch',
-    defaultMessage: 'Enter a valid API key: use letters, numbers, -, ., _, ~, /, +',
-  },
-  deleteAccountReasonSizeHint: {
-    id: 'DeleteAccountFeedbackModal.deleteAccountReasonSizeHint',
-    defaultMessage: 'The field should have size not more than 128 symbols.',
-  },
-  keywordMatcherHint: {
-    id: 'DeleteProjectModal.keywordMatcherHint',
-    defaultMessage: 'The entered text does not match the required keyword',
-  },
-  emailInviteUserHint: {
-    id: 'CreateUserModal.emailInviteUserHint',
-    defaultMessage: 'Please enter a valid email',
-  },
-  projectVersionLengthHint: {
-    id: 'ListOfVersionsPage.projectVersionLengthHint',
-    defaultMessage: 'Name must not exceed 60 characters',
-  },
-  enteredTextDoesNotMatchKeyword: {
-    id: 'ProductVersionPage.enteredTextDoesNotMatch',
-    defaultMessage: 'The entered text does not match the required keyword',
-  },
-  logTypeNameAlreadyExistsHint: {
-    id: 'LogTypeModal.logTypeNameAlreadyExistsHint',
-    defaultMessage: 'Log type with the same name already exists on the project',
-  },
-  logTypeLevelAlreadyExistsHint: {
-    id: 'LogTypeModal.logTypeLevelAlreadyExistsHint',
-    defaultMessage: 'Log type with the same level already exists on the project',
-  },
-  logTypeNameInvalidHint: {
-    id: 'LogTypeModal.logTypeNameInvalidHint',
-    defaultMessage:
-      'Log type name may contain only Latin, numeric characters, space (from 3 to 16 symbols)',
-  },
-  logTypeLevelInvalidHint: {
-    id: 'LogTypeModal.logTypeLevelInvalidHint',
-    defaultMessage: 'Log level should be a number from 1 to 59999',
-  },
-});
+const messages = {
+  ...defineMessages({
+    loginHint: {
+      id: 'RegistrationForm.loginHint',
+      defaultMessage: 'Email is incorrect. Please enter correct email',
+    },
+    nameHint: {
+      id: 'RegistrationForm.nameHint',
+      defaultMessage:
+        'Full name may contain {minLength}-{maxLength} characters, using only Latin letters, numbers, spaces, dots, hyphens, underscores, and apostrophes.',
+    },
+    emailCreateUserHint: {
+      id: 'CreateUserModal.emailCreateUserHint',
+      defaultMessage: 'Email is incorrect. Please enter correct email',
+    },
+    oldPasswordHint: {
+      id: 'RegistrationForm.oldPasswordHint',
+      defaultMessage:
+        'Password should contain at least 4 characters; a special symbol; upper-case (A - Z); lower-case',
+    },
+    emailHint: {
+      id: 'Common.validation.email',
+      defaultMessage: 'Email is incorrect. Please enter correct email.',
+    },
+    confirmPasswordHint: {
+      id: 'RegistrationForm.confirmPasswordHint',
+      defaultMessage: 'The passwords you entered do not match. Please try again.',
+    },
+    filterNameError: {
+      id: 'FiltersPage.filterNameLength',
+      defaultMessage: 'Filter name length should have size from 3 to 128 characters.',
+    },
+    filterNameDuplicateHint: {
+      id: 'FiltersPage.filterNameDuplicateHint',
+      defaultMessage: 'Filter with the same name already exists in system.',
+    },
+    launchNameHint: {
+      id: 'LaunchMergeModal.launchNameHint',
+      defaultMessage: 'Launch name should have size from 1 to 256.',
+    },
+    launchDescriptionHint: {
+      id: 'LaunchMergeModal.launchDescriptionHint',
+      defaultMessage: 'Description should have size not more than 2048 symbols.',
+    },
+    testCaseDescriptionHint: {
+      id: 'DescriptionModal.testCaseDescriptionHint',
+      defaultMessage: 'Description should have size not more than 1000 symbols.',
+    },
+    dashboardNameHint: {
+      id: 'AddEditDashboard.dashboardNameHint',
+      defaultMessage: 'Dashboard name should have size  from 3 to 128.',
+    },
+    dashboardNameExistsHint: {
+      id: 'AddEditDashboard.dashboardNameExistsHint',
+      defaultMessage: 'This name is already in use.',
+    },
+    dashboardNameSearchHint: {
+      id: 'SearchDashboardForm.dashboardNameSearchHint',
+      defaultMessage: 'Dashboard name should have size from 3 to 128',
+    },
+    minShouldMatchHint: {
+      id: 'AccuracyFormBlock.minShouldMatchHint',
+      defaultMessage: 'The parameter should have value from 50 to 100',
+    },
+    searchLogsMinShouldMatch: {
+      id: 'AccuracyFormBlock.searchLogsMinShouldMatch',
+      defaultMessage: 'The parameter should have value from 0 to 100',
+    },
+    profilePassword: {
+      id: 'ChangePasswordModal.profilePassword',
+      defaultMessage: 'Password should have size from 4 to 256 symbols',
+    },
+    profileConfirmPassword: {
+      id: 'ChangePasswordModal.profileConfirmPassword',
+      defaultMessage: 'Passwords do not match',
+    },
+    profileUserName: {
+      id: 'ChangePasswordModal.profileUserName',
+      defaultMessage:
+        'Full name should have size from 3 to 256 symbols, latin, cyrillic, numeric characters, hyphen, underscore, dot, space.',
+    },
+    profileEmail: {
+      id: 'ChangePasswordModal.profileEmail',
+      defaultMessage: 'Email is incorrect.',
+    },
+    itemNameEntityHint: {
+      id: 'LaunchLevelEntities.itemNameEntityHint',
+      defaultMessage: 'At least 3 symbols required',
+    },
+    launchNumericEntityHint: {
+      id: 'LaunchLevelEntities.launchNumberEntityHint',
+      defaultMessage: 'This filter accepts only digits',
+    },
+    descriptionEntityHint: {
+      id: 'LaunchLevelEntities.descriptionEntityHint',
+      defaultMessage: 'Description should have size from 1 to 256',
+    },
+    descriptionStepLevelEntityHint: {
+      id: 'LaunchLevelEntities.descriptionStepLevelEntityHint',
+      defaultMessage: 'Description should have size from 1 to 256',
+    },
+    demoDataPostfixHint: {
+      id: 'DemoDataTabForm.demoDataPostfixHint',
+      defaultMessage: 'Postfix should have size from 1 to 90',
+    },
+    recipientsHint: {
+      id: 'AddEditNotificationCaseModal.recipientsHint',
+      defaultMessage: 'Please enter existent user name on your project or valid email',
+    },
+    ruleNameHint: {
+      id: 'AddEditNotificationModal.ruleNameHint',
+      defaultMessage: "Field is required. Rule name should have size from '1' to '55' characters",
+    },
+    launchesHint: {
+      id: 'AddEditNotificationCaseModal.launchesHint',
+      defaultMessage: 'Launch name should have size from 1 to 256',
+    },
+    urlHint: {
+      id: 'LinkIssueModal.urlHint',
+      defaultMessage: 'Link should match a valid website address',
+    },
+    issueIdHint: {
+      id: 'LinkIssueModal.issueIdHint',
+      defaultMessage: 'Issue ID should have size from 1 to 128',
+    },
+    requirementsLinkHint: {
+      id: 'Common.requirementsLinkHint',
+      defaultMessage: 'Please enter a valid URL using the format: https://example.com.',
+    },
+    requiredFieldHint: {
+      id: 'Common.requiredFieldHint',
+      defaultMessage: 'Field is required',
+    },
+    githubOrganizationNameHint: {
+      id: 'GithubFormFields.organizationNameHint',
+      defaultMessage: 'Organization name may contain only Latin, numeric characters and hyphen',
+    },
+    requiredFieldWithPeriodHint: {
+      id: 'Common.requiredFieldWithPeriodHint',
+      defaultMessage: 'Field is required.',
+    },
+    shortRequiredFieldHint: {
+      id: 'Common.shortRequiredFieldHint',
+      defaultMessage: 'Field is required',
+    },
+    attributeKeyLengthHint: {
+      id: 'AttributeEditor.attributeKeyLengthHint',
+      defaultMessage: 'Key should have size from 1 to 512 symbols',
+    },
+    attributeValueLengthHint: {
+      id: 'AttributeEditor.attributeValueLengthHint',
+      defaultMessage: 'Value should have size not more than 512 symbols',
+    },
+    uniqueAttributeKeyHint: {
+      id: 'AttributeEditor.uniqueAttributeKeyHint',
+      defaultMessage: 'Attribute key should be unique',
+    },
+    defectLongNameHint: {
+      id: 'DefectTypesTab.defectLongNameHint',
+      defaultMessage: "Defect Type name should have size from '3' to '55' characters",
+    },
+    defectShortNameHint: {
+      id: 'DefectTypesTab.defectShortNameHint',
+      defaultMessage: "Defect Type abbreviation should have size from '1' to '4' characters",
+    },
+    projectNamePatternHint: {
+      id: 'ProjectsPage.projectNamePatternHint',
+      defaultMessage:
+        'Project name may contain only Latin, numeric characters, hyphen, underscore, dot. Space is permitted',
+    },
+    projectNameLengthHint: {
+      id: 'ProjectsPage.projectNameLengthHint',
+      defaultMessage: "Project name should have size from '3' to '60' characters",
+    },
+    projectDuplicateHint: {
+      id: 'ProjectsPage.projectDuplicateHint',
+      defaultMessage: 'Project with the same name already exists in this organization',
+    },
+    organizationNameLengthHint: {
+      id: 'OrganizationsPage.organizationNameLengthHint',
+      defaultMessage: "Organization name should have size from '3' to '60' characters",
+    },
+    organizationNamePatternHint: {
+      id: 'OrganizationsPage.organizationNamePatternHint',
+      defaultMessage:
+        'Organization name may contain only Latin, numeric characters, hyphen, underscore, apostrophe, dot. Space is permitted',
+    },
+    btsIntegrationNameHint: {
+      id: 'BtsCommonMessages.btsIntegrationNameHint',
+      defaultMessage: 'Integration name should have size from 1 to 55 characters',
+    },
+    btsUrlHint: {
+      id: 'BtsCommonMessages.btsUrlHint',
+      defaultMessage: 'Please provide a valid BTS link',
+    },
+    btsProjectKeyHint: {
+      id: 'BtsCommonMessages.btsProjectKeyHint',
+      defaultMessage: 'Project key should have size from 1 to 55',
+    },
+    btsBoardIdHint: {
+      id: 'BtsCommonMessages.btsBoardIdHint',
+      defaultMessage: 'Board ID should have size from 1 to 55 characters',
+    },
+    btsProjectIdHint: {
+      id: 'BtsCommonMessages.btsProjectIdHint',
+      defaultMessage: 'Project ID should have size from 1 to 55',
+    },
+    btsUserNameHint: {
+      id: 'BtsCommonMessages.btsUserNameHint',
+      defaultMessage: 'Username should have size from 1 to 55',
+    },
+    btsPasswordHint: {
+      id: 'BtsCommonMessages.btsPasswordHint',
+      defaultMessage: 'Password should have size from 1 to 55',
+    },
+    portFieldHint: {
+      id: 'EmailFormFields.portFieldHint',
+      defaultMessage: "Only numbers from '1' to '65535' are possible.",
+    },
+    patternNameLengthHint: {
+      id: 'PatternAnalysis.patternNameLengthHint',
+      defaultMessage: 'Pattern name should have size from 1 to 55',
+    },
+    patternNameDuplicateHint: {
+      id: 'PatternAnalysis.patternNameDuplicateHint',
+      defaultMessage: 'Pattern with the same name already exists in the project',
+    },
+    ruleNameDuplicateHint: {
+      id: 'Notifications.ruleNameDuplicateHint',
+      defaultMessage: 'Rule with the same name already exists for this communication channel',
+    },
+    footerLinkNameLengthHint: {
+      id: 'FooterLink.footerLinkNameLengthHint',
+      defaultMessage: "Link name should have a size from '3' to 30' characters",
+    },
+    footerLinkNameDuplicateHint: {
+      id: 'FooterLink.footerLinkNameDuplicateHint',
+      defaultMessage: 'Link with the same name already exists',
+    },
+    footerLinkURLDuplicateHint: {
+      id: 'FooterLink.footerLinkURLDuplicateHint',
+      defaultMessage: 'Link with the same URL or Email already exists',
+    },
+    footerLinkUrlHint: {
+      id: 'FooterLink.footerLinkUrlHint',
+      defaultMessage: 'Please provide a valid URL or Email',
+    },
+    footerLinkURLLengthHint: {
+      id: 'FooterLink.footerLinkURLLengthHint',
+      defaultMessage: 'URL or Email should have size not more than 1024 symbols',
+    },
+    customColumnsDuplicationHint: {
+      id: 'ProductStatusControls.customColumnsDuplicationHint',
+      defaultMessage: 'Duplicated column names are prohibited',
+    },
+    booleanFieldHint: {
+      id: 'PostIssueModal.booleanFieldHint',
+      defaultMessage: 'This field must have only true/false values',
+    },
+    doubleFieldHint: {
+      id: 'PostIssueModal.doubleFieldHint',
+      defaultMessage: "This field must be of 'double' type",
+    },
+    membersSearchHint: {
+      id: 'MembersPageToolbar.membersSearchHint',
+      defaultMessage: 'Member name must not be empty',
+    },
+    descriptionHint: {
+      id: 'EditItemModal.descriptionHint',
+      defaultMessage: "Description should have size from '0' to '2048' symbols",
+    },
+    apiKeyNameWrongSizeHint: {
+      id: 'GenerateApiKeyModal.apiKeyNameWrongSizeHint',
+      defaultMessage: 'API Key name should have size from 1 to 40 characters',
+    },
+    apiKeyNameUniqueHint: {
+      id: 'GenerateApiKeyModal.apiKeyNameUniqueHint',
+      defaultMessage: 'API Key with the same name already exists',
+    },
+    apiKeyNameShouldMatch: {
+      id: 'GenerateApiKeyModal.apiKeyNameShouldMatch',
+      defaultMessage: 'Enter a valid API key: use letters, numbers, -, ., _, ~, /, +',
+    },
+    deleteAccountReasonSizeHint: {
+      id: 'DeleteAccountFeedbackModal.deleteAccountReasonSizeHint',
+      defaultMessage: 'The field should have size not more than 128 symbols.',
+    },
+    keywordMatcherHint: {
+      id: 'DeleteProjectModal.keywordMatcherHint',
+      defaultMessage: 'The entered text does not match the required keyword',
+    },
+    emailInviteUserHint: {
+      id: 'CreateUserModal.emailInviteUserHint',
+      defaultMessage: 'Please enter a valid email',
+    },
+    projectVersionLengthHint: {
+      id: 'ListOfVersionsPage.projectVersionLengthHint',
+      defaultMessage: 'Name must not exceed 60 characters',
+    },
+    enteredTextDoesNotMatchKeyword: {
+      id: 'ProductVersionPage.enteredTextDoesNotMatch',
+      defaultMessage: 'The entered text does not match the required keyword',
+    },
+    logTypeNameAlreadyExistsHint: {
+      id: 'LogTypeModal.logTypeNameAlreadyExistsHint',
+      defaultMessage: 'Log type with the same name already exists on the project',
+    },
+    logTypeLevelAlreadyExistsHint: {
+      id: 'LogTypeModal.logTypeLevelAlreadyExistsHint',
+      defaultMessage: 'Log type with the same level already exists on the project',
+    },
+    logTypeNameInvalidHint: {
+      id: 'LogTypeModal.logTypeNameInvalidHint',
+      defaultMessage:
+        'Log type name may contain only Latin, numeric characters, space (from 3 to 16 symbols)',
+    },
+    logTypeLevelInvalidHint: {
+      id: 'LogTypeModal.logTypeLevelInvalidHint',
+      defaultMessage: 'Log level should be a number from 1 to 59999',
+    },
+  }),
+  duplicationOrganization: inviteMessages.duplicationOrganization,
+};
 
 const MESSAGE_VALUES = {
   nameHint: {

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserEmailField/inviteUserEmailField.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserEmailField/inviteUserEmailField.tsx
@@ -14,86 +14,32 @@
  * limitations under the License.
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import { change } from 'redux-form';
 import { FieldText } from '@reportportal/ui-kit';
 
-import { createClassnames, fetch } from 'common/utils';
-import { email as isValidEmail } from 'common/utils/validation/validate';
+import { createClassnames } from 'common/utils';
 import { FieldErrorHint } from 'components/fields/fieldErrorHint';
 import { FieldElement } from 'pages/inside/projectSettingsPageContainer/content/elements';
 import { messages } from 'common/constants/localization/invitationsLocalization';
-import { URLS } from 'common/urls';
 
 import styles from './inviteUserEmailField.scss';
 
 const cx = createClassnames(styles);
 
-interface UserSearchItem {
-  id?: number;
-  email?: string;
-}
-
-interface UserSearchResponse {
-  items?: UserSearchItem[];
-}
-
 interface InviteUserEmailFieldProps {
   formName: string;
-  onUserSelect?: (userId: number | null) => void;
 }
 
-export const InviteUserEmailField = ({ formName, onUserSelect }: InviteUserEmailFieldProps) => {
+export const InviteUserEmailField = ({ formName }: InviteUserEmailFieldProps) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const emailValueRef = useRef<string>('');
-  const lookupIdRef = useRef(0);
 
   const handleClear = useCallback(() => {
     dispatch(change(formName, 'email', ''));
-    emailValueRef.current = '';
-    lookupIdRef.current += 1;
-    onUserSelect?.(null);
-  }, [dispatch, formName, onUserSelect]);
-
-  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    emailValueRef.current = e.target.value ?? '';
-  }, []);
-
-  const handleBlur = useCallback(
-    () => {
-      const email = emailValueRef.current.trim();
-      const lookupId = (lookupIdRef.current += 1);
-
-      if (!email || isValidEmail(email) !== true) {
-        onUserSelect?.(null);
-        return;
-      }
-
-      fetch(URLS.searchAllUsers(), {
-        method: 'post',
-        data: {
-          limit: 1,
-          search_criteria: [{ filter_key: 'email', operation: 'EQ', value: email }],
-        },
-      })
-        .then((response: UserSearchResponse) => {
-          if (lookupId !== lookupIdRef.current || emailValueRef.current.trim() !== email) {
-            return;
-          }
-          const user = response.items?.[0];
-          onUserSelect?.(user?.id ?? null);
-        })
-        .catch(() => {
-          if (lookupId === lookupIdRef.current && emailValueRef.current.trim() === email) {
-            onUserSelect?.(null);
-          }
-        });
-    },
-    [onUserSelect],
-  );
+  }, [dispatch, formName]);
 
   return (
     <FieldElement name="email" className={cx('email')}>
@@ -106,8 +52,6 @@ export const InviteUserEmailField = ({ formName, onUserSelect }: InviteUserEmail
           type="email"
           clearable
           onClear={handleClear}
-          onChange={handleChange}
-          onBlur={handleBlur}
         />
       </FieldErrorHint>
     </FieldElement>

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
@@ -16,14 +16,14 @@
 
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
-import { reduxForm, getFormValues } from 'redux-form';
+import { reduxForm, getFormValues, SubmissionError } from 'redux-form';
 import { isString } from 'es-toolkit';
 import DOMPurify from 'dompurify';
 import { Modal } from '@reportportal/ui-kit';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils/fetch';
-import { commonValidators } from 'common/utils/validation';
+import { commonValidators, validateAsync } from 'common/utils/validation';
 import { showSuccessNotification } from 'controllers/notification';
 import { hideModalAction, showModalAction } from 'controllers/modal';
 import { ModalButtonProps } from 'types/common';
@@ -88,6 +88,31 @@ function validateOrganization(
   return errors;
 }
 
+const asyncValidateOrganizationEmail = ({
+  email,
+  organization,
+}: FormDataMap[Level.ORGANIZATION]) => {
+  if (!organization?.id) {
+    return Promise.resolve();
+  }
+
+  return validateAsync.organizationUserEmailUnique(organization.id, email);
+};
+
+const shouldAsyncValidateOrganizationEmail = ({
+  trigger,
+  syncValidationPasses,
+}: {
+  trigger: string;
+  syncValidationPasses: boolean;
+}) => {
+  if (!syncValidationPasses) {
+    return false;
+  }
+
+  return trigger !== 'submit';
+};
+
 type InviteUserFormInnerProps = InviteUserProps<Level> & { content: ReactNode };
 
 const InviteUserFormInner = (props: InviteUserFormInnerProps) => (
@@ -112,6 +137,9 @@ const InviteUserFormOrganization = reduxForm<FormDataMap[Level.ORGANIZATION]>({
   validate: validateOrganization as Parameters<
     typeof reduxForm<FormDataMap[Level.ORGANIZATION]>
   >[0]['validate'],
+  asyncValidate: asyncValidateOrganizationEmail,
+  asyncBlurFields: ['email'],
+  shouldAsyncValidate: shouldAsyncValidateOrganizationEmail,
   enableReinitialize: true,
 })(InviteUserFormInner as ComponentType<FormInnerProps<FormDataMap[Level.ORGANIZATION]>>);
 
@@ -130,6 +158,7 @@ export const InviteUser = <L extends keyof FormDataMap>({
   handleSubmit,
   dirty,
   invalid,
+  submitting,
   projectId,
   projectName,
 }: InviteUserProps<L>) => {
@@ -163,7 +192,7 @@ export const InviteUser = <L extends keyof FormDataMap>({
     }
   };
 
-  const inviteUserAndCloseModal = async (formData: FormDataMap[L]) => {
+  const completeInvite = async (formData: FormDataMap[L]) => {
     const userData = buildUserData(formData) as InvitationRequestData;
     const getCondition = (): InviteProjectCondition => {
       if (level === Level.PROJECT) return 'without_project';
@@ -202,10 +231,27 @@ export const InviteUser = <L extends keyof FormDataMap>({
     }
   };
 
+  const inviteUserAndCloseModal = async (formData: FormDataMap[L]) => {
+    if (level === Level.ORGANIZATION) {
+      const orgFormData = formData as FormDataMap[Level.ORGANIZATION];
+      const { id: organizationId } = orgFormData.organization ?? {};
+
+      if (organizationId != null) {
+        try {
+          await validateAsync.organizationUserEmailUnique(organizationId, orgFormData.email);
+        } catch (error: unknown) {
+          throw new SubmissionError(error);
+        }
+      }
+    }
+
+    return completeInvite(formData);
+  };
+
   const okButton: ModalButtonProps = {
     children: okButtonTitle,
     onClick: handleSubmit(inviteUserAndCloseModal) as () => void,
-    disabled: !dirty || invalid,
+    disabled: !dirty || invalid || submitting,
     'data-automation-id': 'submitButton',
   };
 

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
@@ -96,7 +96,10 @@ const asyncValidateOrganizationEmail = ({
     return Promise.resolve();
   }
 
-  return validateAsync.organizationUserEmailUnique(organization.id, email);
+  return validateAsync.organizationUserEmailUnique(
+    organization.id,
+    extractEmailString(email).trim(),
+  );
 };
 
 const shouldAsyncValidateOrganizationEmail = ({
@@ -238,7 +241,10 @@ export const InviteUser = <L extends keyof FormDataMap>({
 
       if (organizationId != null) {
         try {
-          await validateAsync.organizationUserEmailUnique(organizationId, orgFormData.email);
+          await validateAsync.organizationUserEmailUnique(
+            organizationId,
+            extractEmailString(orgFormData.email).trim(),
+          );
         } catch (error: unknown) {
           throw new SubmissionError(error);
         }

--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserOrganizationForm/inviteUserOrganizationForm.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserOrganizationForm/inviteUserOrganizationForm.tsx
@@ -1,5 +1,3 @@
-import { useState, useCallback } from 'react';
-
 import { createClassnames } from 'common/utils';
 import { FieldElement } from 'pages/inside/projectSettingsPageContainer/content/elements';
 import {
@@ -18,29 +16,14 @@ const cx = createClassnames(styles);
 export interface InviteUserOrganizationFormData {
   email: string;
   organization: Organization;
-  isAddingProject?: boolean
+  isAddingProject?: boolean;
 }
 
-export const InviteUserOrganizationForm = () => {
-  const [invitedUserId, setInvitedUserId] = useState<number | null>(null);
-
-  const handleUserSelect = useCallback((userId: number | null) => {
-    setInvitedUserId(userId);
-  }, []);
-
-  return (
-    <form className={cx('form')}>
-      <InviteUserEmailField
-        formName={getFormName(Level.ORGANIZATION)}
-        onUserSelect={handleUserSelect}
-      />
-      <FieldElement name="organization">
-        <OrganizationAssignment
-          invitedUserId={invitedUserId}
-          formName={getFormName(Level.ORGANIZATION)}
-          excludeUserAssignments
-        />
-      </FieldElement>
-    </form>
-  );
-};
+export const InviteUserOrganizationForm = () => (
+  <form className={cx('form')}>
+    <InviteUserEmailField formName={getFormName(Level.ORGANIZATION)} />
+    <FieldElement name="organization">
+      <OrganizationAssignment formName={getFormName(Level.ORGANIZATION)} excludeUserAssignments />
+    </FieldElement>
+  </form>
+);


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
### Problem
On the organization invite flow, blurring the email field triggered `searchAllUsers` and passed `userId` into `OrganizationAssignment`, which then fetched user projects — an endpoint managers cannot access. Duplicate users were not validated at the organization level.

### What changed

**`asyncValidation.js`**  
Added `organizationUserEmailUnique`: calls `GET /organizations/{id}/users?email=...`, throws `{ email: 'duplicationOrganization' }` on duplicate. Skips the request for invalid emails and on API errors (e.g. 504) so submit is not blocked.

**`inviteUserModal.tsx`**  
Organization form follows the `filterEditModal` pattern:
- **On blur** — `asyncValidate` + `asyncBlurFields` for early feedback; `invalid` disables Invite so the user cannot continue with a duplicate email.
- **On submit** — uniqueness is checked again in `onSubmit` and errors are thrown as `SubmissionError`. This is intentionally kept as a **guard**, same as `filterEditModal`: it covers edge cases where blur validation did not run or did not finish (submit without blur, race while blur async is in flight). It may cause a second API call after a successful blur check — accepted trade-off for reliability.
- **`shouldAsyncValidate`** — async runs on blur/change only, not as redux-form pre-submit async (avoids a third request and submit-button quirks).
- **Organization ID** — taken from `form.organization.id` (already in `initialValues`), no extra prop.
- Submit button: `disabled={!dirty || invalid || submitting}`.

**`inviteUserEmailField.tsx` / `inviteUserOrganizationForm.tsx`**  
Removed `searchAllUsers` on blur, `onUserSelect`, and `invitedUserId` passed to `OrganizationAssignment`. Email is a plain redux-form field again.

**`fieldErrorHint.jsx`**  
Registered `duplicationOrganization` by importing the descriptor from `invitationsLocalization` (spread after `defineMessages`). Message text lives in one place; validation throws a key, `FieldErrorHint` resolves it.

### Why this approach
- Matches established redux-form patterns in the codebase (`filterEditModal`).
- Avoids custom `isSubmitPending` / `asyncValidating` workarounds.
- Fixes the manager permission issue by removing the unnecessary user lookup on blur.

## Links
[EPMRPP-116987](https://jiraeu.epam.com/browse/EPMRPP-116987)

## Visuals

https://github.com/user-attachments/assets/9cfdf0dc-cc5a-458f-b3a8-07d1c7602d21




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization invites now validate email uniqueness before sending, helping prevent duplicate invite errors.
  * Invitation email entry is simpler and now shows a clear duplication-related message when needed.

* **Bug Fixes**
  * Improved invite form behavior so submission is blocked while validation is in progress.
  * Removed extra email lookup behavior from the invite flow for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->