### PR TITLE
EPMRPP-117359 || Expose project and organization integration selectors to plugin UI

### DIFF
--- a/app/src/controllers/plugins/uiExtensions/createImportProps.js
+++ b/app/src/controllers/plugins/uiExtensions/createImportProps.js
@@ -223,6 +223,8 @@ import {
   publicPluginsSelector,
   createGlobalNamedIntegrationsSelector,
   availableIntegrationsByPluginNameSelector,
+  namedProjectIntegrationsSelector,
+  namedOrganizationIntegrationsSelector,
 } from 'controllers/plugins/selectors';
 import { loginAction } from 'controllers/auth';
 import { AttributeEditor } from 'componentLibrary/attributeEditor';
@@ -432,6 +434,10 @@ export const createImportProps = (pluginName) => ({
     urlOrganizationAndProjectSelector,
     // TODO: must be removed when the common plugin commands will be used
     globalIntegrationsSelector: createGlobalNamedIntegrationsSelector(pluginName),
+    projectIntegrationsSelector: (state) =>
+      namedProjectIntegrationsSelector(state)[pluginName] || [],
+    organizationIntegrationsSelector: (state) =>
+      namedOrganizationIntegrationsSelector(state)[pluginName] || [],
     availableIntegrationsSelector: (state) =>
       availableIntegrationsByPluginNameSelector(state, pluginName),
     projectMembersSelector,


### PR DESCRIPTION
## Expose scoped integration selectors in plugin extension props

### Summary

Adds two selectors to `createImportProps` so federated plugin UI can resolve integrations by scope without duplicating Redux logic:

- `projectIntegrationsSelector` — enabled project-level integrations for the plugin
- `organizationIntegrationsSelector` — enabled organization-level integrations for the plugin

`globalIntegrationsSelector` was already provided; together they allow plugin UI to pick the active integration in priority order: **project → organization → global**.


