### PR TITLE
EPMRPP-116792 || Warning is shown when inviting new email to instance without global, but with organization integration existing

### DIFF
--- a/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
+++ b/app/src/pages/inside/common/invitations/inviteUserModal/inviteUserModal.tsx
@@ -21,11 +21,14 @@ import { isString } from 'es-toolkit';
 import DOMPurify from 'dompurify';
 import { Modal } from '@reportportal/ui-kit';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
+import { EMAIL } from 'common/constants/pluginNames';
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils/fetch';
 import { commonValidators, validateAsync } from 'common/utils/validation';
 import { showSuccessNotification } from 'controllers/notification';
 import { hideModalAction, showModalAction } from 'controllers/modal';
+import { Integration } from 'controllers/plugins';
+import { normalizeIntegrationItem } from 'controllers/plugins/utils';
 import { ModalButtonProps } from 'types/common';
 import { ApiError } from 'types/api';
 import { BoundValidator } from 'common/utils/validation/types';
@@ -213,6 +216,15 @@ export const InviteUser = <L extends keyof FormDataMap>({
     }
 
     if (invitedUser?.status === InvitationStatus.PENDING) {
+      let isOrgEmailIntegrationAvailable = false;
+      if (level === Level.INSTANCE && userData.organizations?.length === 1) {
+        const { items = [] } = await fetch<{ items: Integration[] }>(
+          URLS.organizationIntegrations(userData.organizations[0].id),
+        ).catch(() => ({ items: [] }));
+        isOrgEmailIntegrationAvailable = items
+          .map(normalizeIntegrationItem)
+          .some((item: Integration) => item.integrationType?.name === EMAIL && item.enabled);
+      }
       dispatch(
         showModalAction({
           component: (
@@ -220,6 +232,7 @@ export const InviteUser = <L extends keyof FormDataMap>({
               email={invitedUser.email}
               link={invitedUser.link}
               header={header}
+              isOrgEmailIntegrationAvailable={isOrgEmailIntegrationAvailable}
             />
           ),
         }),

--- a/app/src/pages/inside/common/modals/externalUserInvitationModal/externalUserInvitationModal.tsx
+++ b/app/src/pages/inside/common/modals/externalUserInvitationModal/externalUserInvitationModal.tsx
@@ -48,16 +48,19 @@ interface ExternalUserInvitationModalProps {
   email: string;
   link: string;
   header?: string;
+  isOrgEmailIntegrationAvailable?: boolean;
 }
 
 export const ExternalUserInvitationModal = ({
   email,
   link,
   header,
+  isOrgEmailIntegrationAvailable = false,
 }: ExternalUserInvitationModalProps) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-  const isEmailIntegrationAvailable = useSelector(isEmailIntegrationAvailableSelector);
+  const isEmailIntegrationAvailableFromStore = useSelector(isEmailIntegrationAvailableSelector);
+  const isEmailIntegrationAvailable = isEmailIntegrationAvailableFromStore || isOrgEmailIntegrationAvailable;
   const modalTitle = header || formatMessage(messages.header);
   const fullLink = getFullInvitationLink(link);
   const invitationMessageText = formatMessage(messages.invitationMessage, {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Fix: email server warning shown when inviting to organization with active email integration**

**inviteUserModal.tsx**
When an invitation results in a pending status and the level is `INSTANCE` with exactly one organization selected, fetch that organization's integrations before showing the confirmation modal. Check whether any is an enabled email integration. Pass the boolean result as `isOrgEmailIntegrationAvailable` to `ExternalUserInvitationModal`. The check is skipped for `PROJECT` and `ORGANIZATION` levels since `isEmailIntegrationAvailableSelector` already accounts for organizational integrations via `pageLevel` in those cases.

**externalUserInvitationModal.tsx**
Accept `isOrgEmailIntegrationAvailable?: boolean` prop (default `false`). Compute `isEmailIntegrationAvailable` as a union of the global store value and the prop. No async logic or loading state — the modal renders the correct content immediately on open.

## Links
[EPMRPP-116792](https://jiraeu.epam.com/browse/EPMRPP-116792)

## Visuals

https://github.com/user-attachments/assets/25849e0c-b686-419d-81fc-fd4bf7804546



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation flow now more accurately detects when an organization-level email integration is available, so pending external user invitations can be handled with the right email options.
  * The external user invitation modal now considers both account-level and organization-level email availability, improving consistency in invitation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->