### PR TITLE
EPMRPP-117272 || Replace composite/info with API and UI info endpoints

### DIFF
--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -22,11 +22,11 @@ export const API_PATH = '/api';
 
 export const DEFAULT_API_URL_PREFIX = '../api/v1';
 export const DEFAULT_COMMON_API_URL_PREFIX = '../api';
-export const COMPOSITE_API_URL_PREFIX = '../composite/';
+export const UI_INFO_URL_PREFIX = '../ui/';
 
 const urlBase = `${DEFAULT_API_URL_PREFIX}/`;
 const urlCommonBase = `${DEFAULT_COMMON_API_URL_PREFIX}/`;
-const compositeBase = COMPOSITE_API_URL_PREFIX;
+const uiInfoBase = UI_INFO_URL_PREFIX;
 const getQueryParams = (paramsObj, options = {}) =>
   stringify(paramsObj, { addQueryPrefix: true, ...options });
 const removeTrailingSlash = (url) => (url.endsWith('/') ? url.slice(0, -1) : url);
@@ -340,7 +340,8 @@ export const URLS = {
       ...createFilterQuery(filterEntities),
     })}`,
 
-  appInfo: () => `${compositeBase}info`,
+  appInfoApi: () => `${urlCommonBase}info`,
+  appInfoUi: () => `${uiInfoBase}info`,
 
   plugin: () => `${urlBase}plugin`,
   pluginById: (pluginId) => `${urlBase}plugin/${pluginId}`,

--- a/app/src/common/utils/fetch.interceptor.test.js
+++ b/app/src/common/utils/fetch.interceptor.test.js
@@ -113,78 +113,15 @@ describe('initAuthInterceptor', () => {
     expect(store.dispatch).not.toHaveBeenCalled();
   });
 
-  test('marks API unavailable on api info gateway error', async () => {
-    axiosMock.onGet('/api/info').reply(503);
-
-    await expect(axios.get('/api/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on api info internal server error', async () => {
-    axiosMock.onGet('/api/info').reply(500);
-
-    await expect(axios.get('/api/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on api info request timeout', async () => {
-    axiosMock.onGet('/api/info').reply(408);
-
-    await expect(axios.get('/api/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on api info rate limiting', async () => {
-    axiosMock.onGet('/api/info').reply(429);
-
-    await expect(axios.get('/api/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on api info bad gateway error', async () => {
-    axiosMock.onGet('/api/info').reply(502);
-
-    await expect(axios.get('/api/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on api info gateway timeout', async () => {
-    axiosMock.onGet('/api/info').reply(504);
+  test.each([
+    { status: 503, label: 'gateway error' },
+    { status: 500, label: 'internal server error' },
+    { status: 408, label: 'request timeout' },
+    { status: 429, label: 'rate limiting' },
+    { status: 502, label: 'bad gateway error' },
+    { status: 504, label: 'gateway timeout' },
+  ])('marks API unavailable on api info $label', async ({ status }) => {
+    axiosMock.onGet('/api/info').reply(status);
 
     await expect(axios.get('/api/info')).rejects.toBeTruthy();
 

--- a/app/src/common/utils/fetch.interceptor.test.js
+++ b/app/src/common/utils/fetch.interceptor.test.js
@@ -43,13 +43,12 @@ describe('initAuthInterceptor', () => {
     clearResponseInterceptors();
   });
 
-  test('marks API available on successful composite info response with valid API service', async () => {
-    axiosMock.onGet('/composite/info').reply(200, { 
-      api: { build: { name: 'API Service' } },
-      uat: true 
+  test('marks API available on successful api info response with valid API service', async () => {
+    axiosMock.onGet('/api/info').reply(200, {
+      build: { name: 'API Service' },
     });
 
-    await axios.get('/composite/info');
+    await axios.get('/api/info');
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -60,27 +59,10 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable when api.build.name is missing', async () => {
-    axiosMock.onGet('/composite/info').reply(200, { api: { build: {} }, uat: true });
+  test('marks API unavailable when build.name is missing', async () => {
+    axiosMock.onGet('/api/info').reply(200, { build: {} });
 
-    await axios.get('/composite/info');
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable when api.build.name is not "API Service"', async () => {
-    axiosMock.onGet('/composite/info').reply(200, { 
-      api: { build: { name: 'Unknown Service' } },
-      uat: true 
-    });
-
-    await axios.get('/composite/info');
+    await axios.get('/api/info');
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -91,10 +73,12 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable when api is missing', async () => {
-    axiosMock.onGet('/composite/info').reply(200, { uat: true });
+  test('marks API unavailable when build.name is not "API Service"', async () => {
+    axiosMock.onGet('/api/info').reply(200, {
+      build: { name: 'Unknown Service' },
+    });
 
-    await axios.get('/composite/info');
+    await axios.get('/api/info');
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -105,27 +89,10 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable when api.build is missing', async () => {
-    axiosMock.onGet('/composite/info').reply(200, { api: {}, uat: true });
+  test('marks API unavailable when build is missing', async () => {
+    axiosMock.onGet('/api/info').reply(200, {});
 
-    await axios.get('/composite/info');
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test.each([
-    { api: false, label: 'boolean value' },
-    { api: 'string', label: 'string value' },
-  ])('marks API unavailable when api is a non-object ($label)', async ({ api }) => {
-    axiosMock.onGet('/composite/info').reply(200, { api, uat: true });
-
-    await axios.get('/composite/info');
+    await axios.get('/api/info');
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -136,10 +103,20 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable when composite info response is empty', async () => {
-    axiosMock.onGet('/composite/info').reply(200, {});
+  test('does not mark availability for ui info responses', async () => {
+    axiosMock.onGet('/ui/info').reply(200, {
+      build: { name: 'Service UI' },
+    });
 
-    await axios.get('/composite/info');
+    await axios.get('/ui/info');
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  test('marks API unavailable on api info gateway error', async () => {
+    axiosMock.onGet('/api/info').reply(503);
+
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -150,24 +127,10 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable on composite info gateway error', async () => {
-    axiosMock.onGet('/composite/info').reply(503);
+  test('marks API unavailable on api info internal server error', async () => {
+    axiosMock.onGet('/api/info').reply(500);
 
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on composite info internal server error', async () => {
-    axiosMock.onGet('/composite/info').reply(500);
-
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -178,24 +141,10 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable on composite info request timeout', async () => {
-    axiosMock.onGet('/composite/info').reply(408);
+  test('marks API unavailable on api info request timeout', async () => {
+    axiosMock.onGet('/api/info').reply(408);
 
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on composite info rate limiting', async () => {
-    axiosMock.onGet('/composite/info').reply(429);
-
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -206,24 +155,10 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable on composite info bad gateway error', async () => {
-    axiosMock.onGet('/composite/info').reply(502);
+  test('marks API unavailable on api info rate limiting', async () => {
+    axiosMock.onGet('/api/info').reply(429);
 
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
-
-    expect(store.dispatch).toHaveBeenCalledWith({
-      type: 'setServiceAvailability',
-      payload: {
-        checked: true,
-        apiUnavailable: true,
-      },
-    });
-  });
-
-  test('marks API unavailable on composite info gateway timeout', async () => {
-    axiosMock.onGet('/composite/info').reply(504);
-
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -234,10 +169,10 @@ describe('initAuthInterceptor', () => {
     });
   });
 
-  test('marks API unavailable on composite info network error', async () => {
-    axiosMock.onGet('/composite/info').networkError();
+  test('marks API unavailable on api info bad gateway error', async () => {
+    axiosMock.onGet('/api/info').reply(502);
 
-    await expect(axios.get('/composite/info')).rejects.toBeTruthy();
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
 
     expect(store.dispatch).toHaveBeenCalledWith({
       type: 'setServiceAvailability',
@@ -248,4 +183,31 @@ describe('initAuthInterceptor', () => {
     });
   });
 
+  test('marks API unavailable on api info gateway timeout', async () => {
+    axiosMock.onGet('/api/info').reply(504);
+
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: 'setServiceAvailability',
+      payload: {
+        checked: true,
+        apiUnavailable: true,
+      },
+    });
+  });
+
+  test('marks API unavailable on api info network error', async () => {
+    axiosMock.onGet('/api/info').networkError();
+
+    await expect(axios.get('/api/info')).rejects.toBeTruthy();
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: 'setServiceAvailability',
+      payload: {
+        checked: true,
+        apiUnavailable: true,
+      },
+    });
+  });
 });

--- a/app/src/common/utils/fetch.ts
+++ b/app/src/common/utils/fetch.ts
@@ -96,7 +96,7 @@ export const updateToken = (newToken: string): void => {
   axios.defaults.headers.common.Authorization = newToken;
 };
 
-const isCompositeInfoRequest = (url = ''): boolean => /\/composite\/info/.test(url);
+const isAppInfoApiRequest = (url = ''): boolean => /\/api\/info(?:\?|$)/.test(url);
 const isServiceUnavailableError = (error: AxiosError): boolean => {
   const status = error.response?.status;
   return (
@@ -114,8 +114,7 @@ const isApiServiceAvailable = (data: unknown): boolean => {
     return false;
   }
   const responseData = data as Record<string, unknown>;
-  const api = responseData.api as Record<string, unknown> | undefined;
-  const build = api?.build as Record<string, unknown> | undefined;
+  const build = responseData.build as Record<string, unknown> | undefined;
   return build?.name === 'API Service';
 };
 
@@ -124,7 +123,7 @@ export const initAuthInterceptor = (store: Store): void => {
     (response: AxiosResponse) => {
       const responseUrl = response.config?.url || '';
 
-      if (isCompositeInfoRequest(responseUrl)) {
+      if (isAppInfoApiRequest(responseUrl)) {
         store.dispatch(setServiceAvailabilityAction({ 
           checked: true, 
           apiUnavailable: !isApiServiceAvailable(response.data) 
@@ -143,7 +142,7 @@ export const initAuthInterceptor = (store: Store): void => {
         }
       }
 
-      if (isCompositeInfoRequest(requestUrl) && isServiceUnavailableError(error)) {
+      if (isAppInfoApiRequest(requestUrl) && isServiceUnavailableError(error)) {
         store.dispatch(setServiceAvailabilityAction({ checked: true, apiUnavailable: true }));
       }
 

--- a/app/src/common/utils/referenceDictionary.js
+++ b/app/src/common/utils/referenceDictionary.js
@@ -109,7 +109,6 @@ export const faqDictionary = {
 
 export const servicesUpdate = {
   api: 'https://github.com/reportportal/service-api/releases',
-  index: 'https://github.com/reportportal/service-index/releases',
   jobs: 'https://github.com/reportportal/service-jobs/releases',
   ui: 'https://github.com/reportportal/service-ui/releases',
   analyzer: 'https://github.com/reportportal/service-auto-analyzer/releases',

--- a/app/src/controllers/appInfo/actionCreators.js
+++ b/app/src/controllers/appInfo/actionCreators.js
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-import { fetchDataAction } from 'controllers/fetch';
-import { URLS } from 'common/urls';
 import {
-  APP_INFO_NAMESPACE,
+  FETCH_APP_INFO,
   UPDATE_SERVER_SETTINGS,
   UPDATE_API_EXTENSIONS_RESULT,
 } from './constants';
 
-export const fetchAppInfoAction = () =>
-  fetchDataAction(APP_INFO_NAMESPACE, true)(URLS.appInfo(), {
-    headers: { Authorization: undefined },
-  });
+export const fetchAppInfoAction = () => ({
+  type: FETCH_APP_INFO,
+});
 
 export const updateServerSettingsAction = (settings) => ({
   type: UPDATE_SERVER_SETTINGS,

--- a/app/src/controllers/appInfo/constants.js
+++ b/app/src/controllers/appInfo/constants.js
@@ -15,6 +15,7 @@
  */
 
 export const APP_INFO_NAMESPACE = 'appInfo';
+export const FETCH_APP_INFO = 'fetchAppInfo';
 
 export const ANALYTICS_INSTANCE_KEY = 'server.details.instance';
 export const ANALYTICS_ALL_KEY = 'server.analytics.all';

--- a/app/src/controllers/appInfo/index.js
+++ b/app/src/controllers/appInfo/index.js
@@ -42,7 +42,7 @@ export {
   tmsEnabledSelector,
   passwordMinLengthSelector,
 } from './selectors';
-export { serverSettingsSagas } from './sagas';
+export { serverSettingsSagas, appInfoSagas } from './sagas';
 export {
   ANALYTICS_ALL_KEY,
   SERVER_SESSION_EXPIRATION_KEY,

--- a/app/src/controllers/appInfo/sagas.js
+++ b/app/src/controllers/appInfo/sagas.js
@@ -17,9 +17,30 @@
 import { fetch } from 'common/utils';
 import { URLS } from 'common/urls';
 import { call, takeEvery, all, put } from 'redux-saga/effects';
+import { fetchStartAction, fetchSuccessAction, fetchErrorAction } from 'controllers/fetch';
 import { updateServerSettingsSuccessAction } from 'controllers/appInfo/actionCreators';
 import { NOTIFICATION_TYPES, showNotification } from 'controllers/notification';
-import { UPDATE_SERVER_SETTINGS } from './constants';
+import { APP_INFO_NAMESPACE, FETCH_APP_INFO, UPDATE_SERVER_SETTINGS } from './constants';
+import { composeAppInfo } from './utils';
+
+const APP_INFO_FETCH_OPTIONS = {
+  headers: { Authorization: undefined },
+};
+
+const silentFetch = (...args) => fetch(...args).catch(() => null);
+
+function* fetchAppInfo() {
+  try {
+    yield put(fetchStartAction(APP_INFO_NAMESPACE, {}));
+    const [apiInfo, uiInfo] = yield all([
+      call(fetch, URLS.appInfoApi(), APP_INFO_FETCH_OPTIONS),
+      call(silentFetch, URLS.appInfoUi(), APP_INFO_FETCH_OPTIONS),
+    ]);
+    yield put(fetchSuccessAction(APP_INFO_NAMESPACE, composeAppInfo(apiInfo, uiInfo || {})));
+  } catch (error) {
+    yield put(fetchErrorAction(APP_INFO_NAMESPACE, error, true));
+  }
+}
 
 function* updateServerSettings({ payload }) {
   const { data, onSuccess = () => {}, onError = () => {} } = payload;
@@ -41,10 +62,18 @@ function* updateServerSettings({ payload }) {
   }
 }
 
+function* watchFetchAppInfo() {
+  yield takeEvery(FETCH_APP_INFO, fetchAppInfo);
+}
+
 function* watchUpdateServerSettings() {
   yield takeEvery(UPDATE_SERVER_SETTINGS, updateServerSettings);
 }
 
+export function* appInfoSagas() {
+  yield all([watchFetchAppInfo(), watchUpdateServerSettings()]);
+}
+
 export function* serverSettingsSagas() {
-  yield all([watchUpdateServerSettings()]);
+  yield* appInfoSagas();
 }

--- a/app/src/controllers/appInfo/utils.js
+++ b/app/src/controllers/appInfo/utils.js
@@ -30,3 +30,9 @@ export const getTmsOverride = () => {
     return null;
   }
 };
+
+export const composeAppInfo = (apiInfo, uiInfo = {}) => ({
+  api: apiInfo,
+  ui: uiInfo,
+  jobs: apiInfo?.jobsInfo || {},
+});

--- a/app/src/controllers/appInfo/utils.test.js
+++ b/app/src/controllers/appInfo/utils.test.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { composeAppInfo } from './utils';
+
+describe('composeAppInfo', () => {
+  test('composes api, ui and jobs from jobsInfo', () => {
+    const apiInfo = {
+      build: { name: 'API Service' },
+      jobsInfo: { build: { name: 'Jobs Service', version: '1.0' } },
+    };
+    const uiInfo = { build: { name: 'Service UI', version: '2.0' } };
+
+    expect(composeAppInfo(apiInfo, uiInfo)).toEqual({
+      api: apiInfo,
+      ui: uiInfo,
+      jobs: { build: { name: 'Jobs Service', version: '1.0' } },
+    });
+  });
+
+  test('falls back to empty jobs and ui when missing', () => {
+    const apiInfo = { build: { name: 'API Service' } };
+
+    expect(composeAppInfo(apiInfo)).toEqual({
+      api: apiInfo,
+      ui: {},
+      jobs: {},
+    });
+  });
+});

--- a/app/src/controllers/fetch/index.js
+++ b/app/src/controllers/fetch/index.js
@@ -25,6 +25,7 @@ export { fetchReducer } from './reducer';
 export { fetchSagas, handleError } from './sagas';
 export {
   fetchDataAction,
+  fetchStartAction,
   fetchErrorAction,
   fetchSuccessAction,
   bulkFetchDataAction,

--- a/app/src/layouts/common/appSidebar/helpAndService/modals/versionsOfConnectedServicesModal/constants.js
+++ b/app/src/layouts/common/appSidebar/helpAndService/modals/versionsOfConnectedServicesModal/constants.js
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export const PRODUCT_VERSION = '26.0.2';
-export const PRODUCT_VERSION_LINK = 'https://reportportal.io/docs/releases/Version26.0.2/';
+export const PRODUCT_VERSION = '26.1';
+export const PRODUCT_VERSION_LINK = 'https://reportportal.io/docs/releases/Version26.1/';

--- a/app/src/layouts/common/appSidebar/helpAndService/modals/versionsOfConnectedServicesModal/versionsOfConnectedServicesModal.jsx
+++ b/app/src/layouts/common/appSidebar/helpAndService/modals/versionsOfConnectedServicesModal/versionsOfConnectedServicesModal.jsx
@@ -61,7 +61,6 @@ const VersionsOfConnectedServices = ({ data: { latestServiceVersions, analyticsC
 
     const versionsServicesNames = {
       api: 'API Service',
-      index: 'Index Service',
       jobs: 'Jobs Service',
       ui: 'Service UI',
     };

--- a/app/webpack/dev.config.js
+++ b/app/webpack/dev.config.js
@@ -93,7 +93,7 @@ module.exports = () => {
       port: 3000,
       proxy: [
         {
-          context: ['/composite', '/api/'],
+          context: ['/api/', '/ui/info', '/info'],
           target: process.env.PROXY_PATH,
           changeOrigin: true,
           bypass(req) {


### PR DESCRIPTION
## Summary

As the Index service is being removed, the UI no longer calls `GET ../composite/info`. App bootstrap and related consumers now load health/build/settings data from `GET ../api/info` and `GET ../ui/info`, composing the same Redux `appInfo` shape so existing selectors (SSO, server settings, session timeout, feature flags, analytics, demo banner) keep working.

## Changes

- Fetch API and UI `/info` in parallel and compose `{ api, ui, jobs }` where top-level `jobs` comes from `api.jobsInfo`
- Point service-availability checks at `/api/info` (`build.name === 'API Service'`) instead of composite info
- Remove Index Service from the Versions of connected services modal and from `servicesUpdate` links
- Proxy `/ui/info` (and `/info`) in webpack dev config for local development
- Export `fetchStartAction` from `controllers/fetch` for the new appInfo saga
- Update interceptor unit tests and add `composeAppInfo` coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application information now combines API and UI service details.
  * Service availability checks now use the API information endpoint for more accurate status reporting.

* **Bug Fixes**
  * Improved handling of unavailable services, network errors, and API response errors.
  * Updated development routing for API, UI, and information requests.

* **Documentation**
  * Updated the displayed product version to 26.1 and linked documentation.

* **Changes**
  * Removed the Index service from connected-services version details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->