### PR TITLE
EPMRPP-117292 || Fix Mobitru Jump to Log tab switch, highlight, and log resolution

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -1579,6 +1579,7 @@
   "LogItemInfoTabs.historyTab": "Гісторыя дзеянняў",
   "LogItemInfoTabs.logsTab": "Усе логі",
   "LogItemInfoTabs.stackTab": "Трасіроўка стэка",
+  "LogItemInfoTabs.jumpToLogFailed": "Не ўдалося знайсці мэтавы лог",
   "LogMessageSearch.searchHint": "Па меншай меры 3 сімвала патрабуецца.",
   "LogMessageSearch.searchTitle": "Змест лога",
   "LogStatusBlock.statusAllLabel": "Усе",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -1580,6 +1580,7 @@
   "LogItemInfoTabs.historyTab": "История действий",
   "LogItemInfoTabs.logsTab": "Все логи",
   "LogItemInfoTabs.stackTab": "Трассировка стека",
+  "LogItemInfoTabs.jumpToLogFailed": "Не удалось найти целевой лог",
   "LogMessageSearch.searchHint": "Необходимо минимум 3 символа.",
   "LogMessageSearch.searchTitle": "Содержание лога",
   "LogStatusBlock.statusAllLabel": "Все",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -1580,6 +1580,7 @@
   "LogItemInfoTabs.historyTab": "Історія дій",
   "LogItemInfoTabs.logsTab": "Всі логи",
   "LogItemInfoTabs.stackTab": "Трасування стека",
+  "LogItemInfoTabs.jumpToLogFailed": "Не вдалося знайти цільовий лог",
   "LogMessageSearch.searchHint": "Необхідно мінімум 3 символи.",
   "LogMessageSearch.searchTitle": "Зміст лода",
   "LogStatusBlock.statusAllLabel": "Усі",

--- a/app/src/controllers/log/constants.js
+++ b/app/src/controllers/log/constants.js
@@ -65,3 +65,4 @@ export const PREVIOUS = LOADING_DIRECTIONS.PREVIOUS;
 export const NEXT = LOADING_DIRECTIONS.NEXT;
 export const ALL = 'all';
 export const ERROR_LOG_INDEX_KEY = 'errorLogIndex';
+export const MOBITRU_JUMP_LOG_INFO_KEY = 'mobitruJumpLogInfo';

--- a/app/src/controllers/log/index.js
+++ b/app/src/controllers/log/index.js
@@ -58,6 +58,7 @@ export {
   NEXT,
   ALL,
   ERROR_LOG_INDEX_KEY,
+  MOBITRU_JUMP_LOG_INFO_KEY,
   LOAD_MORE_PAGE_SIZE,
 } from './constants';
 export {

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -357,14 +357,11 @@ export class LogItemInfoTabs extends Component {
         return;
       }
 
-      setStorageItem(
-        MOBITRU_JUMP_LOG_INFO_KEY,
-        JSON.stringify({
-          logInfo,
-          logId,
-          shouldClearSearchFilter: Boolean(logQuery[LOG_MESSAGE_FILTER_KEY]),
-        }),
-      );
+      setStorageItem(MOBITRU_JUMP_LOG_INFO_KEY, {
+        logInfo,
+        logId,
+        shouldClearSearchFilter: Boolean(logQuery[LOG_MESSAGE_FILTER_KEY]),
+      });
       setActiveTabId('logs');
     } catch {
       showNotificationAction({

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -29,12 +29,17 @@ import {
   activeLogSelector,
   activeTabIdSelector,
   setActiveTabIdAction,
-  fetchLog,
+  LOG_MESSAGE_FILTER_KEY,
+  MOBITRU_JUMP_LOG_INFO_KEY,
+  NAMESPACE,
 } from 'controllers/log';
+import { querySelector } from 'controllers/log/selectors';
+import { showNotification, NOTIFICATION_TYPES } from 'controllers/notification';
 import { noLogsCollapsingSelector } from 'controllers/user';
 import { projectKeySelector } from 'controllers/project';
 import { fetchFirstAttachmentsAction, attachmentItemsSelector } from 'controllers/log/attachments';
 import { fetch } from 'common/utils/fetch';
+import { setStorageItem } from 'common/utils';
 import { SAUCE_LABS } from 'common/constants/pluginNames';
 import { LOG_PAGE_EVENTS } from 'components/main/analytics/events';
 import StackTraceIcon from 'common/img/stack-trace-inline.svg';
@@ -83,6 +88,10 @@ const messages = defineMessages({
     id: 'LogItemInfoTabs.historyTab',
     defaultMessage: 'History of actions',
   },
+  jumpToLogFailed: {
+    id: 'LogItemInfoTabs.jumpToLogFailed',
+    defaultMessage: 'Target log could not be found',
+  },
 });
 
 const ATTACHMENTS_TAB_ID = 'attachments';
@@ -105,11 +114,12 @@ const LOG_TAB_ELEMENT_EVENTS = {
     noLogsCollapsing: noLogsCollapsingSelector(state),
     logTabExtensions: uiExtensionLogTabSelector(state),
     projectKey: projectKeySelector(state),
+    logQuery: querySelector(state, NAMESPACE),
   }),
   {
     fetchFirstAttachments: fetchFirstAttachmentsAction,
     setActiveTabId: setActiveTabIdAction,
-    fetchLog,
+    showNotification,
   },
 )
 @track()
