### PR TITLE
EPMRPP-116844 || Hide Edit and Delete button for member viewer

### DIFF
--- a/app/src/pages/inside/dashboardPage/dashboardList/dashboardGrid/dashboardGridItem/dashboardGridItem.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardList/dashboardGrid/dashboardGridItem/dashboardGridItem.jsx
@@ -24,6 +24,7 @@ import { NavLink } from 'components/main/navLink';
 import { LockedDashboardTooltip } from 'pages/inside/common/lockedDashboardTooltip';
 import { LockedIcon } from 'pages/inside/common/lockedIcon';
 import { useCanLockDashboard } from 'common/hooks/useCanLockDashboard';
+import { useUserPermissions } from 'hooks/useUserPermissions';
 import styles from './dashboardGridItem.scss';
 
 const cx = classNames.bind(styles);
@@ -33,6 +34,7 @@ const calculateGridPreviewBaseOnWidgetId = (id) => id % 14;
 export const DashboardGridItem = ({ item, onEdit, onDelete }) => {
   const getDashboardItemPageLink = useSelector(getDashboardItemPageLinkSelector);
   const canLock = useCanLockDashboard();
+  const { canWorkWithDashboard } = useUserPermissions();
   const { name, description, owner, id, locked } = item;
   const isDisabled = locked && !canLock;
 
@@ -68,6 +70,7 @@ export const DashboardGridItem = ({ item, onEdit, onDelete }) => {
           <p>{description}</p>
         </div>
         <div className={cx('grid-cell', 'owner')}>{owner}</div>
+        {canWorkWithDashboard && (
         <>
           <div className={cx('grid-cell', 'edit')}>
             <LockedDashboardTooltip locked={locked}>
@@ -80,6 +83,7 @@ export const DashboardGridItem = ({ item, onEdit, onDelete }) => {
             </LockedDashboardTooltip>
           </div>
         </>
+        )}
       </NavLink>
     </div>
   );


### PR DESCRIPTION
## Description

Dashboards: Hide Edit and Delete buttons for member viewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Edit and delete controls on dashboard cards now only appear for users with the appropriate dashboard permissions.
  * Dashboard card details like name, description, owner, and lock status remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->