### PR TITLE
EPMRPP-117392 || Harden user HTML sanitization against stored XSS overlays

### DIFF
--- a/app/src/common/utils/sanitizeUserHtml.js
+++ b/app/src/common/utils/sanitizeUserHtml.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import DOMPurify from 'dompurify';
+
+const STYLE_TAG_REGEX = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+const USER_CONTENT_FORBIDDEN_TAGS = [
+  'form',
+  'input',
+  'button',
+  'select',
+  'textarea',
+  'option',
+  'fieldset',
+  'legend',
+  'iframe',
+  'object',
+  'embed',
+];
+
+const UNSAFE_CSS_PROPERTY = /\b(?:position|z-index)\s*:[^;}]*/gi;
+
+const normalizeCss = (value) =>
+  value
+    .replace(/(?:;\s*){2,}/g, ';')
+    .replace(/\{\s*;/g, '{')
+    .replace(/;\s*}/g, '}')
+    .replace(/;\s*$/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+const sanitizeCssValue = (value) => normalizeCss(value.replace(UNSAFE_CSS_PROPERTY, ''));
+
+const splitHtmlByStyleBlocks = (html) => {
+  const parts = [];
+  let lastIndex = 0;
+  let match = STYLE_TAG_REGEX.exec(html);
+
+  while (match) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'html', value: html.slice(lastIndex, match.index) });
+    }
+
+    parts.push({ type: 'style', value: match[1] });
+    lastIndex = STYLE_TAG_REGEX.lastIndex;
+    match = STYLE_TAG_REGEX.exec(html);
+  }
+
+  STYLE_TAG_REGEX.lastIndex = 0;
+
+  if (lastIndex < html.length) {
+    parts.push({ type: 'html', value: html.slice(lastIndex) });
+  }
+
+  return parts;
+};
+
+const removeUnsafeStyleAttribute = (_node, data) => {
+  if (data.attrName !== 'style') {
+    return;
+  }
+
+  const sanitizedStyle = sanitizeCssValue(data.attrValue);
+
+  if (!sanitizedStyle) {
+    data.keepAttr = false;
+    return;
+  }
+
+  data.attrValue = sanitizedStyle;
+};
+
+const sanitizeHtmlPart = (htmlPart, config) =>
+  DOMPurify.sanitize(htmlPart, {
+    FORBID_TAGS: USER_CONTENT_FORBIDDEN_TAGS,
+    ...config,
+  });
+
+const sanitizeStylePart = (styleContent) => {
+  const sanitized = sanitizeCssValue(styleContent);
+
+  return sanitized ? `<style>${sanitized}</style>` : '';
+};
+
+export const sanitizeUserHtml = (html, config = {}) => {
+  const parts = splitHtmlByStyleBlocks(html);
+
+  if (!parts.length) {
+    return '';
+  }
+
+  DOMPurify.addHook('uponSanitizeAttribute', removeUnsafeStyleAttribute);
+
+  const sanitized = parts
+    .map((part) =>
+      part.type === 'style' ? sanitizeStylePart(part.value) : sanitizeHtmlPart(part.value, config),
+    )
+    .join('');
+
+  DOMPurify.removeHook('uponSanitizeAttribute', removeUnsafeStyleAttribute);
+
+  return sanitized;
+};