@@ -127,7 +137,6 @@ export class LogItemInfoTabs extends Component {
     sauceLabsIntegrations: PropTypes.array.isRequired,
     fetchFirstAttachments: PropTypes.func,
     setActiveTabId: PropTypes.func,
-    fetchLog: PropTypes.func,
     attachments: PropTypes.array,
     tracking: PropTypes.shape({
       trackEvent: PropTypes.func,
@@ -137,6 +146,8 @@ export class LogItemInfoTabs extends Component {
     noLogsCollapsing: PropTypes.bool,
     logTabExtensions: PropTypes.array,
     projectKey: PropTypes.string,
+    logQuery: PropTypes.object,
+    showNotification: PropTypes.func,
   };
 
   static defaultProps = {
@@ -145,10 +156,11 @@ export class LogItemInfoTabs extends Component {
     attachments: [],
     activeTabId: 'logs',
     setActiveTabId: () => {},
-    fetchLog: () => {},
     noLogsCollapsing: false,
     logTabExtensions: [],
     projectKey: '',
+    logQuery: {},
+    showNotification: () => {},
   };
 
   state = {
@@ -315,31 +327,50 @@ export class LogItemInfoTabs extends Component {
   };
 
   handleJumpToMobitruLog = async (logId, itemId) => {
-    const { projectKey, retryId, setActiveTabId, fetchLog: fetchLogAction, tracking } = this.props;
+    const {
+      projectKey,
+      retryId,
+      logQuery,
+      setActiveTabId,
+      showNotification: showNotificationAction,
+      intl: { formatMessage },
+      tracking,
+    } = this.props;
 
     tracking.trackEvent(LOG_PAGE_EVENTS.clickJumpToLog('remote_device'));
 
     try {
-      let logInfo = await resolveMobitruLogForJump({
+      const logInfo = await resolveMobitruLogForJump({
         fetchFn: fetch,
         projectKey,
         retryId,
+        itemId,
         logId,
+        logQuery,
       });
 
-      if (!logInfo && itemId === retryId) {
-        logInfo = { id: logId, pagesLocation: [{ [logId]: 1 }] };
-      }
-
       if (!logInfo?.pagesLocation?.length) {
+        showNotificationAction({
+          message: formatMessage(messages.jumpToLogFailed),
+          type: NOTIFICATION_TYPES.ERROR,
+        });
         return;
       }
 
-      fetchLogAction(logInfo, () => {
-        setActiveTabId('logs');
-      }, true);
+      setStorageItem(
+        MOBITRU_JUMP_LOG_INFO_KEY,
+        JSON.stringify({
+          logInfo,
+          logId,
+          shouldClearSearchFilter: Boolean(logQuery[LOG_MESSAGE_FILTER_KEY]),
+        }),
+      );
+      setActiveTabId('logs');
     } catch {
-      // non-blocking: keep user on Remote device tab when navigation fails
+      showNotificationAction({
+        message: formatMessage(messages.jumpToLogFailed),
+        type: NOTIFICATION_TYPES.ERROR,
+      });
     }
   };
 

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -15,6 +15,7 @@
  */
 
 import { URLS } from 'common/urls';
+import { omit } from 'common/utils/omit';
 import { LOG_MESSAGE_FILTER_KEY } from 'controllers/log/constants';
 import { PAGE_KEY } from 'controllers/pagination';
 
@@ -29,11 +30,8 @@ const LOCATION_QUERY_VARIANTS = [
 const findLogInLocationsPage = (content, logId) =>
   content?.find((log) => +log.id === +logId && log.pagesLocation?.length);
 
-const buildLocationQueryParams = (logQuery = {}) => {
-  const { [LOG_MESSAGE_FILTER_KEY]: _messageFilter, [PAGE_KEY]: _page, ...rest } = logQuery;
-
-  return rest;
-};
+const buildLocationQueryParams = (logQuery = {}) =>
+  omit(logQuery, [LOG_MESSAGE_FILTER_KEY, PAGE_KEY]);
 
 const normalizeLocationsResponse = (response) => {
   if (Array.isArray(response)) {

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -15,20 +15,44 @@
  */
 
 import { URLS } from 'common/urls';
+import { LOG_MESSAGE_FILTER_KEY } from 'controllers/log/constants';
+import { PAGE_KEY } from 'controllers/pagination';
 
 const LOCATIONS_PAGE_SIZE = 300;
 
-const LOCATION_QUERY_VARIANTS = [{}, { 'filter.gte.level': 'mobitru' }, { 'filter.eq.level': 'mobitru' }];
+const LOCATION_QUERY_VARIANTS = [
+  { 'filter.eq.level': 'mobitru' },
+  { 'filter.gte.level': 'mobitru' },
+  {},
+];
 
 const findLogInLocationsPage = (content, logId) =>
   content?.find((log) => +log.id === +logId && log.pagesLocation?.length);
 
-const fetchLocationsPage = ({ fetchFn, url, page, extraParams }) =>
+const buildLocationQueryParams = (logQuery = {}) => {
+  const { [LOG_MESSAGE_FILTER_KEY]: _messageFilter, [PAGE_KEY]: _page, ...rest } = logQuery;
+
+  return rest;
+};
+
+const normalizeLocationsResponse = (response) => {
+  if (Array.isArray(response)) {
+    return { content: response, page: { totalPages: 1 } };
+  }
+
+  return {
+    content: response?.content ?? [],
+    page: response?.page ?? { totalPages: 1 },
+  };
+};
+
+const fetchLocationsPage = ({ fetchFn, url, page, logQueryParams, extraParams }) =>
   fetchFn(url, {
     params: {
       excludeLogContent: true,
-      'page.size': LOCATIONS_PAGE_SIZE,
+      'page.size': logQueryParams['page.size'] || LOCATIONS_PAGE_SIZE,
       'page.page': page,
+      ...logQueryParams,
       ...extraParams,
     },
   });
@@ -37,6 +61,7 @@ const searchLocationsPage = async ({
   fetchFn,
   url,
   logId,
+  logQueryParams,
   extraParams,
   page = 1,
   totalPages = 1,
@@ -45,8 +70,9 @@ const searchLocationsPage = async ({
     return null;
   }
 
-  const response = await fetchLocationsPage({ fetchFn, url, page, extraParams });
-  const logInfo = findLogInLocationsPage(response?.content, logId);
+  const response = await fetchLocationsPage({ fetchFn, url, page, logQueryParams, extraParams });
+  const { content, page: pageInfo } = normalizeLocationsResponse(response);
+  const logInfo = findLogInLocationsPage(content, logId);
 
   if (logInfo) {
     return logInfo;
@@ -56,13 +82,20 @@ const searchLocationsPage = async ({
     fetchFn,
     url,
     logId,
+    logQueryParams,
     extraParams,
     page: page + 1,
-    totalPages: response?.page?.totalPages || 1,
+    totalPages: pageInfo?.totalPages || 1,
   });
 };
 
-const searchWithQueryVariants = async ({ fetchFn, url, logId, variantIndex = 0 }) => {
+const searchWithQueryVariants = async ({
+  fetchFn,
+  url,
+  logId,
+  logQueryParams,
+  variantIndex = 0,
+}) => {
   if (variantIndex >= LOCATION_QUERY_VARIANTS.length) {
     return null;
   }
@@ -71,6 +104,7 @@ const searchWithQueryVariants = async ({ fetchFn, url, logId, variantIndex = 0 }
     fetchFn,
     url,
     logId,
+    logQueryParams,
     extraParams: LOCATION_QUERY_VARIANTS[variantIndex],
   });
 
@@ -78,11 +112,137 @@ const searchWithQueryVariants = async ({ fetchFn, url, logId, variantIndex = 0 }
     return logInfo;
   }
 
-  return searchWithQueryVariants({ fetchFn, url, logId, variantIndex: variantIndex + 1 });
+  return searchWithQueryVariants({
+    fetchFn,
+    url,
+    logId,
+    logQueryParams,
+    variantIndex: variantIndex + 1,
+  });
 };
 
-export const resolveMobitruLogForJump = async ({ fetchFn, projectKey, retryId, logId }) => {
-  const url = URLS.errorLogs(projectKey, retryId);
+const findItemPageInNestedLogs = async ({
+  fetchFn,
+  projectKey,
+  parentItemId,
+  targetId,
+  logQueryParams,
+  page = 1,
+  totalPages = 1,
+}) => {
+  if (page > totalPages) {
+    return null;
+  }
 
-  return searchWithQueryVariants({ fetchFn, url, logId });
+  const pageSize = logQueryParams['page.size'] || LOCATIONS_PAGE_SIZE;
+  const response = await fetchFn(URLS.logItems(projectKey, parentItemId), {
+    params: {
+      ...logQueryParams,
+      'page.size': pageSize,
+      'page.page': page,
+    },
+  });
+
+  const content = response?.content ?? [];
+  const isFound = content.some((item) => +item.id === +targetId);
+
+  if (isFound) {
+    return page;
+  }
+
+  return findItemPageInNestedLogs({
+    fetchFn,
+    projectKey,
+    parentItemId,
+    targetId,
+    logQueryParams,
+    page: page + 1,
+    totalPages: response?.page?.totalPages || 1,
+  });
+};
+
+const resolveMobitruLogFromNestedGrid = async ({
+  fetchFn,
+  projectKey,
+  retryId,
+  itemId,
+  logId,
+  logQueryParams,
+}) => {
+  if (+itemId === +retryId) {
+    const logPage = await findItemPageInNestedLogs({
+      fetchFn,
+      projectKey,
+      parentItemId: retryId,
+      targetId: logId,
+      logQueryParams,
+    });
+
+    if (!logPage) {
+      return null;
+    }
+
+    return { id: logId, pagesLocation: [{ [logId]: logPage }] };
+  }
+
+  const stepPage = await findItemPageInNestedLogs({
+    fetchFn,
+    projectKey,
+    parentItemId: retryId,
+    targetId: itemId,
+    logQueryParams,
+  });
+
+  if (!stepPage) {
+    return null;
+  }
+
+  const logPage = await findItemPageInNestedLogs({
+    fetchFn,
+    projectKey,
+    parentItemId: itemId,
+    targetId: logId,
+    logQueryParams,
+  });
+
+  if (!logPage) {
+    return null;
+  }
+
+  return {
+    id: logId,
+    pagesLocation: [{ [itemId]: stepPage }, { [logId]: logPage }],
+  };
+};
+
+export const resolveMobitruLogForJump = async ({
+  fetchFn,
+  projectKey,
+  retryId,
+  itemId,
+  logId,
+  logQuery,
+}) => {
+  const url = URLS.errorLogs(projectKey, retryId);
+  const logQueryParams = buildLocationQueryParams(logQuery);
+
+  const logInfoFromLocations = await searchWithQueryVariants({
+    fetchFn,
+    url,
+    logId,
+    logQueryParams,
+  });
+
+  if (logInfoFromLocations) {
+    return logInfoFromLocations;
+  }
+
+  return resolveMobitruLogFromNestedGrid({
+    fetchFn,
+    projectKey,
+    retryId,
+    itemId,
+    logId,
+    logQueryParams,
+  });
 };

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -191,4 +191,37 @@ describe('resolveMobitruLogForJump', () => {
     expect(fetchFn.mock.calls[0][1].params).not.toHaveProperty('filter.cnt.message');
     expect(fetchFn.mock.calls[0][1].params['page.page']).toBe(1);
   });
+
+  test('should propagate locations API errors to caller', async () => {
+    const fetchFn = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      resolveMobitruLogForJump({
+        fetchFn,
+        projectKey: 'default_personal',
+        retryId: 100,
+        itemId: 100,
+        logId: 10,
+      }),
+    ).rejects.toThrow('Network error');
+  });
+
+  test('should propagate nested grid API errors to caller', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockRejectedValue(new Error('Nested grid unavailable'));
+
+    await expect(
+      resolveMobitruLogForJump({
+        fetchFn,
+        projectKey: 'default_personal',
+        retryId: 100,
+        itemId: 100,
+        logId: 163839,
+      }),
+    ).rejects.toThrow('Nested grid unavailable');
+  });
 });

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -28,14 +28,36 @@ describe('resolveMobitruLogForJump', () => {
       fetchFn,
       projectKey: 'default_personal',
       retryId: 100,
+      itemId: 100,
       logId: 10,
     });
 
     expect(result).toEqual(logInfo);
     expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ 'filter.eq.level': 'mobitru' }),
+      }),
+    );
   });
 
-  test('should paginate until log is found', async () => {
+  test('should parse plain array locations response', async () => {
+    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
+    const fetchFn = jest.fn().mockResolvedValueOnce([logInfo]);
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 100,
+      logId: 10,
+    });
+
+    expect(result).toEqual(logInfo);
+  });
+
+  test('should paginate until log is found in locations', async () => {
     const logInfo = { id: 20, pagesLocation: [{ 20: 2 }] };
     const fetchFn = jest
       .fn()
@@ -52,11 +74,69 @@ describe('resolveMobitruLogForJump', () => {
       fetchFn,
       projectKey: 'default_personal',
       retryId: 100,
+      itemId: 100,
       logId: 20,
     });
 
     expect(result).toEqual(logInfo);
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  test('should fall back to nested grid when locations do not include mobitru log', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 1 }],
+        page: { totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 163839, level: 'mobitru' }],
+        page: { totalPages: 2 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 100,
+      logId: 163839,
+      logQuery: { 'page.size': 50, 'page.sort': 'logTime,ASC' },
+    });
+
+    expect(result).toEqual({ id: 163839, pagesLocation: [{ 163839: 2 }] });
+    expect(fetchFn).toHaveBeenCalledTimes(5);
+  });
+
+  test('should resolve nested step mobitru log via nested grid fallback', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 200, type: 'STEP' }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 200,
+      logId: 300,
+    });
+
+    expect(result).toEqual({
+      id: 300,
+      pagesLocation: [{ 200: 1 }, { 300: 1 }],
+    });
   });
 
   test('should return null when log is not found', async () => {
@@ -69,9 +149,46 @@ describe('resolveMobitruLogForJump', () => {
       fetchFn,
       projectKey: 'default_personal',
       retryId: 100,
+      itemId: 100,
       logId: 99,
     });
 
     expect(result).toBeNull();
+  });
+
+  test('should pass log query params and exclude message filter and page', async () => {
+    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
+    const fetchFn = jest.fn().mockResolvedValue({
+      content: [logInfo],
+      page: { totalPages: 1 },
+    });
+
+    await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 100,
+      logId: 10,
+      logQuery: {
+        'page.size': 50,
+        'page.sort': 'logTime,ASC',
+        'page.page': 3,
+        'filter.cnt.message': 'error text',
+        'filter.gte.level': 'error',
+      },
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          'page.size': 50,
+          'page.sort': 'logTime,ASC',
+          'filter.eq.level': 'mobitru',
+        }),
+      }),
+    );
+    expect(fetchFn.mock.calls[0][1].params).not.toHaveProperty('filter.cnt.message');
+    expect(fetchFn.mock.calls[0][1].params['page.page']).toBe(1);
   });
 });

