### PR TITLE
EPMRPP-117291 || Add API-based Mobitru tab visibility and Jump to log navigation

### DIFF
--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -156,6 +156,8 @@ export class LogItemInfoTabs extends Component {
     logTabVisibility: {},
   };
 
+  logTabVisibilityRequestId = 0;
+
   static getDerivedStateFromProps(props) {
     return props.loading
       ? {
@@ -207,10 +209,13 @@ export class LogItemInfoTabs extends Component {
     const { activeRetry, projectKey, logId, retryId, logTabExtensions } = this.props;
     const mobitruExtensions = logTabExtensions.filter(isMobitruVideoSubtreeTab);
 
+    this.logTabVisibilityRequestId += 1;
+
     if (!mobitruExtensions.length || !activeRetry?.path || !projectKey) {
       return;
     }
 
+    const requestId = this.logTabVisibilityRequestId;
     const excludedRetryParentId = logId === retryId ? retryId : undefined;
     const loadingState = mobitruExtensions.reduce(
       (acc, extension) => ({
@@ -237,6 +242,10 @@ export class LogItemInfoTabs extends Component {
         excludedRetryParentId,
       })
         .then((isVisible) => {
+          if (requestId !== this.logTabVisibilityRequestId) {
+            return;
+          }
+
           this.setState((prevState) => ({
             logTabVisibility: {
               ...prevState.logTabVisibility,
@@ -245,6 +254,10 @@ export class LogItemInfoTabs extends Component {
           }));
         })
         .catch(() => {
+          if (requestId !== this.logTabVisibilityRequestId) {
+            return;
+          }
+
           this.setState((prevState) => ({
             logTabVisibility: {
               ...prevState.logTabVisibility,
@@ -268,10 +281,12 @@ export class LogItemInfoTabs extends Component {
       );
     }
 
-    return false;
+    return true;
   };
 
   componentWillUnmount() {
+    this.logTabVisibilityRequestId += 1;
+
     if (this.props.isSauceLabsIntegrationView) {
       this.props.onToggleSauceLabsIntegrationView();
     }
@@ -320,8 +335,9 @@ export class LogItemInfoTabs extends Component {
         return;
       }
 
-      setActiveTabId('logs');
-      fetchLogAction(logInfo, () => {}, true);
+      fetchLogAction(logInfo, () => {
+        setActiveTabId('logs');
+      }, true);
     } catch {
       // non-blocking: keep user on Remote device tab when navigation fails
     }

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -29,9 +29,12 @@ import {
   activeLogSelector,
   activeTabIdSelector,
   setActiveTabIdAction,
+  fetchLog,
 } from 'controllers/log';
 import { noLogsCollapsingSelector } from 'controllers/user';
+import { projectKeySelector } from 'controllers/project';
 import { fetchFirstAttachmentsAction, attachmentItemsSelector } from 'controllers/log/attachments';
+import { fetch } from 'common/utils/fetch';
 import { SAUCE_LABS } from 'common/constants/pluginNames';
 import { LOG_PAGE_EVENTS } from 'components/main/analytics/events';
 import StackTraceIcon from 'common/img/stack-trace-inline.svg';
@@ -51,6 +54,11 @@ import { Attachments } from './attachments';
 import { getActionMessage } from '../utils/getActionMessage';
 import styles from './logItemInfoTabs.scss';
 import { LogsGridWrapper } from '../../logsGridWrapper';
+import {
+  checkMobitruLogTabVisibility,
+  isMobitruVideoSubtreeTab,
+} from './utils/checkMobitruLogTabVisibility';
+import { resolveMobitruLogForJump } from './utils/resolveMobitruLogForJump';
 
 const cx = classNames.bind(styles);
 
@@ -96,10 +104,12 @@ const LOG_TAB_ELEMENT_EVENTS = {
     activeTabId: activeTabIdSelector(state),
     noLogsCollapsing: noLogsCollapsingSelector(state),
     logTabExtensions: uiExtensionLogTabSelector(state),
+    projectKey: projectKeySelector(state),
   }),
   {
     fetchFirstAttachments: fetchFirstAttachmentsAction,
     setActiveTabId: setActiveTabIdAction,
+    fetchLog,
   },
 )
 @track()
@@ -117,6 +127,7 @@ export class LogItemInfoTabs extends Component {
     sauceLabsIntegrations: PropTypes.array.isRequired,
     fetchFirstAttachments: PropTypes.func,
     setActiveTabId: PropTypes.func,
+    fetchLog: PropTypes.func,
     attachments: PropTypes.array,
     tracking: PropTypes.shape({
       trackEvent: PropTypes.func,
@@ -125,6 +136,7 @@ export class LogItemInfoTabs extends Component {
     activeTabId: PropTypes.string,
     noLogsCollapsing: PropTypes.bool,
     logTabExtensions: PropTypes.array,
+    projectKey: PropTypes.string,
   };
 
   static defaultProps = {
@@ -133,12 +145,15 @@ export class LogItemInfoTabs extends Component {
     attachments: [],
     activeTabId: 'logs',
     setActiveTabId: () => {},
+    fetchLog: () => {},
     noLogsCollapsing: false,
     logTabExtensions: [],
+    projectKey: '',
   };
 
   state = {
     activeTabId: null,
+    logTabVisibility: {},
   };
 
   static getDerivedStateFromProps(props) {
@@ -154,18 +169,107 @@ export class LogItemInfoTabs extends Component {
     if (activeTabId === ATTACHMENTS_TAB_ID) {
       fetchFirstAttachments();
     }
+    this.fetchLogTabVisibility();
   }
 
   componentDidUpdate(prevProps) {
-    const { activeTabId, fetchFirstAttachments, isSauceLabsIntegrationView, loading, logId } =
-      this.props;
+    const {
+      activeTabId,
+      fetchFirstAttachments,
+      isSauceLabsIntegrationView,
+      loading,
+      logId,
+      retryId,
+      activeRetry,
+      projectKey,
+      logTabExtensions,
+    } = this.props;
     if (loading && isSauceLabsIntegrationView) {
       this.props.onToggleSauceLabsIntegrationView();
     }
     if (prevProps.logId !== logId && activeTabId === ATTACHMENTS_TAB_ID) {
       fetchFirstAttachments();
     }
+    if (
+      prevProps.retryId !== retryId ||
+      prevProps.logId !== logId ||
+      prevProps.activeRetry?.path !== activeRetry?.path ||
+      prevProps.projectKey !== projectKey ||
+      prevProps.logTabExtensions !== logTabExtensions
+    ) {
+      this.fetchLogTabVisibility();
+    }
   }
+
+  getLogTabId = (extension) => `log-tab:${extension.pluginName}:${extension.name}`;
+
+  fetchLogTabVisibility = () => {
+    const { activeRetry, projectKey, logId, retryId, logTabExtensions } = this.props;
+    const mobitruExtensions = logTabExtensions.filter(isMobitruVideoSubtreeTab);
+
+    if (!mobitruExtensions.length || !activeRetry?.path || !projectKey) {
+      return;
+    }
+
+    const excludedRetryParentId = logId === retryId ? retryId : undefined;
+    const loadingState = mobitruExtensions.reduce(
+      (acc, extension) => ({
+        ...acc,
+        [this.getLogTabId(extension)]: 'loading',
+      }),
+      {},
+    );
+
+    this.setState((prevState) => ({
+      logTabVisibility: {
+        ...prevState.logTabVisibility,
+        ...loadingState,
+      },
+    }));
+
+    mobitruExtensions.forEach((extension) => {
+      const tabId = this.getLogTabId(extension);
+
+      checkMobitruLogTabVisibility({
+        fetchFn: fetch,
+        projectKey,
+        activeRetryPath: activeRetry.path,
+        excludedRetryParentId,
+      })
+        .then((isVisible) => {
+          this.setState((prevState) => ({
+            logTabVisibility: {
+              ...prevState.logTabVisibility,
+              [tabId]: isVisible,
+            },
+          }));
+        })
+        .catch(() => {
+          this.setState((prevState) => ({
+            logTabVisibility: {
+              ...prevState.logTabVisibility,
+              [tabId]: false,
+            },
+          }));
+        });
+    });
+  };
+
+  isLogTabVisible = (extension) => {
+    if (isMobitruVideoSubtreeTab(extension)) {
+      const tabId = this.getLogTabId(extension);
+      return this.state.logTabVisibility[tabId] === true;
+    }
+
+    if (extension.payload?.visibilityAttributeKey) {
+      const { logItem } = this.props;
+      return logItem.attributes?.some(
+        (attr) => attr.key === extension.payload.visibilityAttributeKey,
+      );
+    }
+
+    return false;
+  };
 
   componentWillUnmount() {
     if (this.props.isSauceLabsIntegrationView) {
@@ -194,6 +298,35 @@ export class LogItemInfoTabs extends Component {
     const { retryId, logId } = this.props;
     return retryId === logId;
   };
+
+  handleJumpToMobitruLog = async (logId, itemId) => {
+    const { projectKey, retryId, setActiveTabId, fetchLog: fetchLogAction, tracking } = this.props;
+
+    tracking.trackEvent(LOG_PAGE_EVENTS.clickJumpToLog('remote_device'));
+
+    try {
+      let logInfo = await resolveMobitruLogForJump({
+        fetchFn: fetch,
+        projectKey,
+        retryId,
+        logId,
+      });
+
+      if (!logInfo && itemId === retryId) {
+        logInfo = { id: logId, pagesLocation: [{ [logId]: 1 }] };
+      }
+
+      if (!logInfo?.pagesLocation?.length) {
+        return;
+      }
+
+      setActiveTabId('logs');
+      fetchLogAction(logInfo, () => {}, true);
+    } catch {
+      // non-blocking: keep user on Remote device tab when navigation fails
+    }
+  };
+
   makeTabs = () => {
     const {
       intl: { formatMessage },
@@ -201,6 +334,8 @@ export class LogItemInfoTabs extends Component {
       logItem,
       noLogsCollapsing,
       logTabExtensions,
+      logId,
+      retryId,
     } = this.props;
     const history = {
       id: 'history',
@@ -260,16 +395,14 @@ export class LogItemInfoTabs extends Component {
     }
 
     logTabExtensions.forEach((extension) => {
-      const isVisible = logItem.attributes?.some(
-        (attr) => attr.key === extension.payload.visibilityAttributeKey
-      );
-
-      if (!isVisible) {
+      if (!this.isLogTabVisible(extension)) {
         return;
       }
 
-      const tabId = `log-tab:${extension.pluginName}:${extension.name}`;
+      const tabId = this.getLogTabId(extension);
       const tabElementName = extension.payload?.tabElementName;
+      const excludedRetryParentId = logId === retryId ? retryId : undefined;
+      const isMobitruTab = isMobitruVideoSubtreeTab(extension);
       tabs.push({
         id: tabId,
         label: extension.name,
@@ -279,6 +412,9 @@ export class LogItemInfoTabs extends Component {
         componentProps: {
           extension,
           logItem,
+          activeRetry,
+          excludedRetryParentId,
+          ...(isMobitruTab && { onJumpToLog: this.handleJumpToMobitruLog }),
         },
       });
     });

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { URLS } from 'common/urls';
+
+export const MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE = 'mobitruVideoSubtree';
+
+export const isMobitruVideoSubtreeTab = (extension) =>
+  extension.payload?.visibilityMode === MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE ||
+  extension.payload?.tabElementName === 'remote_device';
+
+export const checkMobitruLogTabVisibility = async ({
+  fetchFn,
+  projectKey,
+  activeRetryPath,
+  excludedRetryParentId,
+}) => {
+  const url = URLS.logsUnderPath(projectKey, activeRetryPath, excludedRetryParentId);
+  const response = await fetchFn(url, {
+    params: {
+      'filter.eq.level': 'mobitru',
+      'filter.ex.binaryContent': true,
+      'page.size': 1,
+      'page.page': 1,
+    },
+  });
+
+  return Boolean(response?.content?.length);
+};

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.js
@@ -19,8 +19,7 @@ import { URLS } from 'common/urls';
 export const MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE = 'mobitruVideoSubtree';
 
 export const isMobitruVideoSubtreeTab = (extension) =>
-  extension.payload?.visibilityMode === MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE ||
-  extension.payload?.tabElementName === 'remote_device';
+  extension.payload?.visibilityMode === MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE;
 
 export const checkMobitruLogTabVisibility = async ({
   fetchFn,

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.test.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkMobitruLogTabVisibility } from './checkMobitruLogTabVisibility';
+
+describe('checkMobitruLogTabVisibility', () => {
+  test('should return true when mobitru video logs exist in subtree', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({ content: [{ id: 1 }] });
+
+    const result = await checkMobitruLogTabVisibility({
+      fetchFn,
+      projectKey: 'default_personal',
+      activeRetryPath: '1.2.3',
+      excludedRetryParentId: 10,
+    });
+
+    expect(result).toBe(true);
+    expect(fetchFn).toHaveBeenCalledWith(expect.stringContaining('default_personal/log'), {
+      params: {
+        'filter.eq.level': 'mobitru',
+        'filter.ex.binaryContent': true,
+        'page.size': 1,
+        'page.page': 1,
+      },
+    });
+  });
+
+  test('should return false when no mobitru video logs exist in subtree', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({ content: [] });
+
+    const result = await checkMobitruLogTabVisibility({
+      fetchFn,
+      projectKey: 'default_personal',
+      activeRetryPath: '1.2.3',
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/checkMobitruLogTabVisibility.test.js
@@ -14,7 +14,29 @@
  * limitations under the License.
  */
 
-import { checkMobitruLogTabVisibility } from './checkMobitruLogTabVisibility';
+import {
+  checkMobitruLogTabVisibility,
+  isMobitruVideoSubtreeTab,
+  MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE,
+} from './checkMobitruLogTabVisibility';
+
+describe('isMobitruVideoSubtreeTab', () => {
+  test('should return true when visibilityMode is mobitruVideoSubtree', () => {
+    expect(
+      isMobitruVideoSubtreeTab({
+        payload: { visibilityMode: MOBITRU_VIDEO_SUBTREE_VISIBILITY_MODE },
+      }),
+    ).toBe(true);
+  });
+
+  test('should return false for legacy remote_device tab without visibilityMode', () => {
+    expect(
+      isMobitruVideoSubtreeTab({
+        payload: { tabElementName: 'remote_device', visibilityAttributeKey: 'MBID' },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe('checkMobitruLogTabVisibility', () => {
   test('should return true when mobitru video logs exist in subtree', async () => {

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { URLS } from 'common/urls';
+
+const LOCATIONS_PAGE_SIZE = 300;
+
+const LOCATION_QUERY_VARIANTS = [{}, { 'filter.gte.level': 'mobitru' }, { 'filter.eq.level': 'mobitru' }];
+
+const findLogInLocationsPage = (content, logId) =>
+  content?.find((log) => +log.id === +logId && log.pagesLocation?.length);
+
+const fetchLocationsPage = ({ fetchFn, url, page, extraParams }) =>
+  fetchFn(url, {
+    params: {
+      excludeLogContent: true,
+      'page.size': LOCATIONS_PAGE_SIZE,
+      'page.page': page,
+      ...extraParams,
+    },
+  });
+
+const searchLocationsPage = async ({
+  fetchFn,
+  url,
+  logId,
+  extraParams,
+  page = 1,
+  totalPages = 1,
+}) => {
+  if (page > totalPages) {
+    return null;
+  }
+
+  const response = await fetchLocationsPage({ fetchFn, url, page, extraParams });
+  const logInfo = findLogInLocationsPage(response?.content, logId);
+
+  if (logInfo) {
+    return logInfo;
+  }
+
+  return searchLocationsPage({
+    fetchFn,
+    url,
+    logId,
+    extraParams,
+    page: page + 1,
+    totalPages: response?.page?.totalPages || 1,
+  });
+};
+
+const searchWithQueryVariants = async ({ fetchFn, url, logId, variantIndex = 0 }) => {
+  if (variantIndex >= LOCATION_QUERY_VARIANTS.length) {
+    return null;
+  }
+
+  const logInfo = await searchLocationsPage({
+    fetchFn,
+    url,
+    logId,
+    extraParams: LOCATION_QUERY_VARIANTS[variantIndex],
+  });
+
+  if (logInfo) {
+    return logInfo;
+  }
+
+  return searchWithQueryVariants({ fetchFn, url, logId, variantIndex: variantIndex + 1 });
+};
+
+export const resolveMobitruLogForJump = async ({ fetchFn, projectKey, retryId, logId }) => {
+  const url = URLS.errorLogs(projectKey, retryId);
+
+  return searchWithQueryVariants({ fetchFn, url, logId });
+};

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolveMobitruLogForJump } from './resolveMobitruLogForJump';
+
+describe('resolveMobitruLogForJump', () => {
+  test('should return log info when pagesLocation exists on first page', async () => {
+    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
+    const fetchFn = jest.fn().mockResolvedValue({
+      content: [logInfo],
+      page: { totalPages: 1 },
+    });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      logId: 10,
+    });
+
+    expect(result).toEqual(logInfo);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('should paginate until log is found', async () => {
+    const logInfo = { id: 20, pagesLocation: [{ 20: 2 }] };
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 1, pagesLocation: [{ 1: 1 }] }],
+        page: { totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        content: [logInfo],
+        page: { totalPages: 2 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      logId: 20,
+    });
+
+    expect(result).toEqual(logInfo);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  test('should return null when log is not found', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      content: [],
+      page: { totalPages: 1 },
+    });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      logId: 99,
+    });
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Updates the log item tabs host so the Mobitru Remote Device tab works with multiple video logs per test item subtree (EPMRPP-117291, US-LOG-MOB-002 v0.3).

Previously, plugin log tabs were shown only when the current log item had a matching attribute (`visibilityAttributeKey`, e.g. MBID). That model fits a single video on the active log, but not videos attached to nested steps. The host now detects Mobitru video-subtree tabs via `visibilityMode: mobitruVideoSubtree`, checks visibility through the logs API, and passes retry context plus Jump to navigation into the plugin extension.

## Changes

- Show Mobitru Remote Device tab when at least one `mobitru` log with `binaryContent` exists under the active retry path (instead of relying on log item attributes)
- Re-fetch tab visibility when retry, log item, retry path, project, or registered extensions change
- Pass `activeRetry`, `excludedRetryParentId`, and `onJumpToLog` into the Mobitru extension props so the plugin can list videos for the whole subtree and navigate to the source log
- Implement Jump to: resolve target log `pagesLocation` via log locations API (with pagination and level-filter fallbacks), switch to All Logs tab, and scroll to the log; failures are non-blocking
- Keep legacy `visibilityAttributeKey` behavior for non-Mobitru plugin tabs

## Dependencies

Requires the Mobitru plugin update from the same feature (metadata `visibilityMode: mobitruVideoSubtree`, multi-video Remote Device UI). Host changes are backward-compatible with the legacy single-video tab that used `visibilityAttributeKey`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying Mobitru-specific log tabs only when relevant logs are available.
  * Added navigation from Mobitru log tabs directly to the corresponding log entry.
  * Improved log retrieval across paginated results when jumping to a Mobitru log.

* **Bug Fixes**
  * Preserved the current device view when a Mobitru log cannot be resolved.

* **Tests**
  * Added coverage for Mobitru tab visibility, pagination, log resolution, and missing-log scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->