--- a/app/src/common/utils/sanitizeUserHtml.test.js
+++ b/app/src/common/utils/sanitizeUserHtml.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sanitizeUserHtml } from './sanitizeUserHtml';
+
+const XSS_PAYLOAD =
+  '"><style>#phish{position:fixed;top:0;left:0;width:100%;height:100%;background:white;z-index:9999}</style><div id=phish><form onsubmit="alert(1)"><input name=user><button>Login</button></form></div>';
+
+describe('sanitizeUserHtml', () => {
+  test('should keep common HTML markup', () => {
+    const html = '<div class="note"><p><strong>bold</strong> and <em>italic</em></p></div>';
+
+    expect(sanitizeUserHtml(html)).toBe(
+      '<div class="note"><p><strong>bold</strong> and <em>italic</em></p></div>',
+    );
+  });
+
+  test('should remove form elements', () => {
+    const html = '<p>text</p><form><input><button>Login</button></form>';
+    const sanitized = sanitizeUserHtml(html);
+
+    expect(sanitized).not.toContain('<form');
+    expect(sanitized).not.toContain('<input');
+    expect(sanitized).not.toContain('<button');
+    expect(sanitized).toContain('<p>text</p>');
+  });
+
+  test('should remove overlay markup from reported payload', () => {
+    const sanitized = sanitizeUserHtml(XSS_PAYLOAD);
+
+    expect(sanitized).not.toContain('<form');
+    expect(sanitized).not.toContain('<button');
+    expect(sanitized).not.toContain('position:fixed');
+    expect(sanitized).not.toContain('z-index');
+  });
+
+  test('should keep style tags and strip only position and z-index inside them', () => {
+    const html = '<style>p { color: red; position: fixed; z-index: 10; margin: 0; }</style>';
+    const sanitized = sanitizeUserHtml(html);
+
+    expect(sanitized).toContain('<style>');
+    expect(sanitized).toContain('color: red');
+    expect(sanitized).toContain('margin: 0');
+    expect(sanitized).not.toMatch(/position\s*:/i);
+    expect(sanitized).not.toMatch(/z-index\s*:/i);
+  });
+
+  test('should strip position and z-index from inline styles', () => {
+    const html = '<div style="color:red;position:fixed;z-index:9999">text</div>';
+
+    expect(sanitizeUserHtml(html)).toBe('<div style="color:red">text</div>');
+  });
+});

