### PR TITLE
EPMRPP-117183 || map BTS ticket url to link for ui-kit IssueList

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
@@ -141,9 +141,10 @@ export const ExecutionSidePanel = ({ executionId, onClose }: ExecutionSidePanelP
     return tickets.map(
       (ticket) =>
         ({
+          ...ticket,
           key: String(ticket.ticketId),
           name: ticket.ticketId,
-          ...ticket,
+          link: ticket.url,
         }) as Issue,
     );
   };

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/LinkedToBTSSection/LinkedToBTSSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/LinkedToBTSSection/LinkedToBTSSection.tsx
@@ -44,7 +44,7 @@ const convertBTSTicketsToIssues = (tickets: BtsTicket[]): Issue[] =>
         ...ticket,
         key: String(ticket.ticketId),
         name: String(ticket.ticketId),
-        url: ticket.url,
+        link: ticket.url,
       }) as Issue,
   );
 


### PR DESCRIPTION
## Problem

On the Manual Launch Test Execution page, linked BTS tickets in the **Linked to BTS** section are rendered as static chips. Clicking a ticket ID does not open the external BTS issue, although the URL is returned by the backend.

**Steps to reproduce:** Manual Launches → open a launch → open a Failed test execution with a linked BTS ticket → scroll to Linked to BTS → click the ticket chip.

**Root cause:** `convertBTSTicketsToIssues` passes `url` from `BtsTicket` into ui-kit `IssueList`, but the `Issue` interface expects `link`. Without `link`, ui-kit `Chip` renders a non-clickable `<span>` instead of an anchor. Core ReportPortal already maps correctly in `AdaptiveIssueList` (`link: issue.url`).

## Solution

Map `ticket.url` to `link` when converting `BtsTicket[]` to ui-kit `Issue[]` in both TMS surfaces that render linked BTS tickets:

- Test Execution page (`LinkedToBTSSection`)
- Launch executions side panel (`executionSidePanel`)

Unlink behavior and backend integration are unchanged.

## Visuals

### Before
<img width="1453" height="990" alt="image" src="https://github.com/user-attachments/assets/e55b23e9-673d-4625-acd2-a59e94ea9996" />


### After

<img width="910" height="991" alt="image" src="https://github.com/user-attachments/assets/8ecbc601-47fa-4344-ba54-35a1ce1a4129" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how BTS-linked items are converted and displayed so they now use the correct link for each ticket.
  * Improved the way ticket details are passed through, reducing the chance of incorrect item names or identifiers showing up in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->