### PR TITLE
EPMRPP-117196 || Change max password length to 36 symbols

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -2052,7 +2052,7 @@
   "PassingRateSummaryControls.ItemsFieldLabel": "Элементы",
   "PassingRateSummaryControls.ItemsValidationError": "Колькасць элементаў павінна мець памер ад '1' да '600'",
   "PassingRateSummaryControls.excludeSkipped": "Выключыць прапушчаныя тэсты са статыстыкі",
-  "PasswordForm.description": "Мінімальная колькасць сімвалаў, неабходных для пароля. Дапушчальны дыяпазон: ад 8 да 256 сімвалаў.",
+  "PasswordForm.description": "Мінімальная колькасць сімвалаў, неабходных для пароля. Дапушчальны дыяпазон: ад {min} да {max} сімвалаў.",
   "PasswordForm.formHeader": "Пароль",
   "PasswordForm.label": "Даўжыня пароля",
   "PasswordForm.successNotification": "Мінімальная даўжыня пароля паспяхова абноўлена",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -2052,7 +2052,7 @@
   "PassingRateSummaryControls.ItemsFieldLabel": "Elementos",
   "PassingRateSummaryControls.ItemsValidationError": "La cantidad de elementos debe estar entre '1' y '600'",
   "PassingRateSummaryControls.excludeSkipped": "Excluir pruebas omitidas de las estadísticas",
-  "PasswordForm.description": "Número mínimo de caracteres requeridos para la contraseña. Rango permitido: {mín} a {máx} caracteres.",
+  "PasswordForm.description": "Número mínimo de caracteres requeridos para la contraseña. Rango permitido: {min} a {max} caracteres.",
   "PasswordForm.formHeader": "Password",
   "PasswordForm.label": "Password length",
   "PasswordForm.successNotification": "The minimum password length has been updated successfully",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -2052,7 +2052,7 @@
   "PassingRateSummaryControls.ItemsFieldLabel": "Elementos",
   "PassingRateSummaryControls.ItemsValidationError": "La cantidad de elementos debe estar entre '1' y '600'",
   "PassingRateSummaryControls.excludeSkipped": "Excluir pruebas omitidas de las estadísticas",
-  "PasswordForm.description": "Minimum number of characters required for the password. Allowed range: 8 to 256 characters.",
+  "PasswordForm.description": "Número mínimo de caracteres requeridos para la contraseña. Rango permitido: {mín} a {máx} caracteres.",
   "PasswordForm.formHeader": "Password",
   "PasswordForm.label": "Password length",
   "PasswordForm.successNotification": "The minimum password length has been updated successfully",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -2053,7 +2053,7 @@
   "PassingRateSummaryControls.ItemsFieldLabel": "Элементы",
   "PassingRateSummaryControls.ItemsValidationError": "Количество элементов принимает значения от '1' до '600'",
   "PassingRateSummaryControls.excludeSkipped": "Исключить пропущенные тесты из статистики",
-  "PasswordForm.description": "Минимальное количество символов, необходимое для пароля. Допустимый диапазон: от 8 до 256 символов.",
+  "PasswordForm.description": "Минимальное количество символов, необходимое для пароля. Допустимый диапазон: от {min} до {max} символов.",
   "PasswordForm.formHeader": "Пароль",
   "PasswordForm.label": "Длина пароля",
   "PasswordForm.successNotification": "Минимальная длина пароля успешно обновлена",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -2053,7 +2053,7 @@
   "PassingRateSummaryControls.ItemsFieldLabel": "Елементи",
   "PassingRateSummaryControls.ItemsValidationError": "Кількість елементів приймає значення від '1' до '600'",
   "PassingRateSummaryControls.excludeSkipped": "Виключити пропущені тести зі статистики",
-  "PasswordForm.description": "Мінімальна кількість символів, необхідних для пароля. Допустимий діапазон: від 8 до 256 символів.",
+  "PasswordForm.description": "Мінімальна кількість символів, необхідних для пароля. Допустимий діапазон: від {min} до {max} символів.",
   "PasswordForm.formHeader": "Пароль",
   "PasswordForm.label": "Довжина пароля",
   "PasswordForm.successNotification": "Мінімальну довжину пароля успішно оновлено",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -2051,7 +2051,7 @@
   "PassingRateSummaryControls.ItemsFieldLabel": "测试项",
   "PassingRateSummaryControls.ItemsValidationError": "测试项的数量应为1到600个",
   "PassingRateSummaryControls.excludeSkipped": "Exclude Skipped tests from statistics",
-  "PasswordForm.description": "Minimum number of characters required for the password. Allowed range: 8 to 256 characters.",
+  "PasswordForm.description": "密码所需的最少字符数。允许范围：{min} 到 {max} 个字符。",
   "PasswordForm.formHeader": "Password",
   "PasswordForm.label": "Password length",
   "PasswordForm.successNotification": "The minimum password length has been updated successfully",

--- a/app/src/common/constants/validation.js
+++ b/app/src/common/constants/validation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 export const PASSWORD_MIN_ALLOWED_LENGTH = 8;
-export const PASSWORD_MAX_ALLOWED_LENGTH = 256;
+export const PASSWORD_MAX_ALLOWED_LENGTH = 36;
 
 export const REGISTRATION_NAME_MIN_LENGTH = 3;
 export const REGISTRATION_NAME_MAX_LENGTH = 60;