--- a/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
+++ b/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
@@ -230,18 +230,19 @@ export class LogsGridWrapper extends Component {
       } else {
         const mobitruJumpLogInfo = getStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
         if (mobitruJumpLogInfo) {
-          removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
           try {
             const { logInfo, logId, shouldClearSearchFilter } = JSON.parse(mobitruJumpLogInfo);
-            const fetchMobitruLogCb = () =>
+            const fetchMobitruLogCb = () => {
+              removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
               this.setState({
                 highlightedRowId: +logId,
                 isGridRowHighlighted: true,
               });
+            };
 
             this.props.fetchLog(logInfo, fetchMobitruLogCb, shouldClearSearchFilter);
           } catch {
-            // ignore invalid pending jump payload
+            removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
           }
         }
       }

--- a/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
+++ b/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
@@ -40,6 +40,7 @@ import {
   fetchLog,
   RETRY_ID,
   ERROR_LOG_INDEX_KEY,
+  MOBITRU_JUMP_LOG_INFO_KEY,
   loadMoreLogsAction,
   fetchLogItemsForPageAction,
   loadedPagesRangeSelector,
@@ -226,6 +227,23 @@ export class LogsGridWrapper extends Component {
             isGridRowHighlighted: true,
           });
         this.props.fetchLog(errorLogs[errorLogIndex], fetchLogCb);
