### PR TITLE
EPMRPP-117319 || '+New value' button UI is broken for long values

### DIFF
--- a/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.jsx
+++ b/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.jsx
@@ -30,6 +30,7 @@ export const AutocompleteOption = ({
   isSelected,
   children,
   isNew,
+  showDivider,
   disabled,
   optionVariant,
   variant,
@@ -37,7 +38,7 @@ export const AutocompleteOption = ({
 }) => {
   return isNew ? (
     <>
-      <div className={cx('divider', variant)} />
+      {showDivider && <div className={cx('divider', variant)} />}
       <li
         className={cx('new-item', optionVariant, variant, {
           active: isActive,
@@ -49,7 +50,7 @@ export const AutocompleteOption = ({
         <span className={cx('value')}>{children}</span>
         <Button
           {...(!disabled ? props : {})}
-          className={cx({ 'button-active': isActive })}
+          className={cx('new-button', { 'button-active': isActive })}
           icon={Parser(PlusIcon)}
           variant="text"
           adjustWidthOn="content"
@@ -75,6 +76,7 @@ AutocompleteOption.propTypes = {
   isActive: PropTypes.bool,
   isSelected: PropTypes.bool,
   isNew: PropTypes.bool,
+  showDivider: PropTypes.bool,
   children: PropTypes.node,
   disabled: PropTypes.bool,
   optionVariant: singleAutocompleteOptionVariantType,
@@ -84,6 +86,7 @@ AutocompleteOption.defaultProps = {
   isActive: false,
   isSelected: false,
   isNew: false,
+  showDivider: false,
   children: null,
   disabled: false,
   optionVariant: '',

--- a/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.scss
+++ b/app/src/componentLibrary/autocompletes/common/autocompleteOption/autocompleteOption.scss
@@ -27,27 +27,10 @@
   }
 }
 
-@mixin draw-button-border($displayValue, $width) {
-  content: '';
-  display: block;
-  position: absolute;
-  width: $width;
-  height: 25px;
-  border-radius: 4px;
-  border: 1px solid $COLOR--topaz-focused;
-  top: 0;
-  left: 0;
-  transform: translateY(-2px);
-}
-
 @mixin button-active-state($width) {
   .button-active:not(.disabled, :hover) {
     position: relative;
     color: $COLOR--topaz-focused;
-
-    &::after {
-      @include draw-button-border(block, $width);
-    }
 
     svg * {
       fill: $COLOR--topaz-focused;
@@ -66,7 +49,7 @@
 .divider {
   display: block;
   height: 1px;
-  margin: 0 12px;
+  margin: 8px 12px;
   background: $COLOR--e-100;
 }
 
@@ -74,6 +57,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
 }
 
 .item,
@@ -87,17 +71,11 @@
   &:hover {
     background-color: $COLOR--bg-100;
   }
-
-  &.active:not(:hover) {
-    border: 1px solid $COLOR--topaz-focused;
-    padding: 3px 11px;
-  }
 }
 
 .value {
   display: inline-block;
   height: 28px;
-  max-width: 50%;
   padding: 4px 8px;
   font-size: 13px;
   text-align: center;
@@ -107,6 +85,11 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   box-sizing: border-box;
+}
+
+.new-button {
+  flex-shrink: 0;
+  min-width: fit-content;
 }
 
 .key-variant {

--- a/app/src/componentLibrary/autocompletes/common/autocompleteOptions.jsx
+++ b/app/src/componentLibrary/autocompletes/common/autocompleteOptions.jsx
@@ -103,7 +103,7 @@ export class AutocompleteOptions extends Component {
     return options.length ? options.map((item, index) => this.renderItem(item, index)) : '';
   };
 
-  renderNewItem = (options) => {
+  renderNewItem = (options, showDivider = false) => {
     const { inputValue, getItemProps, optionVariant, variant } = this.props;
     const index = options.length;
     const isNew = true;
@@ -114,6 +114,7 @@ export class AutocompleteOptions extends Component {
           optionVariant={optionVariant}
           {...getItemProps({ item: inputValue, index })}
           isNew={isNew}
+          showDivider={showDivider}
           variant={variant}
         >
           {this.props.parseValueToString(inputValue)}
@@ -132,7 +133,9 @@ export class AutocompleteOptions extends Component {
         <ScrollWrapper autoHeight autoHeightMax={140}>
           {this.renderItems(availableOptions)}
         </ScrollWrapper>
-        {!createWithoutConfirmation && creatable && this.renderNewItem(availableOptions)}
+        {!createWithoutConfirmation &&
+          creatable &&
+          this.renderNewItem(availableOptions, availableOptions.length > 0)}
       </div>
     );
   }


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
1. The `New key / New value` row in component-library autocompletes was updated.
The row that allows creating a new attribute key or value was broken when the typed text was long — the value chip was capped at 50% width, causing it to be cut off, while the button got squeezed or wrapped. The fix removes the `max-width: 50%` cap from the chip, adds `gap: 8px` between the chip and the button, and ensures the button always stays at least as wide as its text content with `min-width: fit-content`
2. The divider above the new-item row is now hidden by default and shown only when there are already loaded options above it.
3. In loading state, the divider stays hidden.

## Visuals

https://github.com/user-attachments/assets/3644b47b-3cdc-4d05-9bc9-651b30a10dcf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved autocomplete “new item” rendering so separators now appear only when relevant.
  * Added clearer active-state styling for new autocomplete options.

* **Bug Fixes**
  * Fixed spacing and sizing issues in autocomplete option rows for better alignment.
  * Updated active option visuals to display more consistently across states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->