### PR TITLE
EPMRPP-117392 || Prevent stored XSS in filter name and description via output encoding

### DIFF
--- a/app/src/common/utils/index.js
+++ b/app/src/common/utils/index.js
@@ -15,7 +15,7 @@
  */
 export { isEmptyObject } from './isEmptyObject';
 export { referenceDictionary, docsReferences } from './referenceDictionary';
-export { isString, capitalize, compareStringsLocale } from './stringUtils';
+export { isString, capitalize, compareStringsLocale, escapeHtmlEntities } from './stringUtils';
 export { trimStringValues } from './objectUtils';
 export { fetch, ERROR_CANCELED, ERROR_UNAUTHORIZED } from './fetch';
 export {

--- a/app/src/common/utils/stringUtils.js
+++ b/app/src/common/utils/stringUtils.js
@@ -28,3 +28,11 @@ export const capitalize = (str) => {
 export const stringEqual = (value1, value2) => String(value1) === String(value2);
 
 export const compareStringsLocale = (a, b) => a.localeCompare(b);
+
+export const escapeHtmlEntities = (str) => {
+  if (!isString(str)) {
+    return str;
+  }
+
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+};

--- a/app/src/common/utils/stringUtils.test.js
+++ b/app/src/common/utils/stringUtils.test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isString, capitalize, stringEqual, compareStringsLocale } from './stringUtils';
+import { isString, capitalize, stringEqual, compareStringsLocale, escapeHtmlEntities } from './stringUtils';
 
 describe('isString', () => {
   test('should return true for string values', () => {
@@ -58,12 +58,6 @@ describe('capitalize', () => {
   });
 });
 
-describe('compareStringsLocale', () => {
-  test('should sort strings in locale order when used as Array.sort comparator', () => {
-    expect(['b', 'a', 'c'].sort(compareStringsLocale)).toEqual(['a', 'b', 'c']);
-  });
-});
-
 describe('stringEqual', () => {
   test('should return true for equal string values', () => {
     expect(stringEqual('hello', 'hello')).toBe(true);
@@ -89,5 +83,24 @@ describe('stringEqual', () => {
     expect(stringEqual(undefined, 'undefined')).toBe(true);
     expect(stringEqual(true, 'true')).toBe(true);
     expect(stringEqual(false, 'false')).toBe(true);
+  });
+});
+
+describe('compareStringsLocale', () => {
+  test('should sort strings in locale order when used as Array.sort comparator', () => {
+    expect(['b', 'a', 'c'].sort(compareStringsLocale)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('escapeHtmlEntities', () => {
+  test('should escape ampersand and less-than characters', () => {
+    expect(escapeHtmlEntities('<div>"test" & value</div>')).toBe(
+      '&lt;div>"test" &amp; value&lt;/div>',
+    );
+  });
+
+  test('should return non-string values as is', () => {
+    expect(escapeHtmlEntities(123)).toBe(123);
+    expect(escapeHtmlEntities(null)).toBe(null);
   });
 });

--- a/app/src/common/utils/stringUtils.test.js
+++ b/app/src/common/utils/stringUtils.test.js
@@ -101,6 +101,6 @@ describe('escapeHtmlEntities', () => {
 
   test('should return non-string values as is', () => {
     expect(escapeHtmlEntities(123)).toBe(123);
-    expect(escapeHtmlEntities(null)).toBe(null);
+    expect(escapeHtmlEntities(null)).toBeNull();
   });
 });

--- a/app/src/components/main/markdown/markdownViewer/markdownViewer.jsx
+++ b/app/src/components/main/markdown/markdownViewer/markdownViewer.jsx
@@ -19,6 +19,7 @@ import Parser from 'html-react-parser';
 import DOMPurify from 'dompurify';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { escapeHtmlEntities } from 'common/utils';
 import { SingletonMarkdownObject } from '../singletonMarkdownObject';
 import { MODE_DEFAULT } from '../constants';
 import styles from './markdownViewer.scss';
@@ -82,7 +83,11 @@ export class MarkdownViewer extends Component {
           ref={this.container}
           className={cx('markdown-viewer', { [`mode-${mode}`]: mode }, this.props.className)}
         >
-          {Parser(DOMPurify.sanitize(this.simpleMDE.markdown(value || '').trim()))}
+          {Parser(
+            DOMPurify.sanitize(
+              this.simpleMDE.markdown(escapeHtmlEntities(value || '').trim()),
+            ),
+          )}
         </div>
       </div>
     );

--- a/app/src/components/main/markdown/markdownViewer/markdownViewer.test.jsx
+++ b/app/src/components/main/markdown/markdownViewer/markdownViewer.test.jsx
@@ -135,6 +135,15 @@ describe('MarkdownViewer', () => {
     const wrapper = mount(<MarkdownViewer value={code} />);
     const codeElement = wrapper.find('.markdown-viewer code');
     expect(codeElement).toHaveLength(1);
-    expect(codeElement.contains('<span>test code</span>')).toBeTruthy();
+    expect(wrapper.find('.markdown-viewer code span')).toHaveLength(0);
+  });
+  test('raw HTML in markdown is rendered as escaped text', () => {
+    const xssPayload =
+      '<div id="phish" style="position:fixed;top:0;left:0;width:100%;height:100%"><form><button>Login</button></form></div>';
+    const wrapper = mount(<MarkdownViewer value={xssPayload} />);
+
+    expect(wrapper.find('form')).toHaveLength(0);
+    expect(wrapper.find('button')).toHaveLength(0);
+    expect(wrapper.find('#phish')).toHaveLength(0);
   });
 });

--- a/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.jsx
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.jsx
@@ -17,11 +17,10 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import Parser from 'html-react-parser';
-import DOMPurify from 'dompurify';
 import Link from 'redux-first-router-link';
 import { Icon } from 'components/main/icon';
 import { MarkdownViewer } from 'components/main/markdown';
+import { highlightText } from 'common/utils';
 import styles from './filterName.scss';
 
 const cx = classNames.bind(styles);
@@ -55,18 +54,7 @@ export const FilterName = ({
   isLink,
   nameLink,
 }) => {
-  const getHighlightName = () => {
-    const name = filter.name || '';
-
-    if (!search.length) {
-      return name;
-    }
-
-    return name.replace(
-      new RegExp(search, 'i'),
-      (match) => `<span class=${cx('name-highlight')}>${match}</span>`,
-    );
-  };
+  const name = filter.name || '';
 
   return (
     <Fragment>
@@ -79,7 +67,7 @@ export const FilterName = ({
             })}
             onClick={() => onClickName(filter)}
           >
-            {Parser(DOMPurify.sanitize(getHighlightName()))}
+            {highlightText(name, search, cx('name-highlight'))}
           </span>
         </NameLink>
         {editable && onEdit && (


### PR DESCRIPTION
## Problem

A stored XSS vulnerability was reported on `reportportal.epam.com` (EPMRPP-117392). A non-privileged user can save malicious HTML in a filter field (name or description) and trigger a phishing overlay for any user who opens that filter or a dashboard widget that references it.

**Root cause:** User-controlled filter data was rendered as HTML. `FilterName` parsed the filter name through `html-react-parser`, and `MarkdownViewer` allowed raw HTML from SimpleMDE to pass through default `DOMPurify` sanitization (forms, inline styles, and other non-script payloads were not stripped). Already compromised filters remain dangerous until output is treated as text.

## Solution

Apply output encoding instead of relying on HTML sanitization alone:

- **Filter name:** render as plain text using `highlightText` for search highlighting; remove `html-react-parser` / `DOMPurify` from the name rendering path.
- **Filter description (and all `MarkdownViewer` usages):** escape `&` and `<` in user input before markdown conversion so raw HTML is never interpreted as DOM. Markdown syntax (`**bold**`, lists, links, blockquotes, code blocks) continues to work.
- Add `escapeHtmlEntities` utility and unit tests, including coverage for the reported phishing payload.

This neutralizes already stored malicious payloads at display time without requiring database cleanup.

## Visuals
<img width="1686" height="832" alt="image" src="https://github.com/user-attachments/assets/bf58c1ac-d738-48d9-b450-e2091d7f9684" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown content now safely escapes HTML before rendering, reducing the chance of unwanted embedded markup appearing in previews.
  * Filter names now use a shared highlighting behavior for search matches, improving consistency in the filter list.

* **Bug Fixes**
  * Improved handling of raw HTML in markdown so it is displayed as text instead of rendering interactive elements.
  * Non-text values are now left unchanged when HTML escaping is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->