### PR TITLE
EPMRPP-117231 || Add GA4 events for Manual Launches BTS actions on Test Execution Page

### DIFF
--- a/app/src/components/main/analytics/events/ga4Events/manualLaunchesPageEvents.ts
+++ b/app/src/components/main/analytics/events/ga4Events/manualLaunchesPageEvents.ts
@@ -18,6 +18,7 @@ import {
   getBasicChooseEventParameters,
   getBasicClickEventParameters,
   getBasicEventParameters,
+  normalizeEventParameter,
 } from '../common/ga4Utils';
 
 const MANUAL_LAUNCHES = 'manual_launches';
@@ -33,8 +34,10 @@ export const MANUAL_LAUNCHES_PLACE = {
   EXECUTION_DETAILS_SIDEBAR: 'execution_details_sidebar',
   DELETE_TEST_EXECUTION_MODAL: 'delete_test_execution_modal',
   TEST_EXECUTION_PAGE: 'test_execution_page',
+  TEST_EXECUTION_PAGE_HEADER: 'test_execution_page_header',
+  TEST_EXECUTION_PAGE_BTS_SECTION: 'test_execution_page_bts_section',
+  EXECUTION_DETAILS_SIDEBAR_FAILED: 'execution_details_sidebar_failed',
   CLEAR_STATUS_MODAL: 'clear_status_modal',
-  POST_LINK_BTS_MODAL: 'post_link_bts_modal',
 } as const;
 
 export type ManualLaunchListOrSidebarPlace =
@@ -44,6 +47,18 @@ export type ManualLaunchListOrSidebarPlace =
 export type ExecutionStatusChangePlace =
   | typeof MANUAL_LAUNCHES_PLACE.EXECUTION_DETAILS_SIDEBAR
   | typeof MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE;
