### PR TITLE
EPMRPP-117808 || Fix Mobitru Jump to Log pagination page size mismatch

### DIFF
--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -17,10 +17,11 @@
 import { URLS } from 'common/urls';
 import { omit } from 'common/utils/omit';
 import { LOG_LEVEL_FILTER_KEY, LOG_MESSAGE_FILTER_KEY } from 'controllers/log/constants';
-import { PAGE_KEY } from 'controllers/pagination';
+import { PAGINATION_OFFSET } from 'controllers/log/nestedSteps/constants';
+import { DEFAULT_PAGE_SIZE, PAGE_KEY, SIZE_KEY } from 'controllers/pagination';
 
-const LOCATIONS_PAGE_SIZE = 300;
 const LEVEL_FILTER_KEYS = [LOG_LEVEL_FILTER_KEY, 'filter.eq.level'];
+const NESTED_QUERY_OMIT_KEYS = [...LEVEL_FILTER_KEYS, PAGE_KEY, SIZE_KEY];
 
 const LOCATION_QUERY_VARIANTS = [
   { 'filter.eq.level': 'mobitru' },
@@ -33,8 +34,11 @@ const findLogInLocationsPage = (content, logId) =>
 const buildLocationQueryParams = (logQuery = {}) =>
   omit(logQuery, [LOG_MESSAGE_FILTER_KEY, PAGE_KEY]);
 
+const getRootPageSize = (logQueryParams = {}) =>
+  Number(logQueryParams[SIZE_KEY]) || DEFAULT_PAGE_SIZE;
+
 const buildNestedGridQueryParams = (logQueryParams = {}) =>
-  omit(logQueryParams, LEVEL_FILTER_KEYS);
+  omit(logQueryParams, NESTED_QUERY_OMIT_KEYS);
 
 const normalizePageResponse = (response) => {
   if (Array.isArray(response)) {
@@ -51,8 +55,8 @@ const fetchLocationsPage = ({ fetchFn, url, page, logQueryParams, extraParams })
   fetchFn(url, {
     params: {
       excludeLogContent: true,
-      'page.size': logQueryParams['page.size'] || LOCATIONS_PAGE_SIZE,
-      'page.page': page,
+      [SIZE_KEY]: getRootPageSize(logQueryParams),
+      [PAGE_KEY]: page,
       ...logQueryParams,
       ...extraParams,
     },
@@ -122,14 +126,20 @@ const searchWithQueryVariants = async ({
   });
 };
 
-const fetchNestedLogsPage = async ({ fetchFn, projectKey, parentItemId, logQueryParams, page }) => {
+const fetchNestedLogsPage = async ({
+  fetchFn,
+  projectKey,
+  parentItemId,
+  logQueryParams,
+  page,
+  pageSize,
+}) => {
   const nestedQueryParams = buildNestedGridQueryParams(logQueryParams);
-  const pageSize = nestedQueryParams['page.size'] || LOCATIONS_PAGE_SIZE;
   const response = await fetchFn(URLS.logItems(projectKey, parentItemId), {
     params: {
       ...nestedQueryParams,
-      'page.size': pageSize,
-      'page.page': page,
+      [SIZE_KEY]: pageSize,
+      [PAGE_KEY]: page,
     },
   });
 
@@ -142,6 +152,7 @@ const findItemPageInNestedLogs = async ({
   parentItemId,
   targetId,
   logQueryParams,
+  pageSize,
   page = 1,
   totalPages = 1,
 }) => {
@@ -155,6 +166,7 @@ const findItemPageInNestedLogs = async ({
     parentItemId,
     logQueryParams,
     page,
+    pageSize,
   });
   const isFound = content.some((item) => +item.id === +targetId);
 
@@ -168,6 +180,7 @@ const findItemPageInNestedLogs = async ({
     parentItemId,
     targetId,
     logQueryParams,
+    pageSize,
     page: page + 1,
     totalPages: pageInfo?.totalPages || 1,
   });
@@ -199,6 +212,7 @@ const searchNestedStepsSequentially = ({
     logId,
     logQueryParams,
     pathPrefix: [...pathPrefix, { [step.id]: page }],
+    pageSize: PAGINATION_OFFSET,
     visitedItemIds,
   }).then((nestedResult) => {
     if (nestedResult) {
@@ -226,6 +240,7 @@ const findLogPathRecursively = async ({
   logId,
   logQueryParams,
   pathPrefix = [],
+  pageSize,
   page = 1,
   totalPages = 1,
   visitedItemIds = new Set(),
@@ -247,6 +262,7 @@ const findLogPathRecursively = async ({
     parentItemId,
     logQueryParams,
     page,
+    pageSize,
   });
 
   if (content.some((item) => +item.id === +logId)) {
@@ -278,6 +294,7 @@ const findLogPathRecursively = async ({
     logId,
     logQueryParams,
     pathPrefix,
+    pageSize,
     page: page + 1,
     totalPages: pageInfo?.totalPages || 1,
     visitedItemIds,
@@ -292,6 +309,8 @@ const resolveMobitruLogFromNestedGrid = async ({
   logId,
   logQueryParams,
 }) => {
+  const rootPageSize = getRootPageSize(logQueryParams);
+
   if (itemId != null && +itemId === +retryId) {
     const logPage = await findItemPageInNestedLogs({
       fetchFn,
@@ -299,6 +318,7 @@ const resolveMobitruLogFromNestedGrid = async ({
       parentItemId: retryId,
       targetId: logId,
       logQueryParams,
+      pageSize: rootPageSize,
     });
 
     if (logPage) {
@@ -313,6 +333,7 @@ const resolveMobitruLogFromNestedGrid = async ({
       parentItemId: retryId,
       targetId: itemId,
       logQueryParams,
+      pageSize: rootPageSize,
     });
 
     if (stepPage) {
@@ -322,6 +343,7 @@ const resolveMobitruLogFromNestedGrid = async ({
         parentItemId: itemId,
         targetId: logId,
         logQueryParams,
+        pageSize: PAGINATION_OFFSET,
       });
 
       if (logPage) {
@@ -339,6 +361,7 @@ const resolveMobitruLogFromNestedGrid = async ({
     parentItemId: retryId,
     logId,
     logQueryParams,
+    pageSize: rootPageSize,
   });
 };
 
@@ -353,18 +376,7 @@ export const resolveMobitruLogForJump = async ({
   const url = URLS.searchLogs(projectKey, retryId).split('?')[0];
   const logQueryParams = buildLocationQueryParams(logQuery);
 
-  const logInfoFromLocations = await searchWithQueryVariants({
-    fetchFn,
-    url,
-    logId,
-    logQueryParams,
-  });
-
-  if (logInfoFromLocations) {
-    return logInfoFromLocations;
-  }
-
-  return resolveMobitruLogFromNestedGrid({
+  const nestedResult = await resolveMobitruLogFromNestedGrid({
     fetchFn,
     projectKey,
     retryId,
@@ -372,4 +384,17 @@ export const resolveMobitruLogForJump = async ({
     logId,
     logQueryParams,
   });
+
+  if (nestedResult) {
+    return nestedResult;
+  }
+
+  const logInfoFromLocations = await searchWithQueryVariants({
+    fetchFn,
+    url,
+    logId,
+    logQueryParams,
+  });
+
+  return logInfoFromLocations;
 };

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -14,88 +14,19 @@
  * limitations under the License.
  */
 
+import { PAGINATION_OFFSET } from 'controllers/log/nestedSteps/constants';
 import { resolveMobitruLogForJump } from './resolveMobitruLogForJump';
 
 describe('resolveMobitruLogForJump', () => {
-  test('should return log info when pagesLocation exists on first page', async () => {
-    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
-    const fetchFn = jest.fn().mockResolvedValue({
-      content: [logInfo],
-      page: { totalPages: 1 },
-    });
-
-    const result = await resolveMobitruLogForJump({
-      fetchFn,
-      projectKey: 'default_personal',
-      retryId: 100,
-      itemId: 100,
-      logId: 10,
-    });
-
-    expect(result).toEqual(logInfo);
-    expect(fetchFn).toHaveBeenCalledTimes(1);
-    expect(fetchFn).toHaveBeenCalledWith(
-      expect.stringMatching(/\/log\/locations\/search\/\d+$/),
-      expect.objectContaining({
-        params: expect.objectContaining({
-          'filter.eq.level': 'mobitru',
-          excludeLogContent: true,
-        }),
-      }),
-    );
-  });
-
-  test('should parse plain array locations response', async () => {
-    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
-    const fetchFn = jest.fn().mockResolvedValueOnce([logInfo]);
-
-    const result = await resolveMobitruLogForJump({
-      fetchFn,
-      projectKey: 'default_personal',
-      retryId: 100,
-      itemId: 100,
-      logId: 10,
-    });
-
-    expect(result).toEqual(logInfo);
-  });
-
-  test('should paginate until log is found in locations', async () => {
-    const logInfo = { id: 20, pagesLocation: [{ 20: 2 }] };
+  test('should resolve log via nested grid using active root page size', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce({
-        content: [{ id: 1, pagesLocation: [{ 1: 1 }] }],
-        page: { totalPages: 2 },
-      })
-      .mockResolvedValueOnce({
-        content: [logInfo],
-        page: { totalPages: 2 },
-      });
-
-    const result = await resolveMobitruLogForJump({
-      fetchFn,
-      projectKey: 'default_personal',
-      retryId: 100,
-      itemId: 100,
-      logId: 20,
-    });
-
-    expect(result).toEqual(logInfo);
-    expect(fetchFn).toHaveBeenCalledTimes(2);
-  });
-
-  test('should fall back to nested grid when locations do not include mobitru log', async () => {
-    const fetchFn = jest
-      .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         content: [{ id: 1 }],
         page: { totalPages: 2 },
       })
       .mockResolvedValueOnce({
-        content: [{ id: 163839, level: 'mobitru' }],
+        content: [{ id: 10, level: 'mobitru' }],
         page: { totalPages: 2 },
       });
 
@@ -104,19 +35,61 @@ describe('resolveMobitruLogForJump', () => {
       projectKey: 'default_personal',
       retryId: 100,
       itemId: 100,
-      logId: 163839,
-      logQuery: { 'page.size': 50, 'page.sort': 'logTime,ASC' },
+      logId: 10,
+      logQuery: { 'page.size': 10, 'page.sort': 'logTime,ASC' },
     });
 
-    expect(result).toEqual({ id: 163839, pagesLocation: [{ 163839: 2 }] });
-    expect(fetchFn).toHaveBeenCalledTimes(4);
+    expect(result).toEqual({ id: 10, pagesLocation: [{ 10: 2 }] });
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringContaining('/log/nested/'),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          'page.size': 10,
+          'page.page': 1,
+        }),
+      }),
+    );
+    expect(fetchFn.mock.calls[1][1].params['page.size']).toBe(10);
+    expect(fetchFn.mock.calls[1][1].params['page.page']).toBe(2);
   });
 
-  test('should resolve nested step mobitru log via nested grid fallback', async () => {
+  test('should use nested step page size matching loadStep pagination offset', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 1 }],
+        page: { totalPages: 2 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, level: 'mobitru' }],
+        page: { totalPages: 2 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 200,
+      logId: 300,
+      logQuery: { 'page.size': 10 },
+    });
+
+    expect(result).toEqual({
+      id: 300,
+      pagesLocation: [{ 200: 1 }, { 300: 2 }],
+    });
+    expect(fetchFn.mock.calls[0][1].params['page.size']).toBe(10);
+    expect(fetchFn.mock.calls[1][1].params['page.size']).toBe(PAGINATION_OFFSET);
+    expect(fetchFn.mock.calls[2][1].params['page.size']).toBe(PAGINATION_OFFSET);
+  });
+
+  test('should resolve nested step mobitru log via nested grid', async () => {
+    const fetchFn = jest
+      .fn()
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -140,11 +113,9 @@ describe('resolveMobitruLogForJump', () => {
     });
   });
 
-  test('should resolve deeply nested mobitru log via recursive nested grid fallback', async () => {
+  test('should resolve deeply nested mobitru log via recursive nested grid', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -174,13 +145,14 @@ describe('resolveMobitruLogForJump', () => {
       id: 400,
       pagesLocation: [{ 200: 1 }, { 300: 1 }, { 400: 1 }],
     });
+    expect(fetchFn.mock.calls[0][1].params['page.size']).toBe(50);
+    expect(fetchFn.mock.calls[2][1].params['page.size']).toBe(PAGINATION_OFFSET);
+    expect(fetchFn.mock.calls[3][1].params['page.size']).toBe(PAGINATION_OFFSET);
   });
 
   test('should resolve nested log by recursion when itemId is missing', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -204,11 +176,9 @@ describe('resolveMobitruLogForJump', () => {
     });
   });
 
-  test('should resolve nested log on page two via recursive nested grid fallback', async () => {
+  test('should resolve nested log on page two via recursive nested grid', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         content: [{ id: 1 }],
         page: { totalPages: 2 },
@@ -236,11 +206,9 @@ describe('resolveMobitruLogForJump', () => {
     });
   });
 
-  test('should omit caller level filters in nested grid fallback', async () => {
+  test('should omit caller level filters in nested grid resolution', async () => {
     const fetchFn = jest
       .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -269,8 +237,44 @@ describe('resolveMobitruLogForJump', () => {
     nestedCalls.forEach(([, options]) => {
       expect(options.params).not.toHaveProperty('filter.gte.level');
       expect(options.params).not.toHaveProperty('filter.eq.level');
-      expect(String(nestedCalls[0][0])).not.toContain('filter.gte.level');
     });
+  });
+
+  test('should fall back to locations search when nested grid cannot resolve log', async () => {
+    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce({
+        content: [],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [logInfo],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 100,
+      logId: 10,
+    });
+
+    expect(result).toEqual(logInfo);
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringMatching(/\/log\/locations\/search\/\d+$/),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          'filter.eq.level': 'mobitru',
+          excludeLogContent: true,
+        }),
+      }),
+    );
   });
 
   test('should return null when log is not found', async () => {
@@ -290,63 +294,8 @@ describe('resolveMobitruLogForJump', () => {
     expect(result).toBeNull();
   });
 
-  test('should pass log query params and exclude message filter and page', async () => {
-    const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
-    const fetchFn = jest.fn().mockResolvedValue({
-      content: [logInfo],
-      page: { totalPages: 1 },
-    });
-
-    await resolveMobitruLogForJump({
-      fetchFn,
-      projectKey: 'default_personal',
-      retryId: 100,
-      itemId: 100,
-      logId: 10,
-      logQuery: {
-        'page.size': 50,
-        'page.sort': 'logTime,ASC',
-        'page.page': 3,
-        'filter.cnt.message': 'error text',
-        'filter.gte.level': 'error',
-      },
-    });
-
-    expect(fetchFn).toHaveBeenCalledWith(
-      expect.stringMatching(/\/log\/locations\/search\/\d+$/),
-      expect.objectContaining({
-        params: expect.objectContaining({
-          'page.size': 50,
-          'page.sort': 'logTime,ASC',
-          'filter.eq.level': 'mobitru',
-          excludeLogContent: true,
-        }),
-      }),
-    );
-    expect(fetchFn.mock.calls[0][1].params).not.toHaveProperty('filter.cnt.message');
-    expect(fetchFn.mock.calls[0][1].params['page.page']).toBe(1);
-  });
-
-  test('should propagate locations API errors to caller', async () => {
-    const fetchFn = jest.fn().mockRejectedValue(new Error('Network error'));
-
-    await expect(
-      resolveMobitruLogForJump({
-        fetchFn,
-        projectKey: 'default_personal',
-        retryId: 100,
-        itemId: 100,
-        logId: 10,
-      }),
-    ).rejects.toThrow('Network error');
-  });
-
   test('should propagate nested grid API errors to caller', async () => {
-    const fetchFn = jest
-      .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockRejectedValue(new Error('Nested grid unavailable'));
+    const fetchFn = jest.fn().mockRejectedValue(new Error('Nested grid unavailable'));
 
     await expect(
       resolveMobitruLogForJump({
@@ -357,5 +306,25 @@ describe('resolveMobitruLogForJump', () => {
         logId: 163839,
       }),
     ).rejects.toThrow('Nested grid unavailable');
+  });
+
+  test('should propagate locations API errors when nested grid misses the log', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce({
+        content: [],
+        page: { totalPages: 1 },
+      })
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(
+      resolveMobitruLogForJump({
+        fetchFn,
+        projectKey: 'default_personal',
+        retryId: 100,
+        itemId: 100,
+        logId: 10,
+      }),
+    ).rejects.toThrow('Network error');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for **EPMRPP-117808**: Jump to Log from the Mobitru **Remote device** tab worked with default pagination, but navigated to the wrong place after the All logs page size was changed. `pagesLocation` did not match how the log grid and nested-step loader paginate.

## Changes

- Build `pagesLocation` primarily via the nested log grid so page numbers match the active All logs view
- Use the active root `page.size` for the test-item nested grid; use `PAGINATION_OFFSET` (300) for nested steps — the same size `fetchLog` / `loadStep` use when expanding steps
- Keep `/log/locations/search` only as a last-resort fallback when nested-grid resolution fails (its page numbers under a mobitru level filter do not match the unfiltered All logs grid)
- Update unit tests for root vs nested page sizes and the search fallback path

## Visuals


https://github.com/user-attachments/assets/bf32995e-b814-49db-ae0f-b13670c217f6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation to logs within nested grids, including deeply nested steps and logs located on later pages.
  * Enhanced pagination handling for root and nested log results.
  * Preserved fallback search behavior when nested-grid resolution cannot locate a log.
  * Improved handling of missing or unavailable logs and ensured relevant API errors are surfaced correctly.
  * Prevented caller-level filters from affecting nested-grid log navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->