### PR TITLE
EPMRPP-117808 || Fix Mobitru Jump to Log for nested-step videos

### DIFF
--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -350,7 +350,7 @@ export const resolveMobitruLogForJump = async ({
   logId,
   logQuery,
 }) => {
-  const url = URLS.searchLogs(projectKey, retryId).replace(/\?.*$/, '');
+  const url = URLS.searchLogs(projectKey, retryId).split('?')[0];
   const logQueryParams = buildLocationQueryParams(logQuery);
 
   const logInfoFromLocations = await searchWithQueryVariants({

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -16,10 +16,11 @@
 
 import { URLS } from 'common/urls';
 import { omit } from 'common/utils/omit';
-import { LOG_MESSAGE_FILTER_KEY } from 'controllers/log/constants';
+import { LOG_LEVEL_FILTER_KEY, LOG_MESSAGE_FILTER_KEY } from 'controllers/log/constants';
 import { PAGE_KEY } from 'controllers/pagination';
 
 const LOCATIONS_PAGE_SIZE = 300;
+const LEVEL_FILTER_KEYS = [LOG_LEVEL_FILTER_KEY, 'filter.eq.level'];
 
 const LOCATION_QUERY_VARIANTS = [
   { 'filter.eq.level': 'mobitru' },
@@ -31,6 +32,9 @@ const findLogInLocationsPage = (content, logId) =>
 
 const buildLocationQueryParams = (logQuery = {}) =>
   omit(logQuery, [LOG_MESSAGE_FILTER_KEY, PAGE_KEY]);
+
+const buildNestedGridQueryParams = (logQueryParams = {}) =>
+  omit(logQueryParams, LEVEL_FILTER_KEYS);
 
 const normalizePageResponse = (response) => {
   if (Array.isArray(response)) {
@@ -119,10 +123,11 @@ const searchWithQueryVariants = async ({
 };
 
 const fetchNestedLogsPage = async ({ fetchFn, projectKey, parentItemId, logQueryParams, page }) => {
-  const pageSize = logQueryParams['page.size'] || LOCATIONS_PAGE_SIZE;
+  const nestedQueryParams = buildNestedGridQueryParams(logQueryParams);
+  const pageSize = nestedQueryParams['page.size'] || LOCATIONS_PAGE_SIZE;
   const response = await fetchFn(URLS.logItems(projectKey, parentItemId), {
     params: {
-      ...logQueryParams,
+      ...nestedQueryParams,
       'page.size': pageSize,
       'page.page': page,
     },
@@ -225,11 +230,14 @@ const findLogPathRecursively = async ({
   totalPages = 1,
   visitedItemIds = new Set(),
 }) => {
-  if (page > totalPages || visitedItemIds.has(+parentItemId)) {
+  if (page > totalPages) {
     return null;
   }
 
   if (page === 1) {
+    if (visitedItemIds.has(+parentItemId)) {
+      return null;
+    }
     visitedItemIds.add(+parentItemId);
   }
 
@@ -342,7 +350,7 @@ export const resolveMobitruLogForJump = async ({
   logId,
   logQuery,
 }) => {
-  const url = URLS.searchLogs(projectKey, retryId);
+  const url = URLS.searchLogs(projectKey, retryId).replace(/\?.*$/, '');
   const logQueryParams = buildLocationQueryParams(logQuery);
 
   const logInfoFromLocations = await searchWithQueryVariants({

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -24,7 +24,6 @@ const LOCATIONS_PAGE_SIZE = 300;
 const LOCATION_QUERY_VARIANTS = [
   { 'filter.eq.level': 'mobitru' },
   { 'filter.gte.level': 'mobitru' },
-  {},
 ];
 
 const findLogInLocationsPage = (content, logId) =>
@@ -33,7 +32,7 @@ const findLogInLocationsPage = (content, logId) =>
 const buildLocationQueryParams = (logQuery = {}) =>
   omit(logQuery, [LOG_MESSAGE_FILTER_KEY, PAGE_KEY]);
 
-const normalizeLocationsResponse = (response) => {
+const normalizePageResponse = (response) => {
   if (Array.isArray(response)) {
     return { content: response, page: { totalPages: 1 } };
   }
@@ -69,7 +68,7 @@ const searchLocationsPage = async ({
   }
 
   const response = await fetchLocationsPage({ fetchFn, url, page, logQueryParams, extraParams });
-  const { content, page: pageInfo } = normalizeLocationsResponse(response);
+  const { content, page: pageInfo } = normalizePageResponse(response);
   const logInfo = findLogInLocationsPage(content, logId);
 
   if (logInfo) {
@@ -119,6 +118,19 @@ const searchWithQueryVariants = async ({
   });
 };
 
+const fetchNestedLogsPage = async ({ fetchFn, projectKey, parentItemId, logQueryParams, page }) => {
+  const pageSize = logQueryParams['page.size'] || LOCATIONS_PAGE_SIZE;
+  const response = await fetchFn(URLS.logItems(projectKey, parentItemId), {
+    params: {
+      ...logQueryParams,
+      'page.size': pageSize,
+      'page.page': page,
+    },
+  });
+
+  return normalizePageResponse(response);
+};
+
 const findItemPageInNestedLogs = async ({
   fetchFn,
   projectKey,
@@ -132,16 +144,13 @@ const findItemPageInNestedLogs = async ({
     return null;
   }
 
-  const pageSize = logQueryParams['page.size'] || LOCATIONS_PAGE_SIZE;
-  const response = await fetchFn(URLS.logItems(projectKey, parentItemId), {
-    params: {
-      ...logQueryParams,
-      'page.size': pageSize,
-      'page.page': page,
-    },
+  const { content, page: pageInfo } = await fetchNestedLogsPage({
+    fetchFn,
+    projectKey,
+    parentItemId,
+    logQueryParams,
+    page,
   });
-
-  const content = response?.content ?? [];
   const isFound = content.some((item) => +item.id === +targetId);
 
   if (isFound) {
@@ -155,7 +164,115 @@ const findItemPageInNestedLogs = async ({
     targetId,
     logQueryParams,
     page: page + 1,
-    totalPages: response?.page?.totalPages || 1,
+    totalPages: pageInfo?.totalPages || 1,
+  });
+};
+
+const isNestedStepItem = (item) => Boolean(item?.hasContent);
+
+const searchNestedStepsSequentially = ({
+  fetchFn,
+  projectKey,
+  nestedSteps,
+  logId,
+  logQueryParams,
+  pathPrefix,
+  page,
+  visitedItemIds,
+  stepIndex = 0,
+}) => {
+  if (stepIndex >= nestedSteps.length) {
+    return Promise.resolve(null);
+  }
+
+  const step = nestedSteps[stepIndex];
+
+  return findLogPathRecursively({
+    fetchFn,
+    projectKey,
+    parentItemId: step.id,
+    logId,
+    logQueryParams,
+    pathPrefix: [...pathPrefix, { [step.id]: page }],
+    visitedItemIds,
+  }).then((nestedResult) => {
+    if (nestedResult) {
+      return nestedResult;
+    }
+
+    return searchNestedStepsSequentially({
+      fetchFn,
+      projectKey,
+      nestedSteps,
+      logId,
+      logQueryParams,
+      pathPrefix,
+      page,
+      visitedItemIds,
+      stepIndex: stepIndex + 1,
+    });
+  });
+};
+
+const findLogPathRecursively = async ({
+  fetchFn,
+  projectKey,
+  parentItemId,
+  logId,
+  logQueryParams,
+  pathPrefix = [],
+  page = 1,
+  totalPages = 1,
+  visitedItemIds = new Set(),
+}) => {
+  if (page > totalPages || visitedItemIds.has(+parentItemId)) {
+    return null;
+  }
+
+  if (page === 1) {
+    visitedItemIds.add(+parentItemId);
+  }
+
+  const { content, page: pageInfo } = await fetchNestedLogsPage({
+    fetchFn,
+    projectKey,
+    parentItemId,
+    logQueryParams,
+    page,
+  });
+
+  if (content.some((item) => +item.id === +logId)) {
+    return {
+      id: logId,
+      pagesLocation: [...pathPrefix, { [logId]: page }],
+    };
+  }
+
+  const nestedResult = await searchNestedStepsSequentially({
+    fetchFn,
+    projectKey,
+    nestedSteps: content.filter(isNestedStepItem),
+    logId,
+    logQueryParams,
+    pathPrefix,
+    page,
+    visitedItemIds,
+  });
+
+  if (nestedResult) {
+    return nestedResult;
+  }
+
+  return findLogPathRecursively({
+    fetchFn,
+    projectKey,
+    parentItemId,
+    logId,
+    logQueryParams,
+    pathPrefix,
+    page: page + 1,
+    totalPages: pageInfo?.totalPages || 1,
+    visitedItemIds,
   });
 };
 
@@ -167,7 +284,7 @@ const resolveMobitruLogFromNestedGrid = async ({
   logId,
   logQueryParams,
 }) => {
-  if (+itemId === +retryId) {
+  if (itemId != null && +itemId === +retryId) {
     const logPage = await findItemPageInNestedLogs({
       fetchFn,
       projectKey,
@@ -176,41 +293,45 @@ const resolveMobitruLogFromNestedGrid = async ({
       logQueryParams,
     });
 
-    if (!logPage) {
-      return null;
+    if (logPage) {
+      return { id: logId, pagesLocation: [{ [logId]: logPage }] };
     }
-
-    return { id: logId, pagesLocation: [{ [logId]: logPage }] };
   }
 
-  const stepPage = await findItemPageInNestedLogs({
+  if (itemId != null && +itemId !== +retryId) {
+    const stepPage = await findItemPageInNestedLogs({
+      fetchFn,
+      projectKey,
+      parentItemId: retryId,
+      targetId: itemId,
+      logQueryParams,
+    });
+
+    if (stepPage) {
+      const logPage = await findItemPageInNestedLogs({
+        fetchFn,
+        projectKey,
+        parentItemId: itemId,
+        targetId: logId,
+        logQueryParams,
+      });
+
+      if (logPage) {
+        return {
+          id: logId,
+          pagesLocation: [{ [itemId]: stepPage }, { [logId]: logPage }],
+        };
+      }
+    }
+  }
+
+  return findLogPathRecursively({
     fetchFn,
     projectKey,
     parentItemId: retryId,
-    targetId: itemId,
+    logId,
     logQueryParams,
   });
-
-  if (!stepPage) {
-    return null;
-  }
-
-  const logPage = await findItemPageInNestedLogs({
-    fetchFn,
-    projectKey,
-    parentItemId: itemId,
-    targetId: logId,
-    logQueryParams,
-  });
-
-  if (!logPage) {
-    return null;
-  }
-
-  return {
-    id: logId,
-    pagesLocation: [{ [itemId]: stepPage }, { [logId]: logPage }],
-  };
 };
 
 export const resolveMobitruLogForJump = async ({
@@ -221,7 +342,7 @@ export const resolveMobitruLogForJump = async ({
   logId,
   logQuery,
 }) => {
-  const url = URLS.errorLogs(projectKey, retryId);
+  const url = URLS.searchLogs(projectKey, retryId);
   const logQueryParams = buildLocationQueryParams(logQuery);
 
   const logInfoFromLocations = await searchWithQueryVariants({

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -35,9 +35,12 @@ describe('resolveMobitruLogForJump', () => {
     expect(result).toEqual(logInfo);
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn).toHaveBeenCalledWith(
-      expect.stringContaining('/log/locations/search/'),
+      expect.stringMatching(/\/log\/locations\/search\/\d+$/),
       expect.objectContaining({
-        params: expect.objectContaining({ 'filter.eq.level': 'mobitru' }),
+        params: expect.objectContaining({
+          'filter.eq.level': 'mobitru',
+          excludeLogContent: true,
+        }),
       }),
     );
   });
@@ -201,6 +204,75 @@ describe('resolveMobitruLogForJump', () => {
     });
   });
 
+  test('should resolve nested log on page two via recursive nested grid fallback', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 1 }],
+        page: { totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: undefined,
+      logId: 300,
+    });
+
+    expect(result).toEqual({
+      id: 300,
+      pagesLocation: [{ 200: 2 }, { 300: 1 }],
+    });
+  });
+
+  test('should omit caller level filters in nested grid fallback', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 200,
+      logId: 300,
+      logQuery: { 'filter.gte.level': 'error', 'page.size': 50 },
+    });
+
+    expect(result).toEqual({
+      id: 300,
+      pagesLocation: [{ 200: 1 }, { 300: 1 }],
+    });
+
+    const nestedCalls = fetchFn.mock.calls.filter(([url]) => String(url).includes('/log/nested/'));
+    expect(nestedCalls.length).toBeGreaterThan(0);
+    nestedCalls.forEach(([, options]) => {
+      expect(options.params).not.toHaveProperty('filter.gte.level');
+      expect(options.params).not.toHaveProperty('filter.eq.level');
+      expect(String(nestedCalls[0][0])).not.toContain('filter.gte.level');
+    });
+  });
+
   test('should return null when log is not found', async () => {
     const fetchFn = jest.fn().mockResolvedValue({
       content: [],
@@ -241,12 +313,13 @@ describe('resolveMobitruLogForJump', () => {
     });
 
     expect(fetchFn).toHaveBeenCalledWith(
-      expect.stringContaining('/log/locations/search/'),
+      expect.stringMatching(/\/log\/locations\/search\/\d+$/),
       expect.objectContaining({
         params: expect.objectContaining({
           'page.size': 50,
           'page.sort': 'logTime,ASC',
           'filter.eq.level': 'mobitru',
+          excludeLogContent: true,
         }),
       }),
     );

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -35,7 +35,7 @@ describe('resolveMobitruLogForJump', () => {
     expect(result).toEqual(logInfo);
     expect(fetchFn).toHaveBeenCalledTimes(1);
     expect(fetchFn).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.stringContaining('/log/locations/search/'),
       expect.objectContaining({
         params: expect.objectContaining({ 'filter.eq.level': 'mobitru' }),
       }),
@@ -87,7 +87,6 @@ describe('resolveMobitruLogForJump', () => {
       .fn()
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         content: [{ id: 1 }],
         page: { totalPages: 2 },
@@ -107,7 +106,7 @@ describe('resolveMobitruLogForJump', () => {
     });
 
     expect(result).toEqual({ id: 163839, pagesLocation: [{ 163839: 2 }] });
-    expect(fetchFn).toHaveBeenCalledTimes(5);
+    expect(fetchFn).toHaveBeenCalledTimes(4);
   });
 
   test('should resolve nested step mobitru log via nested grid fallback', async () => {
@@ -115,9 +114,8 @@ describe('resolveMobitruLogForJump', () => {
       .fn()
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
-        content: [{ id: 200, type: 'STEP' }],
+        content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
       })
       .mockResolvedValueOnce({
@@ -130,6 +128,70 @@ describe('resolveMobitruLogForJump', () => {
       projectKey: 'default_personal',
       retryId: 100,
       itemId: 200,
+      logId: 300,
+    });
+
+    expect(result).toEqual({
+      id: 300,
+      pagesLocation: [{ 200: 1 }, { 300: 1 }],
+    });
+  });
+
+  test('should resolve deeply nested mobitru log via recursive nested grid fallback', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 400, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 300,
+      logId: 400,
+    });
+
+    expect(result).toEqual({
+      id: 400,
+      pagesLocation: [{ 200: 1 }, { 300: 1 }, { 400: 1 }],
+    });
+  });
+
+  test('should resolve nested log by recursion when itemId is missing', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: undefined,
       logId: 300,
     });
 
@@ -179,7 +241,7 @@ describe('resolveMobitruLogForJump', () => {
     });
 
     expect(fetchFn).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.stringContaining('/log/locations/search/'),
       expect.objectContaining({
         params: expect.objectContaining({
           'page.size': 50,
@@ -209,7 +271,6 @@ describe('resolveMobitruLogForJump', () => {
   test('should propagate nested grid API errors to caller', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockRejectedValue(new Error('Nested grid unavailable'));


### PR DESCRIPTION
## Summary

Fixes **Jump to Log** from the Mobitru **Remote device** tab when the target video log lives on a nested step (EPMRPP-117808). Previously the UI showed **Target log could not be found** even though the log existed in **All logs** and the backend returned no errors.

## Changes

- Resolve Mobitru log location via `GET /log/locations/search/{itemId}` (`URLS.searchLogs`) instead of `/log/locations/{itemId}` (`URLS.errorLogs`). The error-locations endpoint only returns error-level logs (40000–60000); Mobitru level is 90000 and was never included
- Keep mobitru-only level filter variants (`filter.eq.level` / `filter.gte.level`); drop the empty filter variant that was ineffective on the error-locations API
- Strengthen nested-grid fallback: keep the one-level `itemId` path, then recursively walk nested steps (`hasContent`) to build a full `pagesLocation` when the log is deeper than one level or `itemId` is missing
- Extend unit coverage for search URL usage, deep nesting, and missing `itemId`

## Visuals


https://github.com/user-attachments/assets/a7380156-ffa3-437c-b496-5b5f02622f30



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation from log entries to their corresponding locations.
  * Added support for finding logs across deeply nested grid structures.
  * Improved handling of paginated search results and missing item identifiers.
  * Preserved error reporting when nested log searches fail.
* **Tests**
  * Expanded coverage for nested log navigation, recursive searches, and updated search requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->