### PR TITLE
EPMRPP-117296 || Plugin translation

### DIFF
--- a/app/src/common/constants/coreMessages.js
+++ b/app/src/common/constants/coreMessages.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import localeUK from '../../../localization/translated/uk.json';
+import localeRU from '../../../localization/translated/ru.json';
+import localeBE from '../../../localization/translated/be.json';
+import localeZH from '../../../localization/translated/zh.json';
+import localeES from '../../../localization/translated/es.json';
+
+// Core (host) message catalog per language. `en` is intentionally absent:
+// English is covered by `defaultMessage` in `defineMessages`.
+export const CORE_MESSAGES = {
+  ru: localeRU,
+  be: localeBE,
+  uk: localeUK,
+  zh: localeZH,
+  es: localeES,
+};

--- a/app/src/components/containers/localizationContainer/localizationContainer.jsx
+++ b/app/src/components/containers/localizationContainer/localizationContainer.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,40 +19,27 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import { langSelector } from 'controllers/lang';
+import { mergedMessagesSelector } from 'controllers/plugins/uiExtensions/localization';
 import { polyfillLocales } from 'common/polyfills';
-
-import localeUK from '../../../../localization/translated/uk.json';
-import localeRU from '../../../../localization/translated/ru.json';
-import localeBE from '../../../../localization/translated/be.json';
-import localeZH from '../../../../localization/translated/zh.json';
-import localeES from '../../../../localization/translated/es.json';
 
 const localesReadyPromise = polyfillLocales();
 
 @connect((state) => ({
   lang: langSelector(state),
+  messages: mergedMessagesSelector(state),
 }))
 export class LocalizationContainer extends React.Component {
   static propTypes = {
     lang: PropTypes.string,
+    messages: PropTypes.object,
     children: PropTypes.node,
   };
 
   static defaultProps = {
     lang: 'be',
+    messages: {},
     children: null,
   };
-
-  constructor(props) {
-    super(props);
-    this.messages = {
-      ru: localeRU,
-      be: localeBE,
-      uk: localeUK,
-      zh: localeZH,
-      es: localeES,
-    };
-  }
 
   state = {
     ready: false,
@@ -72,7 +59,7 @@ export class LocalizationContainer extends React.Component {
       <IntlProvider
         defaultLocale={this.props.lang === 'be' ? 'be' : 'en'}
         locale={this.props.lang}
-        messages={this.messages[this.props.lang]}
+        messages={this.props.messages}
       >
         {React.cloneElement(this.props.children, { key: this.props.lang })}
       </IntlProvider>

--- a/app/src/components/extensionLoader/federatedExtensionLoader/federatedExtensionLoader.jsx
+++ b/app/src/components/extensionLoader/federatedExtensionLoader/federatedExtensionLoader.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -10,8 +10,8 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';
@@ -20,6 +20,7 @@ import { BubblesLoader } from '@reportportal/ui-kit';
 import { createImportProps } from 'controllers/plugins/uiExtensions/createImportProps';
 import { getExtensionUrl } from '../utils';
 import { useFederatedComponent } from '../hooks';
+import { useExtensionLocalization } from '../useExtensionLocalization';
 import { extensionType } from '../extensionTypes';
 
 export function FederatedExtensionLoader({ extension, withPreloader = false, ...componentProps }) {
@@ -28,6 +29,10 @@ export function FederatedExtensionLoader({ extension, withPreloader = false, ...
     payload: { moduleName, scope },
   } = extension;
   const url = getExtensionUrl(extension);
+
+  // Soft gate: load/register extension localization as a side effect without blocking render.
+  // Missing keys fall back to `defaultMessage` until the extension's messages are merged.
+  useExtensionLocalization(extension);
 
   const { failed, Component } = useFederatedComponent(scope, moduleName, url);
 

--- a/app/src/components/extensionLoader/fetchExtensionLocalizationFile.js
+++ b/app/src/components/extensionLoader/fetchExtensionLocalizationFile.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fetch } from 'common/utils/fetch';
+import { URLS } from 'common/urls';
+
+export const resolveLocaleFileName = (template, lang) => template.replace('{lang}', lang);
+
+/**
+ * Loads an extension's localization file from the same base URL as its MF entry.
+ * - installed plugin (no baseUrl): host API `plugin/public/{pluginName}/file/{fileKey}`;
+ * - overridden plugin (baseUrl set): the plugin's own origin (dev server / CDN).
+ */
+export const fetchExtensionLocalizationFile = ({ pluginName, baseUrl, fileName }) => {
+  if (baseUrl) {
+    return window.fetch(`${baseUrl.replace(/\/+$/, '')}/${fileName}`).then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load extension localization file (${response.status})`);
+      }
+      return response.json();
+    });
+  }
+
+  return fetch(URLS.pluginPublicFile(pluginName, fileName), { contentType: 'application/json' });
+};

--- a/app/src/components/extensionLoader/fetchExtensionLocalizationFile.js
+++ b/app/src/components/extensionLoader/fetchExtensionLocalizationFile.js
@@ -26,7 +26,7 @@ export const resolveLocaleFileName = (template, lang) => template.replace('{lang
  */
 export const fetchExtensionLocalizationFile = ({ pluginName, baseUrl, fileName }) => {
   if (baseUrl) {
-    return window.fetch(`${baseUrl.replace(/\/+$/, '')}/${fileName}`).then((response) => {
+    return window.fetch(new URL(`/${fileName}`, baseUrl)).then((response) => {
       if (!response.ok) {
         throw new Error(`Failed to load extension localization file (${response.status})`);
       }

--- a/app/src/components/extensionLoader/useExtensionLocalization.js
+++ b/app/src/components/extensionLoader/useExtensionLocalization.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { langSelector } from 'controllers/lang';
+import { extensionManifestSelector } from 'controllers/plugins/uiExtensions';
+import { registerExtensionMessagesAction } from 'controllers/plugins/uiExtensions/localization';
+import { DEFAULT_LANGUAGE } from 'common/constants/supportedLanguages';
+import {
+  fetchExtensionLocalizationFile,
+  resolveLocaleFileName,
+} from './fetchExtensionLocalizationFile';
+
+// Contract: `localization.messages` is a flat file-name template with a single `{lang}`
+// placeholder and no path separator (host serves flat fileKey only).
+const isValidMessagesTemplate = (template) =>
+  typeof template === 'string' && template.includes('{lang}') && !template.includes('/');
+
+/**
+ * Loads and registers an extension's localization messages for the current language.
+ * Registration is keyed by `pluginName`; the store is cleared on language change
+ * (CHANGE_LANG_ACTION) and manifest override (UPDATE_EXTENSION_MANIFEST), which
+ * triggers a re-fetch here. Legacy plugins (no valid `localization`) are a no-op
+ * and rely on core strings + `defaultMessage`.
+ */
+export const useExtensionLocalization = (extension) => {
+  const { pluginName, url: baseUrl } = extension;
+  const dispatch = useDispatch();
+  const lang = useSelector(langSelector);
+  const manifest = useSelector((state) => extensionManifestSelector(state, pluginName));
+  const messagesTemplate = manifest?.localization?.messages;
+
+  useEffect(() => {
+    // English (default language) is the reference language, already covered by `defaultMessage`;
+    // plugins aren't required to ship `locale-en.json`, so skip the guaranteed 404.
+    if (!isValidMessagesTemplate(messagesTemplate) || lang === DEFAULT_LANGUAGE) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const fileName = resolveLocaleFileName(messagesTemplate, lang);
+
+    fetchExtensionLocalizationFile({ pluginName, baseUrl, fileName })
+      .then((messages) => {
+        // Guard against a stale response after the language/source already changed.
+        if (!cancelled) {
+          dispatch(registerExtensionMessagesAction(pluginName, messages));
+        }
+      })
+      .catch(() => {
+        // Fallback to core strings + defaultMessage; no extra request.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginName, baseUrl, lang, messagesTemplate, dispatch]);
+};

--- a/app/src/controllers/plugins/uiExtensions/localization/actions.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/actions.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { REGISTER_EXTENSION_MESSAGES } from './constants';
+
+export const registerExtensionMessagesAction = (pluginName, messages) => ({
+  type: REGISTER_EXTENSION_MESSAGES,
+  payload: { pluginName, messages },
+});

--- a/app/src/controllers/plugins/uiExtensions/localization/constants.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/constants.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const REGISTER_EXTENSION_MESSAGES = 'registerExtensionMessages';

--- a/app/src/controllers/plugins/uiExtensions/localization/index.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/index.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { extensionMessagesReducer } from './reducer';
+export { registerExtensionMessagesAction } from './actions';
+export { mergedMessagesSelector } from './selectors';

--- a/app/src/controllers/plugins/uiExtensions/localization/reducer.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/reducer.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CHANGE_LANG_ACTION } from 'controllers/lang/constants';
+import { UPDATE_EXTENSION_MANIFEST } from '../constants';
+import { REGISTER_EXTENSION_MESSAGES } from './constants';
+
+// State: flat map `pluginName -> messages` for the current app language.
+export const extensionMessagesReducer = (state = {}, { type = '', payload = {} }) => {
+  switch (type) {
+    case REGISTER_EXTENSION_MESSAGES:
+      return { ...state, [payload.pluginName]: payload.messages };
+    // Manifest override changes the plugin source: drop its strings so the loader
+    // re-fetches from the new URL.
+    case UPDATE_EXTENSION_MANIFEST: {
+      if (!state[payload.pluginName]) {
+        return state;
+      }
+      const { [payload.pluginName]: removed, ...rest } = state;
+      return rest;
+    }
+    // Strings belong to the previous language: drop all, loaders re-fetch under new lang.
+    case CHANGE_LANG_ACTION:
+      return {};
+    default:
+      return state;
+  }
+};

--- a/app/src/controllers/plugins/uiExtensions/localization/reducer.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/reducer.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { omit } from 'common/utils/omit';
 import { CHANGE_LANG_ACTION } from 'controllers/lang/constants';
 import { UPDATE_EXTENSION_MANIFEST } from '../constants';
 import { REGISTER_EXTENSION_MESSAGES } from './constants';
@@ -25,13 +26,8 @@ export const extensionMessagesReducer = (state = {}, { type = '', payload = {} }
       return { ...state, [payload.pluginName]: payload.messages };
     // Manifest override changes the plugin source: drop its strings so the loader
     // re-fetches from the new URL.
-    case UPDATE_EXTENSION_MANIFEST: {
-      if (!state[payload.pluginName]) {
-        return state;
-      }
-      const { [payload.pluginName]: removed, ...rest } = state;
-      return rest;
-    }
+    case UPDATE_EXTENSION_MANIFEST:
+      return omit(state, [payload.pluginName]);
     // Strings belong to the previous language: drop all, loaders re-fetch under new lang.
     case CHANGE_LANG_ACTION:
       return {};

--- a/app/src/controllers/plugins/uiExtensions/localization/selectors.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/selectors.js
@@ -27,7 +27,7 @@ const flattenedExtensionMessagesSelector = createSelector(
   extensionMessagesSelector,
   (messagesByPlugin) =>
     Object.keys(messagesByPlugin)
-      .sort()
+      .sort((a, b) => a.localeCompare(b))
       .reduce((acc, pluginName) => ({ ...acc, ...messagesByPlugin[pluginName] }), {}),
 );
 
@@ -35,5 +35,5 @@ const flattenedExtensionMessagesSelector = createSelector(
 export const mergedMessagesSelector = createSelector(
   langSelector,
   flattenedExtensionMessagesSelector,
-  (lang, extensionMessages) => ({ ...(CORE_MESSAGES[lang] || {}), ...extensionMessages }),
+  (lang, extensionMessages) => ({ ...CORE_MESSAGES[lang], ...extensionMessages }),
 );

--- a/app/src/controllers/plugins/uiExtensions/localization/selectors.js
+++ b/app/src/controllers/plugins/uiExtensions/localization/selectors.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSelector } from 'reselect';
+import { langSelector } from 'controllers/lang';
+import { CORE_MESSAGES } from 'common/constants/coreMessages';
+import { domainSelector } from '../../selectors';
+
+const extensionMessagesSelector = (state) =>
+  domainSelector(state).uiExtensions?.extensionMessages || {};
+
+// Flatten all extensions' messages into a single id -> string map (deterministic order).
+const flattenedExtensionMessagesSelector = createSelector(
+  extensionMessagesSelector,
+  (messagesByPlugin) =>
+    Object.keys(messagesByPlugin)
+      .sort()
+      .reduce((acc, pluginName) => ({ ...acc, ...messagesByPlugin[pluginName] }), {}),
+);
+
+// Final catalog for IntlProvider: core first, then extension messages on top.
+export const mergedMessagesSelector = createSelector(
+  langSelector,
+  flattenedExtensionMessagesSelector,
+  (lang, extensionMessages) => ({ ...(CORE_MESSAGES[lang] || {}), ...extensionMessages }),
+);

--- a/app/src/controllers/plugins/uiExtensions/reducer.js
+++ b/app/src/controllers/plugins/uiExtensions/reducer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -10,8 +10,8 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { combineReducers } from 'redux';
@@ -20,6 +20,7 @@ import {
   UPDATE_EXTENSION_MANIFEST,
   ADD_EXTENSION_MANIFEST,
 } from './constants';
+import { extensionMessagesReducer } from './localization';
 
 const extensionManifestsReducer = (state = [], { type = '', payload = {} }) => {
   switch (type) {
@@ -41,4 +42,5 @@ const extensionManifestsReducer = (state = [], { type = '', payload = {} }) => {
 
 export const uiExtensionsReducer = combineReducers({
   extensionManifests: extensionManifestsReducer,
+  extensionMessages: extensionMessagesReducer,
 });

--- a/docs/9-localization.md
+++ b/docs/9-localization.md
@@ -18,3 +18,74 @@ Localization workflow is:
 3. Find keys, related to developing component, in `be.json`, `ru.json` and `uk.json` files placed in `/localization/translated/` folder, and define translations for corresponding languages.
 4. **IMPORTANT!** Make sure that only related to your component keys have been changed, and there is no deleted lines related to other existing components.
    If you see such case, please discuss it with UI Team Lead.
+
+## Plugin localization (runtime merge)
+
+UI plugins (`PLUGIN_TYPE_EXTENSION`, loaded by `FederatedExtensionLoader`) ship their
+own translations inside the plugin artifact instead of storing them in `service-ui`.
+The host merges them into the root `IntlProvider` at runtime.
+
+### Data flow
+
+- Core catalog stays in `service-ui` (`localization/translated/*.json`, exposed via
+  `common/constants/coreMessages.js`).
+- Extension messages for the current language are kept in Redux slice
+  `controllers/plugins/uiExtensions/localization` as a flat `pluginName -> messages` map
+  (state key `extensionMessages`).
+- `mergedMessagesSelector` returns `{ ...core[lang], ...extensionMessages }`;
+  `LocalizationContainer` feeds it to `IntlProvider`.
+- `useExtensionLocalization` (called inside `FederatedExtensionLoader`) fetches
+  `locale-{lang}.json` from the same base URL as the MF entry and registers the
+  extension's messages. The slice reducer clears entries on `CHANGE_LANG_ACTION` (all) and
+  `UPDATE_EXTENSION_MANIFEST` (that plugin), so a re-fetch happens under the new
+  language / source; nothing is unregistered on unmount (including plugin disable/removal —
+  a stale entry only costs a few KB until the next language change or manifest update;
+  see "Potential improvements" if this needs tightening later).
+
+### Manifest contract (`metadata.json`)
+
+```json
+"localization": {
+  "messages": "locale-{lang}.json"
+}
+```
+
+- `messages` is a flat file-name template: exactly one `{lang}` placeholder, no `/`
+  (served as a flat `fileKey` via `plugin/public/{pluginName}/file/{fileKey}`).
+- `{lang}` must match `state.lang` (`ru`, `be`, `uk`, `zh`, `es`). For `en` the host does
+  **not** fetch `locale-en.json` at all (English is the reference language, already covered
+  by `defaultMessage`); plugins are not required to ship it.
+- No `localization` section, or an invalid `messages`, means **legacy**: the host does
+  not fetch plugin locales and uses core strings + `defaultMessage` (backward compatible).
+- On `fetch` error (404/network) the host falls back to core strings + `defaultMessage`;
+  it does **not** request a fallback language file.
+- Message ids use a plugin namespace prefix (e.g. `PluginTemplate.Component.element`).
+  The prefix is a free namespace to avoid collisions — it does **not** have to equal the
+  real `pluginName`; only `metadata.json` / URL resolution use the real name.
+
+### Migration runbook (per plugin, expand/contract)
+
+1. **Expand** — in the plugin repo: add `locale-*.json` sources, generate them from
+   `defineMessages` (do not hand-maintain ids), add the `localization` section to
+   `metadata.json`, release so the JSON lands on the same base URL as the MF entry.
+   Keys may still exist in core (duplicates; the plugin's messages overlay on match).
+2. **Verify** — locally `window.RP.overrideExtension('<pluginName>', '<devUrl>')`; on stage
+   switch languages and mount all extension points at once (validates the plugin's
+   translations stay registered while any of its extension points are mounted).
+3. **Contract** — a `service-ui` MR removes only the migrated keys from
+   `localization/translated/*.json` (never host-only keys or other plugins' keys), in the
+   same release window as the host/plugin rollout.
+
+Until migration completes it is acceptable to edit `localization/translated/*.json`
+manually and **not** run `manage:translations` in `service-ui`, so plugin keys are not
+pruned as "unused".
+
+### Potential improvement (not implemented)
+
+Disabling or removing a plugin does not currently clear its `extensionManifests` /
+`extensionMessages` entries — they stay until the next language change or manifest
+override. This is harmless today (rendering is driven by the enabled-plugins list, not
+by these caches; the stale entry only costs a few KB), but could be tightened by also
+clearing on `UPDATE_PLUGIN_SUCCESS` (disabled) and `REMOVE_PLUGIN_SUCCESS` in
+`uiExtensions/reducer.js` and `uiExtensions/localization/reducer.js` if it ever becomes
+a real problem (e.g. message id collisions between a stale and an active plugin).


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
- New Redux slice `controllers/plugins/uiExtensions/localization/` — stores each plugin's messages for the current language (`pluginName -> messages`), cleared on language change or manifest override.
- `mergedMessagesSelector` merges core strings + all plugins' messages into one flat catalog, fed to the single root `IntlProvider` via `LocalizationContainer`.
- `useExtensionLocalization` hook, called from `FederatedExtensionLoader`, fetches a plugin's `locale-{lang}.json` (per its manifest contract) and registers it — as a soft gate, so missing/late translations fall back to `defaultMessage` without blocking render.
- Manifest contract: `metadata.json` may declare `localization.messages: "<template>-{lang}.json"`; plugins without this section are treated as legacy and unaffected.
- Documented in `docs/9-localization.md` (contract, data flow, migration runbook).

### The result

Plugins now ship and control their own translations inside their own artifact; the host merges them at runtime into the existing single-`IntlProvider` architecture, with no backend/manifest-shape changes and full backward compatibility for plugins that don't opt in.
No cleanup of `extensionManifests/extensionMessages` on plugin disable/removal (harmless today, documented as a potential improvement).

## Links
[EPMRPP-117296](https://jiraeu.epam.com/browse/EPMRPP-117296)

## Visuals

https://github.com/user-attachments/assets/a533006f-6328-447a-a951-ca91d61a2263

---
Implemented along with: https://github.com/reportportal/plugin-template/pull/17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extension-provided translations that load dynamically with the selected language.
  * Improved language coverage by combining core translations with plugin translation files at runtime.

* **Bug Fixes**
  * Language changes and plugin updates now refresh displayed messages more reliably.
  * Fallback behavior is handled more gracefully when a translation file can’t be loaded.

* **Documentation**
  * Expanded localization docs with guidance for plugin translation setup, naming, and migration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->