### PR TITLE
EPMRPP-115870 || Align TCS promo banner Documentation link with Figma

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,7 +13,7 @@
         "@formatjs/intl-pluralrules": "1.3.9",
         "@formatjs/intl-relativetimeformat": "4.5.1",
         "@formatjs/intl-utils": "1.6.0",
-        "@reportportal/ui-kit": "^0.0.1-alpha.229",
+        "@reportportal/ui-kit": "^0.0.1-alpha.239",
         "axios": "^1.13.2",
         "c3": "0.7.20",
         "chart.js": "2.9.4",
@@ -4880,9 +4880,9 @@
       "license": "MIT"
     },
     "node_modules/@reportportal/ui-kit": {
-      "version": "0.0.1-alpha.229",
-      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.229.tgz",
-      "integrity": "sha512-5pczkj3cqInB3/ABi9ut9MYG8H851kM6rnYToCV3puuPVMBwNCNZ0RXCbY6hVllWdPsGJuD21EKoIj5A3nQYVA==",
+      "version": "0.0.1-alpha.239",
+      "resolved": "https://registry.npmjs.org/@reportportal/ui-kit/-/ui-kit-0.0.1-alpha.239.tgz",
+      "integrity": "sha512-vXRe4+jLZrk40mpruV85jRUbBXXxs9rr0zKPlVK6YAyyU4zD4j9waQKkpLcN7J/DOnZ0PzOnu7VGX2xiGE7TbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "@formatjs/intl-pluralrules": "1.3.9",
     "@formatjs/intl-relativetimeformat": "4.5.1",
     "@formatjs/intl-utils": "1.6.0",
-    "@reportportal/ui-kit": "^0.0.1-alpha.229",
+    "@reportportal/ui-kit": "^0.0.1-alpha.239",
     "axios": "^1.13.2",
     "c3": "0.7.20",
     "chart.js": "2.9.4",

--- a/app/src/components/widgets/multiLevelWidgets/testCaseSearchTable/testCaseSearch.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/testCaseSearchTable/testCaseSearch.jsx
@@ -128,9 +128,6 @@ export const TestCaseSearch = ({ widget: { id: widgetId }, isDisplayedLaunches }
     dispatch(loadMoreSearchedItemsAction({ widgetId, trackPerformance, isDisplayedLaunches }));
   };
 
-  const handleDocumentationClick = () => {
-    trackEvent(WIDGETS_EVENTS.onTcsPromoDocumentationClick(dashboardId, PROMOTION_BANNER_SOURCE));
-  };
   const handleLoadMoreMessageDocumentationClick = () => {
     trackEvent(
       WIDGETS_EVENTS.onSearchWidgetDocumentLinkClick(dashboardId, 'promotion_load_more_message'),
@@ -206,7 +203,10 @@ export const TestCaseSearch = ({ widget: { id: widgetId }, isDisplayedLaunches }
       />
       <TestExecutionsPromoBanner
         onOpenNewSearch={handleOpenNewSearch}
-        onDocumentationClick={handleDocumentationClick}
+        documentationClickEvent={WIDGETS_EVENTS.onTcsPromoDocumentationClick(
+          dashboardId,
+          PROMOTION_BANNER_SOURCE,
+        )}
       />
       <TestCaseSearchContent
         listView={isDisplayedLaunches}

--- a/app/src/components/widgets/multiLevelWidgets/testCaseSearchTable/testExecutionsPromoBanner/testExecutionsPromoBanner.jsx
+++ b/app/src/components/widgets/multiLevelWidgets/testCaseSearchTable/testExecutionsPromoBanner/testExecutionsPromoBanner.jsx
@@ -22,17 +22,14 @@ import { useIntl } from 'react-intl';
 import NavigationIcon from 'common/img/navigation-icon-inline.svg';
 import OpenInNewTabIcon from 'common/img/open-in-new-tab-inline.svg';
 import { widgetDocsReferences } from 'common/utils/referenceDictionary';
+import { LinkComponent } from 'pages/inside/projectSettingsPageContainer/content/notifications/LinkComponent';
 import { messages } from '../messages';
 import styles from './testExecutionsPromoBanner.scss';
 
 const cx = classNames.bind(styles);
 
-export const TestExecutionsPromoBanner = ({ onOpenNewSearch, onDocumentationClick }) => {
+export const TestExecutionsPromoBanner = ({ onOpenNewSearch, documentationClickEvent }) => {
   const { formatMessage } = useIntl();
-
-  const handleDocumentationClick = () => {
-    onDocumentationClick?.();
-  };
 
   return (
     <div className={cx('banner')}>
@@ -46,16 +43,14 @@ export const TestExecutionsPromoBanner = ({ onOpenNewSearch, onDocumentationClic
         </div>
       </div>
       <div className={cx('banner-actions')}>
-        <a
+        <LinkComponent
+          to={widgetDocsReferences.testExecutions}
+          icon={OpenInNewTabIcon}
           className={cx('documentation-link')}
-          href={widgetDocsReferences.testExecutions}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={handleDocumentationClick}
+          event={documentationClickEvent}
         >
-          {formatMessage(messages.documentationButton)}
-          <span className={cx('external-link-icon')}>{Parser(OpenInNewTabIcon)}</span>
-        </a>
+          <span>{formatMessage(messages.documentationButton)}</span>
+        </LinkComponent>
         <button type="button" className={cx('open-new-search-btn')} onClick={onOpenNewSearch}>
           {formatMessage(messages.openNewSearchButton)}
         </button>
@@ -66,5 +61,5 @@ export const TestExecutionsPromoBanner = ({ onOpenNewSearch, onDocumentationClic
 
 TestExecutionsPromoBanner.propTypes = {
   onOpenNewSearch: PropTypes.func,
-  onDocumentationClick: PropTypes.func,
+  documentationClickEvent: PropTypes.object,
 };

--- a/app/src/components/widgets/multiLevelWidgets/testCaseSearchTable/testExecutionsPromoBanner/testExecutionsPromoBanner.scss
+++ b/app/src/components/widgets/multiLevelWidgets/testCaseSearchTable/testExecutionsPromoBanner/testExecutionsPromoBanner.scss
@@ -99,8 +99,9 @@
 .documentation-link {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-family: var(--rp-ui-base-font-family);
+  gap: 6px;
+  height: 18px;
+  font-family: var(--rp-ui-base-font-family-heading);
   font-weight: var(--rp-ui-base-fw-regular);
   font-size: 13px;
   line-height: 18px;
@@ -112,19 +113,9 @@
   &:hover {
     color: var(--rp-ui-base-topaz-hover);
   }
-}
 
-.external-link-icon {
-  display: inline-flex;
-  flex-shrink: 0;
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-
-  svg path {
-    fill: currentColor;
+  i svg * {
+    fill: var(--rp-ui-base-e-300);
   }
 }
 
@@ -137,7 +128,7 @@
   border: none;
   border-radius: 3px;
   background-color: var(--rp-ui-base-topaz);
-  font-family: var(--rp-ui-base-font-family);
+  font-family: var(--rp-ui-base-font-family-heading);
   font-weight: var(--rp-ui-base-fw-regular);
   font-size: 13px;
   line-height: 18px;


### PR DESCRIPTION
## Problem

On the Dashboard, the Test Case Search widget promotion banner shows a **Documentation** link with an external-link icon that is misaligned relative to the label text. Typography and icon colors also diverged from the Figma design.

**Steps to reproduce:** Open a Dashboard with a Test Case Search widget → observe the promotion banner at the bottom of the widget.

**Root cause:** The banner used a custom `<a>` markup and local styles instead of the shared `LinkComponent` pattern used elsewhere in service-ui. The text node and icon were laid out inconsistently, and icon styling did not follow project conventions (gray external-link icon with topaz link text).

## Solution

Replace the custom documentation link with `LinkComponent` and align banner action styles with the Figma mockup and existing project patterns:

- Reuse `LinkComponent` for the Documentation link (text + external-link icon alignment, analytics via `documentationClickEvent`)
- Set `--rp-ui-base-font-family-heading` for both the Documentation link and **Open New Search** button
- Keep the external-link icon gray (`--rp-ui-base-e-300`) in default and hover states, consistent with other documentation links in the app
- Apply topaz / topaz-hover colors to link text only

The visual appearance of both banner actions now matches the Figma design exactly.

## Visuals

<img width="1326" height="501" alt="image" src="https://github.com/user-attachments/assets/617fb4bf-51f2-4b35-ad46-205af7cda15c" />
