### PR TITLE
EPMRPP-116999 || Send page_view on Project Settings integration sub-pages

### DIFF
--- a/app/src/components/main/analytics/events/ga4Events/projectSettingsPageEvents.js
+++ b/app/src/components/main/analytics/events/ga4Events/projectSettingsPageEvents.js
@@ -58,7 +58,7 @@ export const PROJECT_SETTINGS_VIEWS = {
     action: 'page_view',
     page: PROJECT_SETTINGS,
     place: subTab
-      ? `${PROJECT_SETTINGS}_${settingsTab.toLowerCase()}_${subTab.toLowerCase()}`
+      ? `${PROJECT_SETTINGS}_${settingsTab.toLowerCase()}_${normalizeEventParameter(subTab)}`
       : `${PROJECT_SETTINGS}_${settingsTab.toLowerCase()}`,
   }),
 };

--- a/app/src/pages/inside/projectSettingsPageContainer/projectSettingsAnalyticsWrapper.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/projectSettingsAnalyticsWrapper.jsx
@@ -17,20 +17,31 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useTracking } from 'react-tracking';
-import { payloadSelector } from 'controllers/pages';
+import { INTEGRATIONS } from 'common/constants/settingsTabs';
+import { pluginByNameSelector } from 'controllers/plugins';
+import { payloadSelector, querySelector } from 'controllers/pages';
 import { PROJECT_SETTINGS_VIEWS } from 'components/main/analytics/events/ga4Events/projectSettingsPageEvents';
 
 export const ProjectSettingsAnalyticsWrapper = ({ children }) => {
   const { trackEvent } = useTracking();
   const payload = useSelector(payloadSelector);
+  const query = useSelector(querySelector);
+  const pluginName = payload.settingsTab === INTEGRATIONS && query.subPage ? query.subPage : null;
+  const plugin = useSelector((state) =>
+    pluginName ? pluginByNameSelector(state, pluginName) : undefined,
+  );
+  const subPage = plugin ? plugin.details?.name || plugin.name : query.subPage;
 
   useEffect(() => {
     if (payload.settingsTab) {
       trackEvent(
-        PROJECT_SETTINGS_VIEWS.getProjectSettingsPageView(payload.settingsTab, payload.subTab),
+        PROJECT_SETTINGS_VIEWS.getProjectSettingsPageView(
+          payload.settingsTab,
+          payload.subTab || subPage,
+        ),
       );
     }
-  }, [payload, trackEvent]);
+  }, [payload, trackEvent, subPage, query.subPage]);
 
   return children;
 };


### PR DESCRIPTION
## Update page_view for Project Settings integration pages

### Summary


The `page_view` event now fires with an integration-specific `place` value when a user opens an individual integration settings page under **Project Settings > Integrations** (for example, Jira Server, Slack, Sauce Labs). This covers both the initial page load and client-side navigation, including browser history changes.

Previously, navigation within the Integrations tab updated `query.subPage`, but `ProjectSettingsAnalyticsWrapper` only tracked `payload.subTab`. As a result, all integration sub-pages reported the same `place`: `project_settings_integrations`.

The wrapper now follows the same approach as `OrganizationSettingsAnalyticsWrapper`: it resolves the active integration from `query.subPage` and includes it in the `page_view` payload. `getProjectSettingsPageView` uses `normalizeEventParameter` for the sub-page segment to keep `place` values consistent with other analytics events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of Project Settings page views so sub-tab names are recorded more consistently, including integration-related views.
  * Analytics now better reflects the currently selected settings sub-page, reducing mismatches in reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Review by Codemie
[EPMRPP-116999-service-ui-pr-5524.md](https://github.com/user-attachments/files/29813581/EPMRPP-116999-service-ui-pr-5524.md)
