### PR TITLE
EPMRPP-115097 || Make selector 'availableIntegrationsSelector' available for plugins

### DIFF
--- a/app/src/controllers/plugins/uiExtensions/createImportProps.js
+++ b/app/src/controllers/plugins/uiExtensions/createImportProps.js
@@ -222,6 +222,7 @@ import { formatMethodType } from 'common/utils/localizationUtils';
 import {
   publicPluginsSelector,
   createGlobalNamedIntegrationsSelector,
+  availableIntegrationsByPluginNameSelector,
 } from 'controllers/plugins/selectors';
 import { loginAction } from 'controllers/auth';
 import { AttributeEditor } from 'componentLibrary/attributeEditor';
@@ -431,6 +432,8 @@ export const createImportProps = (pluginName) => ({
     urlOrganizationAndProjectSelector,
     // TODO: must be removed when the common plugin commands will be used
     globalIntegrationsSelector: createGlobalNamedIntegrationsSelector(pluginName),
+    availableIntegrationsSelector: (state) =>
+      availableIntegrationsByPluginNameSelector(state, pluginName),
     projectMembersSelector,
     projectInfoSelector,
     projectNameSelector,


### PR DESCRIPTION
## Description

Make selector `availableIntegrationsSelector` available for plugins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin-related integrations are now available through the import props returned to UI extensions, scoped to the current plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->