+      } else {
+        const mobitruJumpLogInfo = getStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
+        if (mobitruJumpLogInfo) {
+          removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
+          try {
+            const { logInfo, logId, shouldClearSearchFilter } = JSON.parse(mobitruJumpLogInfo);
+            const fetchMobitruLogCb = () =>
+              this.setState({
+                highlightedRowId: +logId,
+                isGridRowHighlighted: true,
+              });
+
+            this.props.fetchLog(logInfo, fetchMobitruLogCb, shouldClearSearchFilter);
+          } catch {
+            // ignore invalid pending jump payload
+          }
+        }
       }
     }
 

--- a/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
+++ b/app/src/pages/inside/logsPage/logsGridWrapper/logsGridWrapper.jsx
@@ -228,12 +228,12 @@ export class LogsGridWrapper extends Component {
           });
         this.props.fetchLog(errorLogs[errorLogIndex], fetchLogCb);
       } else {
-        const mobitruJumpLogInfo = getStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
-        if (mobitruJumpLogInfo) {
-          try {
-            const { logInfo, logId, shouldClearSearchFilter } = JSON.parse(mobitruJumpLogInfo);
+        try {
+          const mobitruJumpLogInfo = getStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
+          if (mobitruJumpLogInfo) {
+            const { logInfo, logId, shouldClearSearchFilter } = mobitruJumpLogInfo;
+            removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
             const fetchMobitruLogCb = () => {
-              removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
               this.setState({
                 highlightedRowId: +logId,
                 isGridRowHighlighted: true,
@@ -241,9 +241,9 @@ export class LogsGridWrapper extends Component {
             };
 
             this.props.fetchLog(logInfo, fetchMobitruLogCb, shouldClearSearchFilter);
-          } catch {
-            removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
           }
+        } catch {
+          removeStorageItem(MOBITRU_JUMP_LOG_INFO_KEY);
         }
       }
     }


### PR DESCRIPTION
## Summary

Completes **Jump to Log** from the Mobitru **Remote device** tab (EPMRPP-117292, US-LOG-MOB-005). Builds on the host wiring from EPMRPP-117291: when the user clicks **Jump to Log** on a video entry, the app switches to **All logs**, navigates to the target Mobitru log row (including nested-step expansion and pagination via the existing `fetchLog` saga), and highlights that row using the same pattern as stack trace / log search **Jump to**.

## Changes

- Resolve target Mobitru log `pagesLocation` via log locations API with mobitru level-filter variants, plain-array response support, and nested-grid fallback when locations API does not return mobitru logs
- Pass current log query (excluding message filter and page) into location resolution so pagination/sorting match the active All logs view
- Wire **Jump to Log** handler on the Mobitru extension tab: GA4 event `clickJumpToLog('remote_device')`, error notification when the target log cannot be found
- Use stack-trace-style navigation: store pending jump payload in session storage, switch to **All logs** immediately, then run `fetchLog` from `LogsGridWrapper` on mount with highlight callback (avoids saga hang when clearing an inactive search filter)
- Clear active log message search filter only when one is present (aligned with US-LOG-TIL-007 / existing Jump to behaviour)
- Add `LogItemInfoTabs.jumpToLogFailed` translations (ru, be, uk)

## Visuals


https://github.com/user-attachments/assets/4d895cc0-6783-403b-93c3-97e67473ca3c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved “jump to log” navigation to find the target log across error locations and nested log grids.
  * Persist and reuse jump context (including search/page context) when opening the destination log.
* **Bug Fixes**
  * Now shows a clearer notification when the requested log can’t be found, instead of failing silently.
  * Restores the jumped log in the grid view using saved jump details.
* **Localization**
  * Added Belarusian, Russian, and Ukrainian translations for the jump-to-log failure message.
* **Tests**
  * Expanded coverage for resolving jumps, pagination, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->