### PR TITLE
EPMRPP-117370 || Several UI bugs related to Oops... This invitation has expired or already used page

### DIFF
--- a/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
+++ b/app/src/pages/outside/registrationPage/registrationForm/registrationForm.tsx
@@ -147,6 +147,8 @@ const RegistrationFormComponent = ({
 
   // Password errors are shown only after blur or submit — not while typing.
   const [showPasswordValidation, setShowPasswordValidation] = useState(false);
+  const [showConfirmPasswordValidation, setShowConfirmPasswordValidation] = useState(false);
+  const [isConfirmPasswordFocused, setIsConfirmPasswordFocused] = useState(false);
   const [submitAttempted, setSubmitAttempted] = useState(false);
 
   useEffect(() => {
@@ -195,13 +197,20 @@ const RegistrationFormComponent = ({
   }, [showPasswordValidation, password, allRulesMet, hasSpace, minLength, formatMessage]);
 
   const hasMismatch = confirmPassword.length > 0 && password !== confirmPassword;
+  const shouldShowConfirmPasswordValidation =
+    showConfirmPasswordValidation && !isConfirmPasswordFocused;
 
   const confirmPasswordError = useMemo(() => {
-    if (!submitAttempted) return undefined;
+    if (!shouldShowConfirmPasswordValidation) return undefined;
     if (!confirmPassword.trim()) return formatMessage(messages.requiredField);
     if (hasMismatch) return formatMessage(messages.passwordsDoNotMatch);
     return undefined;
-  }, [submitAttempted, confirmPassword, hasMismatch, formatMessage]);
+  }, [
+    shouldShowConfirmPasswordValidation,
+    confirmPassword,
+    hasMismatch,
+    formatMessage,
+  ]);
 
   const nameError = useMemo(() => {
     if (!submitAttempted) return undefined;
@@ -231,10 +240,24 @@ const RegistrationFormComponent = ({
     }
   }, [password]);
 
+  const handleConfirmPasswordFocus = useCallback(() => {
+    setIsConfirmPasswordFocused(true);
+  }, []);
+
+  const handleConfirmPasswordBlur = useCallback(() => {
+    setIsConfirmPasswordFocused(false);
+
+    if (confirmPassword.length > 0) {
+      setShowConfirmPasswordValidation(true);
+    }
+  }, [confirmPassword]);
+
   const submitHandler = useCallback(
     (values: RegistrationFormValues) => {
       setSubmitAttempted(true);
       setShowPasswordValidation(true);
+      setShowConfirmPasswordValidation(true);
+      setIsConfirmPasswordFocused(false);
 
       const nameValid = name.trim() && !commonValidators.userName(name);
       const confirmValid = confirmPassword === password && confirmPassword.trim();
@@ -299,6 +322,8 @@ const RegistrationFormComponent = ({
         className={cx('confirm-password-field', {
           'confirm-password-field--inactive': isConfirmDisabled,
         })}
+        onFocus={handleConfirmPasswordFocus}
+        onBlur={handleConfirmPasswordBlur}
       >
         <FieldProvider
           name="confirmPassword"

--- a/app/src/pages/outside/registrationPage/registrationPage.scss
+++ b/app/src/pages/outside/registrationPage/registrationPage.scss
@@ -17,7 +17,7 @@
 .fail-actions {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 32px;
   margin: 0;
 }
 
@@ -40,6 +40,10 @@
 // Scoped registration-page overrides
 .registrationLogo {
   margin-bottom: 54px;
+
+  &.registrationLogoError {
+    margin-bottom: 140px;
+  }
 }
 
 // Form scrolls when errors expand; footer stays pinned below and never overlays Create.

--- a/app/src/pages/outside/registrationPage/registrationPage.tsx
+++ b/app/src/pages/outside/registrationPage/registrationPage.tsx
@@ -81,13 +81,17 @@ export const RegistrationPage = ({
   initialData = {},
   submitButtonTitle = '',
 }: RegistrationPageProps) => {
-  const isFormVisible = tokenProvided && tokenActive;
+  const isRegistrationFormVisible = tokenProvided && tokenActive;
 
   return (
     <div className={loginCx('login-page')}>
       <div className={loginCx('login-page-content')}>
         <div className={loginCx('login-form-side')}>
-          <div className={`${loginCx('logo')} ${cx('registrationLogo')}`}>
+          <div
+            className={`${loginCx('logo')} ${cx('registrationLogo', {
+              registrationLogoError: !isRegistrationFormVisible,
+            })}`}
+          >
             <a
               href={referenceDictionary.rpLanding}
               target="_blank"
@@ -99,7 +103,7 @@ export const RegistrationPage = ({
           </div>
           <LoginPageSection>
             <div className={cx('registration-scroll-area')}>
-              {isFormVisible ? (
+              {isRegistrationFormVisible ? (
                 <PageSectionContainer
                   header={messages.registration}
                   leftAligned


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
fixed some margins and gaps sizes

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing on the registration page, including clearer separation between the logo and the error content.
  * Refined the registration page’s UI state switching so the correct form or “Oops...” error view appears reliably.
  * Updated confirm-password validation behavior to better match user interaction, showing errors only at the right times and reducing premature error display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->