--- a/app/src/pages/inside/profilePage/modals/changePasswordModal/changePasswordModal.jsx
+++ b/app/src/pages/inside/profilePage/modals/changePasswordModal/changePasswordModal.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import { passwordMinLengthSelector } from 'controllers/appInfo';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { validationLocalization } from 'common/constants/localization/validationLocalization';
 import { ERROR_CODE_LOGIN_BAD_CREDENTIALS } from 'common/constants/apiErrorCodes';
+import { PASSWORD_MAX_ALLOWED_LENGTH } from 'common/constants/validation';
 import { reduxForm, SubmissionError } from 'redux-form';
 import { Input } from 'components/inputs/input';
 import { InputCheckbox } from 'components/inputs/inputCheckbox';
@@ -217,7 +218,7 @@ export class ChangePasswordModal extends Component {
                 <Input
                   placeholder={intl.formatMessage(messages.newPasswordPlaceholder)}
                   type={this.state.showPassword ? 'text' : 'password'}
-                  maxLength="256"
+                  maxLength={PASSWORD_MAX_ALLOWED_LENGTH}
                 />
               </FieldErrorHint>
             </FieldProvider>
@@ -228,7 +229,7 @@ export class ChangePasswordModal extends Component {
                 <Input
                   placeholder={intl.formatMessage(messages.confirmPlaceholder)}
                   type={this.state.showPassword ? 'text' : 'password'}
-                  maxLength="256"
+                  maxLength={PASSWORD_MAX_ALLOWED_LENGTH}
                 />
               </FieldErrorHint>
             </FieldProvider>

--- a/app/src/pages/instance/allUsersPage/allUsersHeader/createUserModal/createUserModal.jsx
+++ b/app/src/pages/instance/allUsersPage/allUsersHeader/createUserModal/createUserModal.jsx
@@ -40,6 +40,7 @@ import { fetchAllUsersAction, ERROR_CODES } from 'controllers/instance/allUsers'
 import { ALL_USERS_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/allUsersPage';
 import { URLS } from 'common/urls';
 import { ADMINISTRATOR, USER } from 'common/constants/accountRoles';
+import { PASSWORD_MAX_ALLOWED_LENGTH } from 'common/constants/validation';
 import { OrganizationType } from 'controllers/organization';
 import {
   CREATE_USER_FORM,
@@ -305,6 +306,7 @@ export const CreateUserModal = ({ handleSubmit, invalid }) => {
                   defaultWidth={false}
                   placeholder={formatMessage(messages.passwordPlaceholder)}
                   type="password"
+                  maxLength={PASSWORD_MAX_ALLOWED_LENGTH}
                   helpText={formatMessage(messages.passwordValidateMessage, { minLength })}
                   classNameHelpText={cx('help-text')}
                   isRequired

--- a/app/src/pages/instance/serverSettingsPage/serverSettingsTabs/authConfigurationTab/forms/passwordForm/passwordForm.jsx
+++ b/app/src/pages/instance/serverSettingsPage/serverSettingsTabs/authConfigurationTab/forms/passwordForm/passwordForm.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ const messages = defineMessages({
   description: {
     id: 'PasswordForm.description',
     defaultMessage:
-      'Minimum number of characters required for the password. Allowed range: 8 to 256 characters.',
+      'Minimum number of characters required for the password. Allowed range: {min} to {max} characters.',
   },
   successNotification: {
     id: 'PasswordForm.successNotification',
@@ -96,7 +96,10 @@ export const PasswordForm = () => {
     <SectionLayout header={formatMessage(messages.formHeader)}>
       <ServerSettingsField
         label={formatMessage(messages.label)}
-        description={formatMessage(messages.description)}
+        description={formatMessage(messages.description, {
+          min: PASSWORD_MIN_ALLOWED_LENGTH,
+          max: PASSWORD_MAX_ALLOWED_LENGTH,
+        })}
       >
         <FieldNumber
           min={PASSWORD_MIN_ALLOWED_LENGTH}

--- a/app/src/pages/outside/loginPage/pageBlocks/loginBlock/loginForm/loginForm.jsx
+++ b/app/src/pages/outside/loginPage/pageBlocks/loginBlock/loginForm/loginForm.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import { useTracking } from 'react-tracking';
 import { LDAP } from 'common/constants/pluginNames';
 import { commonValidators } from 'common/utils/validation';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
+import { PASSWORD_MAX_ALLOWED_LENGTH } from 'common/constants/validation';
 import { isDemoInstanceSelector } from 'controllers/appInfo';
 import {
   badCredentialsSelector,
@@ -189,7 +190,7 @@ const LoginFormComponent = ({
             <FieldText
               label={formatMessage(messages.password)}
               type="password"
-              maxLength={256}
+              maxLength={PASSWORD_MAX_ALLOWED_LENGTH}
               defaultWidth={false}
               autoComplete="off"
               disabled={isLoginLoading}


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
1. Decrease `PASSWORD_MAX_ALLOWED_LENGTH` and use it for password fields

## Links
[EPMRPP-117196](https://jiraeu.epam.com/browse/EPMRPP-117196)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Password fields now enforce a maximum length of 36 characters across login, profile, user creation, and server settings.
  - Password requirements display dynamic minimum and maximum lengths.

- **Bug Fixes**
  - Updated Belarusian, Spanish, Russian, Ukrainian, and Chinese translations to show the correct password length range.
  - Replaced outdated fixed password-length guidance with localized, parameterized messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->