--- a/app/src/common/utils/textHighlight.jsx
+++ b/app/src/common/utils/textHighlight.jsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+export const highlightText = (text, query, highlightClassName = 'highlight') => {
+  if (!query || !text) {
+    return text;
+  }
+
+  const trimmedQuery = query.trim();
+
+  if (!trimmedQuery) {
+    return text;
+  }
+
+  const escapedQuery = trimmedQuery.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`); // NOSONAR
+
+  const regex = new RegExp(`(${escapedQuery})`, 'gi');
+  const parts = text.split(regex);
+
+  if (parts.length === 1) {
+    return text;
+  }
+
+  const nodes = parts.reduce(
+    (acc, part) => {
+      if (!part) {
+        return acc;
+      }
+
+      const currentKey = acc.counter;
+      const isMatch = part.toLowerCase() === trimmedQuery.toLowerCase();
+      const newNode = isMatch ? (
+        <span key={`highlight-${currentKey}`} className={highlightClassName}>
+          {part}
+        </span>
+      ) : (
+        <span key={`text-${currentKey}`}>{part}</span>
+      );
+
+      return {
+        nodes: [...acc.nodes, newNode],
+        counter: acc.counter + 1,
+      };
+    },
+    { nodes: [], counter: 0 },
+  );
+
+  return <>{nodes.nodes}</>;
+};

--- a/app/src/components/main/markdown/markdownViewer/markdownViewer.jsx
+++ b/app/src/components/main/markdown/markdownViewer/markdownViewer.jsx
@@ -16,9 +16,9 @@
 
 import React, { Component } from 'react';
 import Parser from 'html-react-parser';
-import DOMPurify from 'dompurify';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
+import { sanitizeUserHtml } from 'common/utils/sanitizeUserHtml';
 import { SingletonMarkdownObject } from '../singletonMarkdownObject';
 import { MODE_DEFAULT } from '../constants';
 import styles from './markdownViewer.scss';
@@ -76,13 +76,14 @@ export class MarkdownViewer extends Component {
 
   render() {
     const { value, mode } = this.props;
+
     return (
       <div className={cx('viewer-wrapper')}>
         <div
           ref={this.container}
           className={cx('markdown-viewer', { [`mode-${mode}`]: mode }, this.props.className)}
         >
-          {Parser(DOMPurify.sanitize(this.simpleMDE.markdown(value || '').trim()))}
+          {Parser(sanitizeUserHtml(this.simpleMDE.markdown(value || '').trim()))}
         </div>
       </div>
     );

--- a/app/src/components/main/markdown/markdownViewer/markdownViewer.test.jsx
+++ b/app/src/components/main/markdown/markdownViewer/markdownViewer.test.jsx
@@ -155,4 +155,13 @@ describe('MarkdownViewer', () => {
     expect(wrapper.find('.markdown-viewer code')).toHaveLength(1);
     expect(wrapper.find('.markdown-viewer code').text()).toEqual('<span>test code</span>');
   });
+  test('raw HTML with unsafe overlay markup is not rendered', () => {
+    const xssPayload =
+      '"><style>#phish{position:fixed;top:0;left:0;width:100%;height:100%}</style><div id=phish><form><button>Login</button></form></div>';
+    const wrapper = mount(<MarkdownViewer value={xssPayload} />);
+
+    expect(wrapper.find('form')).toHaveLength(0);
+    expect(wrapper.find('button')).toHaveLength(0);
+    expect(wrapper.html()).not.toContain('position:fixed');
+  });
 });

--- a/app/src/components/main/tooltips/textTooltip/textTooltip.jsx
+++ b/app/src/components/main/tooltips/textTooltip/textTooltip.jsx
@@ -17,7 +17,7 @@
 import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
 import Parser from 'html-react-parser';
-import DOMPurify from 'dompurify';
+import { sanitizeUserHtml } from 'common/utils/sanitizeUserHtml';
 import styles from './textTooltip.scss';
 
 const cx = classNames.bind(styles);
@@ -29,8 +29,8 @@ export const TextTooltip = ({
   preventTargetSanitizing,
 }) => {
   const content = preventTargetSanitizing
-    ? Parser(DOMPurify.sanitize(tooltipContent, { ADD_ATTR: ['target'] }))
-    : Parser(DOMPurify.sanitize(tooltipContent));
+    ? Parser(sanitizeUserHtml(tooltipContent, { ADD_ATTR: ['target'] }))
+    : Parser(sanitizeUserHtml(tooltipContent));
 
   return (
     <div className={cx('text-tooltip', className)}>{preventParsing ? tooltipContent : content}</div>

--- a/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.jsx
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterName/filterName.jsx
@@ -17,11 +17,10 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import Parser from 'html-react-parser';
-import DOMPurify from 'dompurify';
 import Link from 'redux-first-router-link';
 import { Icon } from 'components/main/icon';
 import { MarkdownViewer } from 'components/main/markdown';
+import { highlightText } from 'common/utils/textHighlight';
 import styles from './filterName.scss';
 
 const cx = classNames.bind(styles);
@@ -55,18 +54,7 @@ export const FilterName = ({
   isLink,
   nameLink,
 }) => {
-  const getHighlightName = () => {
-    const name = filter.name || '';
-
-    if (!search.length) {
-      return name;
-    }
-
-    return name.replace(
-      new RegExp(search, 'i'),
-      (match) => `<span class=${cx('name-highlight')}>${match}</span>`,
-    );
-  };
+  const name = filter.name || '';
 
   return (
     <Fragment>
@@ -79,7 +67,7 @@ export const FilterName = ({
             })}
             onClick={() => onClickName(filter)}
           >
-            {Parser(DOMPurify.sanitize(getHighlightName()))}
+            {highlightText(name, search, cx('name-highlight'))}
           </span>
         </NameLink>
         {editable && onEdit && (


### PR DESCRIPTION
## Problem

A stored XSS vulnerability was reported on `reportportal.epam.com` (EPMRPP-117392). A non-privileged user can save malicious HTML in a filter field (name or description) and trigger a phishing overlay for any user who opens that filter or a dashboard widget that references it.

**Root cause:** User-controlled content was rendered as HTML with default `DOMPurify` sanitization, which is insufficient for this attack class. The reported payload does not rely on `<script>` — it uses a full-screen overlay built from `<style>` / inline CSS (`position`, `z-index`) and a phishing `<form>`. Default sanitization allowed these constructs to reach the DOM. `FilterName` additionally parsed the filter name through `html-react-parser`, creating another HTML rendering path.

## Solution

Introduce a shared `sanitizeUserHtml` policy for user-generated HTML and apply it globally where markdown/HTML is rendered:

- **Remove dangerous markup:** forbid form-related tags (`form`, `input`, `button`, etc.).
- **Block overlay CSS:** strip `position` and `z-index` from inline `style` attributes and from `<style>` block contents; other CSS (e.g. `color`, `margin`) is preserved.
- **Keep HTML support:** legitimate HTML/markdown output (including in logs and descriptions) continues to work; only harmful constructs are removed.
- **Apply globally:** use `sanitizeUserHtml` in `MarkdownViewer` and `TextTooltip` instead of default `DOMPurify.sanitize`.
- **Filter name:** render as plain text via `highlightText` for search highlighting; remove `html-react-parser` from the name rendering path.

Already stored malicious payloads are neutralized at display time without requiring database cleanup.

## Related

EPMRPP-117392
