### PR TITLE
EPMRPP-116685 || Email Server. Billing doesn't detect organizational integration if global doesn't exist

### DIFF
--- a/app/src/controllers/plugins/selectors.js
+++ b/app/src/controllers/plugins/selectors.js
@@ -139,6 +139,9 @@ export const availableIntegrationsByPluginNameSelector = (state, pluginName) => 
   }
   let availableIntegrations = namedProjectIntegrationsSelector(state)[pluginName] || [];
   if (!availableIntegrations.length) {
+    availableIntegrations = namedOrganizationIntegrationsSelector(state)[pluginName] || [];
+  }
+  if (!availableIntegrations.length) {
     availableIntegrations = namedGlobalIntegrationsSelector(state)[pluginName] || [];
   }
   return availableIntegrations.filter((item) => item.enabled);

--- a/app/src/controllers/plugins/selectors.js
+++ b/app/src/controllers/plugins/selectors.js
@@ -21,6 +21,7 @@ import {
   NOTIFICATION_GROUP_TYPE,
 } from 'common/constants/pluginsGroupTypes';
 import { EMAIL, ORGANIZATION } from 'common/constants/pluginNames';
+import { APP_LEVEL, pageLevelSelector } from 'controllers/pages';
 import {
   filterAvailablePlugins,
   sortItemsByGroupType,
@@ -137,13 +138,30 @@ export const availableIntegrationsByPluginNameSelector = (state, pluginName) => 
   if (!selectedPlugin) {
     return [];
   }
-  let availableIntegrations = namedProjectIntegrationsSelector(state)[pluginName] || [];
-  if (!availableIntegrations.length) {
-    availableIntegrations = namedOrganizationIntegrationsSelector(state)[pluginName] || [];
+
+  const pageLevel = pageLevelSelector(state);
+  const projectIntegrations = namedProjectIntegrationsSelector(state)[pluginName] || [];
+  const organizationIntegrations = namedOrganizationIntegrationsSelector(state)[pluginName] || [];
+  const globalIntegrations = namedGlobalIntegrationsSelector(state)[pluginName] || [];
+
+  let availableIntegrations = globalIntegrations;
+
+  if (pageLevel === APP_LEVEL.ORGANIZATION) {
+    availableIntegrations = organizationIntegrations.length
+      ? organizationIntegrations
+      : globalIntegrations;
   }
-  if (!availableIntegrations.length) {
-    availableIntegrations = namedGlobalIntegrationsSelector(state)[pluginName] || [];
+
+  if (pageLevel === APP_LEVEL.PROJECT) {
+    if (projectIntegrations.length) {
+      availableIntegrations = projectIntegrations;
+    } else if (organizationIntegrations.length) {
+      availableIntegrations = organizationIntegrations;
+    } else {
+      availableIntegrations = globalIntegrations;
+    }
   }
+
   return availableIntegrations.filter((item) => item.enabled);
 };
 


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Fix:** Added organization-level integrations to the fallback chain in `availableIntegrationsByPluginNameSelector`.

**Before:** project → global  
**After:** project → organization → global

**Why:** After org-level Email Server support was added (`namedOrganizationIntegrationsSelector`), this selector was not updated. As a result, org-configured email integrations were skipped when resolving available integrations from project pages (e.g. notification rules, external user invitation modal). The selector now follows the correct hierarchy: project first, then organization, then global.

Also:
**Problem:** `availableIntegrationsByPluginNameSelector` always preferred **project → organization → global** based on whatever was left in Redux. Project/org integrations are **not cleared** on navigation (e.g. leaving a project for the org projects list or instance pages), so the selector could report integrations from a **previous context** instead of the current page.

**Fix:** Use `pageLevelSelector` (derived from URL) to scope the fallback chain:

- **Project** → project → organization → global  
- **Organization** → organization → global  
- **Instance** → global only  

This prevents stale project/org integrations from affecting pages where that context no longer applies.

## Links
[EPMRPP-116685](https://jiraeu.epam.com/browse/EPMRPP-116685)

## Visuals
**_Before:_**
<img width="622" height="679" alt="image" src="https://github.com/user-attachments/assets/bf3631d7-8660-420d-ace5-107005e456ef" />

**_After:_**
<img width="649" height="657" alt="Screenshot 2026-06-30 101044" src="https://github.com/user-attachments/assets/fdc9acf9-035a-45b1-bea8-e64f4ca9e338" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how available plugin integrations are chosen so they now respect the current page level.
  * On organization pages, organization-scoped integrations are preferred, with a fallback to global integrations.
  * On project pages, project-scoped integrations are preferred, then organization-scoped, then global integrations.
  * Disabled integrations are still filtered out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->