+
+export type BtsModalEntryPlace =
+  | typeof MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE_HEADER
+  | typeof MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE_BTS_SECTION
+  | typeof MANUAL_LAUNCHES_PLACE.EXECUTION_DETAILS_SIDEBAR_FAILED;
+
+export const getBtsModalEntryPlaceFromStatusChangePlace = (
+  place: ExecutionStatusChangePlace,
+): BtsModalEntryPlace =>
+  place === MANUAL_LAUNCHES_PLACE.EXECUTION_DETAILS_SIDEBAR
+    ? MANUAL_LAUNCHES_PLACE.EXECUTION_DETAILS_SIDEBAR_FAILED
+    : MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE_HEADER;
 
 const MANUAL_LAUNCHES_MODAL = {
   EDIT_LAUNCH: 'edit_launch',
@@ -74,6 +89,9 @@ const MANUAL_LAUNCHES_ELEMENT = {
   SUBMIT_BULK_DELETE_TEST_EXECUTION: 'submit_bulk_delete_test_execution',
   SUBMIT_ADD_TO_TEST_PLAN: 'submit_add_to_test_plan',
   SUBMIT_BTS_ACTION: 'submit_bts_action',
+  ISSUE_TICKET: 'issue_ticket',
+  SAVE_ATTACHMENTS: 'save_attachments',
+  SAVE_EXECUTION_COMMENT: 'save_execution_comment',
   START_DELETE_TEST_EXECUTION: 'start_delete_test_execution',
   START_BULK_DELETE_TEST_EXECUTION: 'start_bulk_delete_test_execution',
   CONTINUE_TESTING: 'continue_testing',
@@ -227,13 +245,29 @@ export const MANUAL_LAUNCHES_PAGE_EVENTS = {
     modal: MANUAL_LAUNCHES_MODAL.ADD_TO_TEST_PLAN,
     element_name: MANUAL_LAUNCHES_ELEMENT.SUBMIT_ADD_TO_TEST_PLAN,
   },
-  submitBtsAction: (type: BtsActionType) => ({
+  submitBtsAction: (place: BtsModalEntryPlace, type: BtsActionType) => ({
     ...CLICK,
-    place: MANUAL_LAUNCHES_PLACE.POST_LINK_BTS_MODAL,
+    place,
     modal: MANUAL_LAUNCHES_MODAL.POST_LINK_BTS,
     element_name: MANUAL_LAUNCHES_ELEMENT.SUBMIT_BTS_ACTION,
     type,
   }),
+  clickIssueTicket: (pluginName: string) => ({
+    ...CLICK,
+    place: MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE,
+    element_name: MANUAL_LAUNCHES_ELEMENT.ISSUE_TICKET,
+    type: normalizeEventParameter(pluginName || 'BTS'),
+  }),
+  CLICK_SAVE_ATTACHMENTS: {
+    ...CLICK,
+    place: MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE,
+    element_name: MANUAL_LAUNCHES_ELEMENT.SAVE_ATTACHMENTS,
+  },
+  CLICK_SAVE_EXECUTION_COMMENT: {
+    ...CLICK,
+    place: MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE,
+    element_name: MANUAL_LAUNCHES_ELEMENT.SAVE_EXECUTION_COMMENT,
+  },
   CLICK_START_DELETE_TEST_EXECUTION: {
     ...CLICK,
     place: MANUAL_LAUNCHES_PLACE.EXECUTION_DETAILS_SIDEBAR,

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/BTSIssuesModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/BTSIssuesModal.tsx
@@ -19,6 +19,7 @@ import { useIntl } from 'react-intl';
 import { Modal, SegmentedControl } from '@reportportal/ui-kit';
 import { InjectedFormProps, reduxForm } from 'redux-form';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTracking } from 'react-tracking';
 
 import { fetch, commonValidators, uniqueId, createClassnames } from 'common/utils';
 import { URLS } from 'common/urls';
@@ -53,7 +54,12 @@ import { messages } from './messages';
 import { BTS_ISSUES_MODAL } from '../constants';
 import { LinkBTSIssueForm } from './LinkBTSIssueForm';
 import { PostBTSIssueForm } from './PostBTSIssueForm/PostBTSIssueForm';
-import { DynamicField, BTSIntegration } from './types';
+import { DynamicField, BTSIntegration, BTSIssuesModalData } from './types';
+import {
+  BTS_ACTION_TYPE,
+  MANUAL_LAUNCHES_PAGE_EVENTS,
+  type BtsActionType,
+} from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
 
 import styles from './BTSIssuesModal.scss';
 import { activeManualLaunchExecutionSelector, getManualLaunchExecutionAction } from 'controllers/manualLaunch';
@@ -71,9 +77,7 @@ const CONTROL_TYPE_FIELD = '_controlType';
 let validationConfig: Record<string, unknown> | null = null;
 
 interface BTSIssuesModalOwnProps {
-  data: {
-    executionId: number;
-  };
+  data: BTSIssuesModalData;
 }
 
 type BTSIssuesModalProps = BTSIssuesModalOwnProps &
@@ -89,6 +93,7 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
   change,
 }) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const dispatch = useDispatch();
   const namedBtsIntegrations = useSelector(namedAvailableBtsIntegrationsSelector) as Record<
     string,
@@ -396,11 +401,21 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
     isSubmitButtonDisabled: invalid,
     onSubmit: () => {
       handleSubmit((values: Record<string, unknown>) => {
+        const btsActionType: BtsActionType =
+          selectedControl === BTSIssueActionTypes.POST
+            ? BTS_ACTION_TYPE.POST
+            : BTS_ACTION_TYPE.LINK;
+
+        const onSuccess = () => {
+          trackEvent(MANUAL_LAUNCHES_PAGE_EVENTS.submitBtsAction(data.entryPlace, btsActionType));
+          hideModal();
+        };
+
         if (selectedControl === BTSIssueActionTypes.POST) {
           const issueData = prepareDataToSend(values);
-          postIssue(issueData, hideModal);
+          postIssue(issueData, onSuccess);
         } else {
-          linkIssue(values, hideModal);
+          linkIssue(values, onSuccess);
         }
       })();
     },

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/types.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/types.ts
@@ -45,6 +45,9 @@ export interface LinkedIssue {
   issueId: string;
 }
 
+import type { BtsModalEntryPlace } from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
+
 export interface BTSIssuesModalData {
   executionId?: number;
+  entryPlace: BtsModalEntryPlace;
 }

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/useBTSIssuesModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/useBTSIssuesModal.tsx
@@ -18,6 +18,8 @@ import { useCallback } from 'react';
 
 import { useModal } from 'common/hooks';
 
+import type { BtsModalEntryPlace } from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
+
 import { BTSIssuesModal } from './BTSIssuesModal';
 import { BTS_ISSUES_MODAL } from '../constants';
 import type { BTSIssuesModalData } from './types';
@@ -29,8 +31,8 @@ export const useBTSIssuesModal = () => {
   });
 
   const openModal = useCallback(
-    (executionId?: number) => {
-      openRawModal({ executionId });
+    (entryPlace: BtsModalEntryPlace, executionId?: number) => {
+      openRawModal({ executionId, entryPlace });
     },
     [openRawModal],
   );

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/LinkedToBTSSection/LinkedToBTSSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/LinkedToBTSSection/LinkedToBTSSection.tsx
@@ -20,6 +20,7 @@ import { Button, IssueList, PlusIcon } from '@reportportal/ui-kit';
 import type { Issue } from '@reportportal/ui-kit/issueList';
 import { isEmpty } from 'es-toolkit/compat';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTracking } from 'react-tracking';
 
 import { createClassnames, fetch } from 'common/utils';
 import { BtsTicket, TestCaseExecution } from 'controllers/manualLaunch';
@@ -32,6 +33,10 @@ import { ExecutionStatus } from 'types/testCase';
 import { messages as executionPageMessages } from '../messages';
 import { messages as executionSidePanelMessages } from '../../manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/messages';
 import { useBTSIssuesModal } from '../BTSIssuesModal/useBTSIssuesModal';
+import {
+  MANUAL_LAUNCHES_PAGE_EVENTS,
+  MANUAL_LAUNCHES_PLACE,
+} from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
 
 import styles from './LinkedToBTSSection.scss';
 
@@ -68,6 +73,7 @@ const getTicketId = (value: unknown): string | null => {
 
 export const LinkedToBTSSection: FC<LinkedToBTSSectionProps> = ({ execution }) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const dispatch = useDispatch();
   const projectKey = useSelector(projectKeySelector);
   const { openModal } = useBTSIssuesModal();
@@ -112,6 +118,19 @@ export const LinkedToBTSSection: FC<LinkedToBTSSectionProps> = ({ execution }) =
     [displayedBtsTickets, projectKey, testItemId, dispatch],
   );
 
+  const handleOpenBtsModal = useCallback(() => {
+    openModal(MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE_BTS_SECTION, execution.id);
+  }, [openModal, execution.id]);
+
+  const handleIssueClick = useCallback(
+    (issue: Issue) => {
+      const pluginName =
+        'pluginName' in issue && typeof issue.pluginName === 'string' ? issue.pluginName : '';
+      trackEvent(MANUAL_LAUNCHES_PAGE_EVENTS.clickIssueTicket(pluginName));
+    },
+    [trackEvent],
+  );
+
   return (
     <section className={cx('linked-to-bts-section')}>
       <div className={cx('linked-to-bts-section__header')}>
@@ -123,7 +142,7 @@ export const LinkedToBTSSection: FC<LinkedToBTSSectionProps> = ({ execution }) =
             variant="text"
             iconPlace="start"
             icon={<PlusIcon />}
-            onClick={() => openModal(execution.id)}
+            onClick={handleOpenBtsModal}
             className={cx('linked-to-bts-section__action')}
           >
             {formatMessage(executionPageMessages.postOrLinkIssue)}
@@ -136,6 +155,7 @@ export const LinkedToBTSSection: FC<LinkedToBTSSectionProps> = ({ execution }) =
           <IssueList
             issues={btsIssues}
             className={cx('linked-to-bts-section__issue')}
+            onIssueClick={handleIssueClick}
             onIssueRemove={handleIssueRemove}
           />
         </div>
@@ -154,7 +174,7 @@ export const LinkedToBTSSection: FC<LinkedToBTSSectionProps> = ({ execution }) =
               variant="text"
               iconPlace="start"
               icon={<PlusIcon />}
-              onClick={() => openModal(execution.id)}
+              onClick={handleOpenBtsModal}
               className={cx('linked-to-bts-section__action')}
             >
               {formatMessage(executionPageMessages.postOrLinkIssue)}

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionCommentSection/executionCommentSection.tsx
@@ -17,6 +17,7 @@
 import { FC, useMemo, useRef, useState, FormEventHandler, ChangeEventHandler } from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTracking } from 'react-tracking';
 import {
   Button,
   DragAndDropIcon,
@@ -40,6 +41,7 @@ import { useFileAttachments } from 'hooks/useFileAttachments';
 import { messages as statusModalMessages } from '../executionStatusConfirmModal/messages';
 import { messages } from '../messages';
 import { commonMessages } from 'pages/inside/common/common-messages';
+import { MANUAL_LAUNCHES_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
 
 import styles from './executionCommentSection.scss';
 import {
@@ -56,6 +58,7 @@ export interface ExecutionCommentSectionProps {
 
 export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ execution }) => {
   const { formatMessage } = useIntl();
+  const { trackEvent } = useTracking();
   const dispatch = useDispatch();
   const projectKey = useSelector(projectKeySelector);
   const launchId = useManualLaunchId();
@@ -140,6 +143,7 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
         removedAttachmentIds: Array.from(removedAttachmentIds),
         btsTickets: execution.btsTickets,
         onSuccess: () => {
+          trackEvent(MANUAL_LAUNCHES_PAGE_EVENTS.CLICK_SAVE_ATTACHMENTS);
           setPendingFiles([]);
           setRemovedAttachmentIds(new Set());
         },
@@ -196,6 +200,7 @@ export const ExecutionCommentSection: FC<ExecutionCommentSectionProps> = ({ exec
         removedAttachmentIds: Array.from(removedAttachmentIds),
         btsTickets: execution.btsTickets,
         onSuccess: () => {
+          trackEvent(MANUAL_LAUNCHES_PAGE_EVENTS.CLICK_SAVE_EXECUTION_COMMENT);
           setPendingFiles([]);
           setRemovedAttachmentIds(new Set());
         },

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -50,6 +50,7 @@ import { useTextareaAutoResize } from 'common/hooks';
 import { ExecutionStatus } from 'pages/inside/manualLaunchesPage/types';
 import {
   MANUAL_LAUNCHES_PAGE_EVENTS,
+  MANUAL_LAUNCHES_PLACE,
   getBtsModalEntryPlaceFromStatusChangePlace,
   type ExecutionStatusType as AnalyticsExecutionStatusType,
 } from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
@@ -188,8 +189,11 @@ const ExecutionStatusConfirmModalComponent: FC<
           ? { removedServerAttachmentIds: Array.from(removedServerAttachmentIds) }
           : {}),
         onSuccess: () => {
-          if (shouldOpenBtsModal && data?.place) {
-            openModal(getBtsModalEntryPlaceFromStatusChangePlace(data.place), executionId);
+          if (shouldOpenBtsModal) {
+            const entryPlace = data?.place
+              ? getBtsModalEntryPlaceFromStatusChangePlace(data.place)
+              : MANUAL_LAUNCHES_PLACE.TEST_EXECUTION_PAGE_HEADER;
+            openModal(entryPlace, executionId);
           } else {
             dispatch(hideModalAction());
           }

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -50,6 +50,7 @@ import { useTextareaAutoResize } from 'common/hooks';
 import { ExecutionStatus } from 'pages/inside/manualLaunchesPage/types';
 import {
   MANUAL_LAUNCHES_PAGE_EVENTS,
+  getBtsModalEntryPlaceFromStatusChangePlace,
   type ExecutionStatusType as AnalyticsExecutionStatusType,
 } from 'components/main/analytics/events/ga4Events/manualLaunchesPageEvents';
 import { useUserPermissions } from 'hooks/useUserPermissions';
@@ -187,8 +188,8 @@ const ExecutionStatusConfirmModalComponent: FC<
           ? { removedServerAttachmentIds: Array.from(removedServerAttachmentIds) }
           : {}),
         onSuccess: () => {
-          if (shouldOpenBtsModal) {
-            openModal(executionId);
+          if (shouldOpenBtsModal && data?.place) {
+            openModal(getBtsModalEntryPlaceFromStatusChangePlace(data.place), executionId);
           } else {
             dispatch(hideModalAction());
           }


### PR DESCRIPTION
## Summary

Adds GA4 tracking for Manual Launches BTS-related interactions on the Test Execution Page (EPMRPP-117231, events #58–#61 from GA4 - Test Case Library).

The implementation follows the Confluence spec: BTS submit events report the modal entry point (`test_execution_page_header`, `test_execution_page_bts_section`, `execution_details_sidebar_failed`), not the modal itself. Events fire only after successful user actions.

## Changes

### Event definitions (`manualLaunchesPageEvents.ts`)

- Update E23 `submitBtsAction(place, type)` to use BTS modal entry `place` and keep `modal: post_link_bts`
- Add `clickIssueTicket(pluginName)` for BTS ticket chip clicks (`place: test_execution_page`, `element_name: issue_ticket`)
- Add `CLICK_SAVE_ATTACHMENTS` and `CLICK_SAVE_EXECUTION_COMMENT` for Execution Comment section actions
- Add `getBtsModalEntryPlaceFromStatusChangePlace` helper to map status-change context to BTS modal entry place

### BTS modal submit (#58)

- Extend `BTSIssuesModalData` and `useBTSIssuesModal` with required `entryPlace`
- Track `submit_bts_action` on successful link/post in `BTSIssuesModal`
- Pass entry place when opening the modal:
  - `LinkedToBTSSection` → `test_execution_page_bts_section`
  - `executionStatusConfirmModal` (Mark as Failed + Post to BTS checkbox) → `test_execution_page_header` or `execution_details_sidebar_failed` depending on status-change `place`

### BTS ticket click (#59)

- Track `issue_ticket` on chip click in `LinkedToBTSSection` via `IssueList.onIssueClick`
- Map `pluginName` to GA4 `type` using `normalizeEventParameter` (e.g. `jira`, `jira_cloud`, `azure_devops`, `rally`, fallback `bts`)

### Execution comment (#60, #61)

- Track `save_attachments` after a file is successfully attached via drop/browse auto-save
- Track `save_execution_comment` after the user clicks Save and the comment update succeeds




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * BTS issue actions now open with the correct contextual placement based on where the user initiated the flow.
  * Added/expanded GA4 tracking for key BTS interactions, including issuing tickets, saving attachments, and saving execution comments.
  * BTS modal submissions now record tracking after the action succeeds, then close the modal.
* **Bug Fixes**
  * Fixed BTS modal opening from execution status confirmations to include the correct contextual placement data (not just the execution identifier).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->