### PR TITLE
EPMRPP-117063 || Extra middle spaces in organization name are not removed when creating organization

### DIFF
--- a/app/src/common/hooks/useBreadCrumbsTree.tsx
+++ b/app/src/common/hooks/useBreadCrumbsTree.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
@@ -28,9 +28,10 @@ import { activeOrganizationNameSelector } from 'controllers/organization';
 import { projectNameSelector } from 'controllers/project';
 import { ProjectDetails } from 'pages/organization/constants';
 import { messages } from 'pages/organization/messages';
+import { PreservedText } from 'components/preservedText';
 
 interface BreadcrumbTreeNode {
-  title: string;
+  title: string | ReactNode;
   link: object;
   children?: BreadcrumbTreeNode[];
 }
@@ -52,7 +53,7 @@ export const useBreadCrumbsTree = (): BreadcrumbTreeNode[] => {
 
     if (organizationSlug) {
       const organizationCrumb: BreadcrumbTreeNode = {
-        title: organizationName,
+        title: <PreservedText>{organizationName}</PreservedText>,
         link: { type: ORGANIZATION_PROJECTS_PAGE, payload: { organizationSlug } },
         children: [],
       };

--- a/app/src/components/preservedText/index.ts
+++ b/app/src/components/preservedText/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { PreservedText } from './preservedText';

--- a/app/src/components/preservedText/preservedText.scss
+++ b/app/src/components/preservedText/preservedText.scss
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.preserved-text {
+  white-space: pre;
+
+  &.wrap {
+    white-space: pre-wrap;
+  }
+}

--- a/app/src/components/preservedText/preservedText.tsx
+++ b/app/src/components/preservedText/preservedText.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react';
+import { createClassnames } from 'common/utils';
+
+import styles from './preservedText.scss';
+
+const cx = createClassnames(styles);
+
+interface PreservedTextProps {
+  children: ReactNode;
+  className?: string;
+  wrap?: boolean;
+}
+
+export const PreservedText = ({ children, className, wrap = false }: PreservedTextProps) => (
+  <span className={cx('preserved-text', { wrap }, className)}>{children}</span>
+);

--- a/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
+++ b/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
@@ -37,6 +37,7 @@ import {
   activeOrganizationSelector,
 } from 'controllers/organization';
 import { SIDEBAR_EVENTS } from 'components/main/analytics/events';
+import { PreservedText } from 'components/preservedText';
 import { OrganizationsControlWithPopover } from '../../organizationsControl';
 import { messages } from '../../messages';
 import { useUserPermissions } from 'hooks/useUserPermissions';
@@ -116,7 +117,7 @@ export const OrganizationSidebar = ({ onClickNavBtn }) => {
   const titles = {
     shortTitle: `${organizationName?.[0]}${organizationName?.[organizationName.length - 1]}`,
     topTitle: formatMessage(messages.allOrganizations),
-    bottomTitle: organizationName,
+    bottomTitle: <PreservedText>{organizationName}</PreservedText>,
     level: 'organization',
   };
 

--- a/app/src/layouts/organizationsControl/organizationsPopover/organizationsItem/organizationsItem.jsx
+++ b/app/src/layouts/organizationsControl/organizationsPopover/organizationsItem/organizationsItem.jsx
@@ -24,6 +24,7 @@ import { NavLink } from 'components/main/navLink';
 import { ORGANIZATION_PROJECTS_PAGE } from 'controllers/pages/constants';
 import { useTracking } from 'react-tracking';
 import { SIDEBAR_EVENTS } from 'components/main/analytics/events';
+import { PreservedText } from 'components/preservedText';
 import ArrowDownIcon from './img/arrow-down-inline.svg';
 import ArrowRightIcon from './img/arrow-right-inline.svg';
 import OpenIcon from './img/open-inline.svg';
@@ -124,7 +125,9 @@ export const OrganizationsItem = ({
         onBlur={onBlurCollapseButton}
       >
         {Parser(ArrowIcon)}
-        <div className={cx('organization-name', { active: isActive })}>{organizationName}</div>
+        <div className={cx('organization-name', { active: isActive })}>
+          <PreservedText>{organizationName}</PreservedText>
+        </div>
       </button>
       <NavLink
         to={{

--- a/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
+++ b/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
@@ -58,6 +58,7 @@ import { projectNameSelector } from 'controllers/project';
 import { activeOrganizationNameSelector } from 'controllers/organization';
 import { OrganizationsControlWithPopover } from '../../organizationsControl';
 import { getTmsOverride } from 'controllers/appInfo/utils';
+import { PreservedText } from 'components/preservedText';
 import { messages } from '../../messages';
 
 const ORGANIZATION_CONTROL = 'Organization control';
@@ -267,7 +268,11 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
   };
   const titles = {
     shortTitle: `${projectName[0]}${projectName[projectName.length - 1]}`,
-    topTitle: `${formatMessage(messages.organization)}: ${organizationName}`,
+    topTitle: (
+      <PreservedText>
+        {formatMessage(messages.organization)}: {organizationName}
+      </PreservedText>
+    ),
     bottomTitle: projectName,
     level: 'project',
   };

--- a/app/src/pages/inside/common/assignments/unassignOrganizationModal/unassignOrganizationModal.tsx
+++ b/app/src/pages/inside/common/assignments/unassignOrganizationModal/unassignOrganizationModal.tsx
@@ -26,6 +26,7 @@ import { idSelector, UserInfo } from 'controllers/user';
 import { messages } from 'common/constants/localization/assignmentsLocalization';
 import { unassignFromOrganizationAction } from 'controllers/organization/users';
 import { Organization } from 'controllers/organization';
+import { PreservedText } from 'components/preservedText';
 import { useHandleUnassignSuccess } from '../hooks';
 
 import styles from './unassignOrganizationModal.scss';
@@ -80,7 +81,11 @@ export const UnassignOrganizationModal = ({
         {formatMessage(descriptionMessage, {
           name: user.fullName,
           organization: organization.name,
-          b: (innerData) => <b>{innerData}</b>,
+          b: (innerData) => (
+            <PreservedText>
+              <b>{innerData}</b>
+            </PreservedText>
+          ),
         })}
       </div>
     </Modal>

--- a/app/src/pages/inside/common/assignments/unassignOrganizationModal/unassignOrganizationModal.tsx
+++ b/app/src/pages/inside/common/assignments/unassignOrganizationModal/unassignOrganizationModal.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ReactNode } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { Modal } from '@reportportal/ui-kit';
@@ -32,6 +33,12 @@ import { useHandleUnassignSuccess } from '../hooks';
 import styles from './unassignOrganizationModal.scss';
 
 const cx = createClassnames(styles);
+
+const BoldOrganizationName = (chunks: ReactNode) => (
+  <PreservedText wrap>
+    <b>{chunks}</b>
+  </PreservedText>
+);
 
 interface UnassignOrganizationModalProps {
   user: UserInfo;
@@ -81,11 +88,7 @@ export const UnassignOrganizationModal = ({
         {formatMessage(descriptionMessage, {
           name: user.fullName,
           organization: organization.name,
-          b: (innerData) => (
-            <PreservedText>
-              <b>{innerData}</b>
-            </PreservedText>
-          ),
+          b: BoldOrganizationName,
         })}
       </div>
     </Modal>

--- a/app/src/pages/instance/organizationsPage/modals/createOrganizationModal/createOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/modals/createOrganizationModal/createOrganizationModal.tsx
@@ -51,7 +51,7 @@ const CreateOrganizationModal = ({
   const { trackEvent } = useTracking();
 
   const onCreateOrganization = ({ organizationName }: CreateOrganizationFormData) => {
-    onSubmit(organizationName);
+    onSubmit(organizationName.trim());
     trackEvent(ORGANIZATION_PAGE_EVENTS.CLICK_CREATE_BUTTON);
   };
   const hideModal = () => dispatch(hideModalAction());

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/assignToOrganizationModal/assignToOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/assignToOrganizationModal/assignToOrganizationModal.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ReactNode } from 'react';
 import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
@@ -33,6 +34,12 @@ import { messages } from 'pages/instance/organizationsPage/messages';
 import styles from './assignToOrganizationModal.scss';
 
 const cx = createClassnames(styles);
+
+const BoldOrganizationName = (chunks: ReactNode) => (
+  <PreservedText wrap>
+    <b>{chunks}</b>
+  </PreservedText>
+);
 
 interface AssignToOrganizationModalProps {
   organization: Organization;
@@ -77,11 +84,7 @@ export const AssignToOrganizationModal = ({
       <div className={cx('modal-content')}>
         {formatMessage(messages.assignToOrganizationModalDescription, {
           organizationName: organization.name,
-          b: (data) => (
-            <PreservedText>
-              <b>{data}</b>
-            </PreservedText>
-          ),
+          b: BoldOrganizationName,
         })}
       </div>
     </Modal>

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/assignToOrganizationModal/assignToOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/assignToOrganizationModal/assignToOrganizationModal.tsx
@@ -26,6 +26,7 @@ import { ModalButtonProps } from 'types/common';
 import { Organization } from 'controllers/organization';
 import { assignToOrganizationAction } from 'controllers/organization/users';
 import { fetchUserInfoAction } from 'controllers/user';
+import { PreservedText } from 'components/preservedText';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
 import { messages } from 'pages/instance/organizationsPage/messages';
 
@@ -76,7 +77,11 @@ export const AssignToOrganizationModal = ({
       <div className={cx('modal-content')}>
         {formatMessage(messages.assignToOrganizationModalDescription, {
           organizationName: organization.name,
-          b: (data) => <b>{data}</b>,
+          b: (data) => (
+            <PreservedText>
+              <b>{data}</b>
+            </PreservedText>
+          ),
         })}
       </div>
     </Modal>

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationsModal/deleteOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationsModal/deleteOrganizationModal.tsx
@@ -32,6 +32,7 @@ import { commonValidators } from 'common/utils/validation';
 import { ModalButtonProps } from 'types/common';
 import { messages } from 'pages/instance/organizationsPage/messages';
 import { deleteOrganizationAction } from 'controllers/instance/organizations/actionCreators';
+import { PreservedText } from 'components/preservedText';
 
 import styles from './deleteOrganizationModal.scss';
 
@@ -92,7 +93,11 @@ const DeleteOrganizationModal = ({
         <p>
           {formatMessage(messages.confirmDeleteOrganizationMessage, {
             name: organization.name,
-            b: (data) => <b>{data}</b>,
+            b: (data) => (
+              <PreservedText>
+                <b>{data}</b>
+              </PreservedText>
+            ),
           })}
         </p>
         <FieldProvider name={ORGANIZATION_NAME_FIELD}>

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationsModal/deleteOrganizationModal.tsx
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/modals/deleteOrganizationsModal/deleteOrganizationModal.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ReactNode } from 'react';
 import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
@@ -37,6 +38,12 @@ import { PreservedText } from 'components/preservedText';
 import styles from './deleteOrganizationModal.scss';
 
 const cx = createClassnames(styles);
+
+const BoldOrganizationName = (chunks: ReactNode) => (
+  <PreservedText wrap>
+    <b>{chunks}</b>
+  </PreservedText>
+);
 
 const ORGANIZATION_NAME_FIELD = 'organizationName';
 const DELETE_ORGANIZATION_FORM = 'deleteOrganizationForm';
@@ -93,11 +100,7 @@ const DeleteOrganizationModal = ({
         <p>
           {formatMessage(messages.confirmDeleteOrganizationMessage, {
             name: organization.name,
-            b: (data) => (
-              <PreservedText>
-                <b>{data}</b>
-              </PreservedText>
-            ),
+            b: BoldOrganizationName,
           })}
         </p>
         <FieldProvider name={ORGANIZATION_NAME_FIELD}>

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/organizationsPanels/organizationCard/organizationCard.scss
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/organizationsPanels/organizationCard/organizationCard.scss
@@ -88,7 +88,7 @@
   color: $COLOR--almost-black;
   font-size: 13px;
   line-height: 20px;
-  white-space: nowrap;
+  white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
 

--- a/app/src/pages/instance/organizationsPage/organizationsPanelView/organizationsTable/organizationsTable.scss
+++ b/app/src/pages/instance/organizationsPage/organizationsPanelView/organizationsTable/organizationsTable.scss
@@ -45,7 +45,7 @@
   color: $COLOR--almost-black;
   font-size: 13px;
   line-height: 20px;
-  white-space: nowrap;
+  white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/app/src/pages/organization/organizationEventsPage/eventsGrid/eventsGrid.tsx
+++ b/app/src/pages/organization/organizationEventsPage/eventsGrid/eventsGrid.tsx
@@ -35,6 +35,7 @@ import {
   ENTITY_PROJECT_NAME,
   ENTITY_SUBJECT_TYPE,
 } from 'components/filterEntities/constants';
+import { PreservedText } from 'components/preservedText';
 
 import styles from './eventsGrid.scss';
 
@@ -131,7 +132,9 @@ const ObjectTypeColumn = ({
 );
 
 const ObjectNameColumn = ({ className, value = {} }: BaseColumnComponentProps) => (
-  <div className={cx('object-name-col', className)}>{value.object_name}</div>
+  <div className={cx('object-name-col', className)}>
+    <PreservedText wrap>{value.object_name}</PreservedText>
+  </div>
 );
 
 const ValueColumn = ({
@@ -143,7 +146,9 @@ const ValueColumn = ({
     {value?.details?.history.map((item) => (
       <React.Fragment key={`${item.field}__${item.oldValue}__${item.newValue}`}>
         <div>{item.field}:</div>
-        <div className={cx('value')}>{item[valueType]}</div>
+        <div className={cx('value')}>
+          <PreservedText wrap>{item[valueType]}</PreservedText>
+        </div>
       </React.Fragment>
     ))}
   </div>

--- a/app/src/pages/organization/organizationEventsPage/eventsToolbar/eventsToolbar.jsx
+++ b/app/src/pages/organization/organizationEventsPage/eventsToolbar/eventsToolbar.jsx
@@ -28,6 +28,7 @@ import {
   urlOrganizationSlugSelector,
 } from 'controllers/pages';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
+import { PreservedText } from 'components/preservedText';
 import { EventsEntities } from '../eventsEntities';
 import styles from './eventsToolbar.scss';
 
@@ -59,7 +60,7 @@ export const EventsToolbar = () => {
       link: { type: ORGANIZATIONS_PAGE },
     },
     {
-      title: organizationName,
+      title: <PreservedText>{organizationName}</PreservedText>,
       link: { type: ORGANIZATION_PROJECTS_PAGE, payload: { organizationSlug } },
     },
     {

--- a/app/src/pages/organization/organizationProjectsPage/projectsPageHeader/projectsPageHeader.jsx
+++ b/app/src/pages/organization/organizationProjectsPage/projectsPageHeader/projectsPageHeader.jsx
@@ -30,6 +30,7 @@ import { SEARCH_KEY, NAMESPACE } from 'controllers/organization/projects/constan
 import { withFilter } from 'controllers/filter';
 import { createFilterEntitiesURLContainer } from 'components/filterEntities/containers';
 import { PROJECTS_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/projectsPageEvents';
+import { PreservedText } from 'components/preservedText';
 import { ProjectsFilter } from './projectsFilter';
 import projectsIcon from './img/projects-inline.svg';
 import userIcon from './img/user-inline.svg';
@@ -69,7 +70,7 @@ export const ProjectsPageHeader = ({
 
   if (organizationName) {
     breadcrumbs.push({
-      title: organizationName,
+      title: <PreservedText>{organizationName}</PreservedText>,
     });
   }
 
@@ -80,7 +81,7 @@ export const ProjectsPageHeader = ({
       </div>
       <div className={cx('header')}>
         <div className={cx('main-content')}>
-          <span className={cx('title')}>{organizationName}</span>
+          <PreservedText className={cx('title')}>{organizationName}</PreservedText>
           {isNotEmpty && hasPermission && (
             <div className={cx('details')}>
               <div className={cx('details-item')}>

--- a/app/src/pages/organization/organizationProjectsPage/projectsPageHeader/projectsPageHeader.scss
+++ b/app/src/pages/organization/organizationProjectsPage/projectsPageHeader/projectsPageHeader.scss
@@ -40,7 +40,6 @@
     font-size: 20px;
     line-height: 31px;
     color: $COLOR--almost-black;
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;

--- a/app/src/pages/organization/organizationUsersPage/organizationUsersPageHeader/organizationUsersPageHeader.jsx
+++ b/app/src/pages/organization/organizationUsersPage/organizationUsersPageHeader/organizationUsersPageHeader.jsx
@@ -27,6 +27,7 @@ import { activeOrganizationSelector } from 'controllers/organization';
 import { InviteUserButton } from 'pages/inside/common/invitations';
 import { ORGANIZATION_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/organizationsPageEvents';
 import { LocationHeaderLayout } from 'layouts/locationHeaderLayout';
+import { PreservedText } from 'components/preservedText';
 import { messages } from '../../messages';
 import styles from './organizationUsersPageHeader.scss';
 
@@ -58,7 +59,7 @@ export const OrganizationUsersPageHeader = ({
 
   if (organizationSlug) {
     breadcrumbs.push({
-      title: organizationName,
+      title: <PreservedText>{organizationName}</PreservedText>,
       link: { type: ORGANIZATION_PROJECTS_PAGE, payload: { organizationSlug } },
     });
   }

--- a/app/src/pages/organization/projectTeamPage/projectTeamPageHeader/projectTeamPageHeader.jsx
+++ b/app/src/pages/organization/projectTeamPage/projectTeamPageHeader/projectTeamPageHeader.jsx
@@ -32,6 +32,7 @@ import { ssoUsersOnlySelector } from 'controllers/appInfo';
 import { activeOrganizationNameSelector } from 'controllers/organization';
 import { urlOrganizationSlugSelector, urlProjectSlugSelector } from 'controllers/pages';
 import { LocationHeaderLayout } from 'layouts/locationHeaderLayout';
+import { PreservedText } from 'components/preservedText';
 import { messages } from '../../messages';
 import styles from './projectTeamPageHeader.scss';
 
@@ -64,7 +65,7 @@ export const ProjectTeamPageHeader = ({
   };
 
   const organizationCrumb = {
-    title: organizationName,
+    title: <PreservedText>{organizationName}</PreservedText>,
     link: { type: ORGANIZATION_PROJECTS_PAGE, payload: { organizationSlug } },
     children: []
   };


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
Introduced a reusable `PreservedText` component that renders text in a `<span>` with `white-space: pre` (and `pre-wrap` via the `wrap` prop) so organization names display exactly as stored, including internal spaces. 

**Files changed:**
- New: `components/preservedText`
- Modals: assignToOrganization, unassignOrganization, deleteOrganization, createOrganization (trim the value on submit)
- Headers: projectsPageHeader, organizationUsersPageHeader, projectTeamPageHeader
- Sidebars: organizationSidebar, projectSidebar, organizationsItem
- Breadcrumbs: useBreadCrumbsTree.tsx, eventsToolbar
- Activity: eventsGrid (object name + old/new values, with `wrap`)

## Visuals
**_Before:_**
<img width="1919" height="608" alt="Screenshot 2026-06-29 152755" src="https://github.com/user-attachments/assets/77323df8-5948-4118-b8e5-78338c05dd42" />

**_After:_**
<img width="1919" height="611" alt="Screenshot 2026-06-29 152806" src="https://github.com/user-attachments/assets/46ce3210-3dd8-42c2-859f-df763dbd5264" />

**_Before:_**
<img width="683" height="666" alt="Screenshot 2026-06-29 152819" src="https://github.com/user-attachments/assets/b14131ba-e645-412a-afd1-bd279b5cc9fe" />

**_After:_**
<img width="670" height="678" alt="Screenshot 2026-06-29 152829" src="https://github.com/user-attachments/assets/23798be3-f93d-44e0-ab00-c6a351c3bead" />

**_Before:_**
<img width="688" height="354" alt="Screenshot 2026-06-29 152843" src="https://github.com/user-attachments/assets/cab7a791-bbbe-435b-aeba-56ab0ed50ca1" />

**_After:_**
<img width="636" height="348" alt="Screenshot 2026-06-29 152850" src="https://github.com/user-attachments/assets/5f7d5bce-1aad-48c8-aede-03d487bd759f" />

**_Before:_**
<img width="1919" height="726" alt="Screenshot 2026-06-29 152909" src="https://github.com/user-attachments/assets/40ed294d-e59f-4f73-8f3b-1d0f763773d5" />

**_After:_**
<img width="1919" height="736" alt="Screenshot 2026-06-29 153002" src="https://github.com/user-attachments/assets/a7accf40-1f6e-4231-88f9-6975ce40ac64" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text rendering across organization pages, breadcrumbs, sidebars, event history, and confirmation dialogs so names and values keep their spacing and line breaks.
  * Organization-related titles now display more consistently in headers and navigation.

* **Bug Fixes**
  * Fixed organization creation to remove leading/trailing spaces before saving.
  * Updated organization link and title styling to better handle wrapped or spaced text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->