### PR TITLE
Add iOS-like interactivity to the login page news stack

### DIFF
--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
@@ -97,6 +97,33 @@ const prefersReducedMotion = () =>
   !!window.matchMedia &&
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+const clearInlineTransitions = (nodes) => {
+  nodes.forEach((node) => {
+    node.style.transition = '';
+  });
+};
+
+const runStaggerIn = (nodes) => {
+  if (prefersReducedMotion()) {
+    return;
+  }
+  nodes.forEach((node) => {
+    node.style.transition = 'none';
+    node.style.opacity = '0';
+    node.style.transform = 'translateY(16px) scale(0.98)';
+  });
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      nodes.forEach((node, index) => {
+        node.style.transition = `opacity 300ms ease ${index * 55}ms, transform 430ms cubic-bezier(0.34, 1.3, 0.64, 1) ${index * 55}ms`;
+        node.style.opacity = '';
+        node.style.transform = '';
+      });
+      setTimeout(() => clearInlineTransitions(nodes), 430 + nodes.length * 55);
+    });
+  });
+};
+
 const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
@@ -132,6 +159,11 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
   const promoteTimerRef = useRef(null);
   const lastDragEndRef = useRef(0);
   const pendingCollapseRectsRef = useRef(null);
+  const onExpandedChangeRef = useRef(onExpandedChange);
+
+  useEffect(() => {
+    onExpandedChangeRef.current = onExpandedChange;
+  }, [onExpandedChange]);
 
   const commitOrder = useCallback((next) => {
     orderRef.current = next;
@@ -154,6 +186,9 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
       clearTimeout(promoteTimerRef.current);
       dismissTimersRef.current.forEach((timer) => clearTimeout(timer));
       dismissTimersRef.current.clear();
+      if (expandedRef.current) {
+        onExpandedChangeRef.current?.(false);
+      }
     },
     [],
   );
@@ -211,12 +246,22 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
 
   useEffect(() => {
     const remeasure = () => measureStack();
+    let cancelled = false;
     window.addEventListener('resize', remeasure);
-    if (document.fonts?.ready) {
-      document.fonts.ready.then(remeasure).catch(() => {});
+    if (document.fonts) {
+      document.fonts.ready
+        .then(() => {
+          if (!cancelled) {
+            remeasure();
+          }
+        })
+        .catch(() => {});
     }
 
-    return () => window.removeEventListener('resize', remeasure);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('resize', remeasure);
+    };
   }, [measureStack]);
 
   const cycle = useCallback(
@@ -405,8 +450,11 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
       if (expandedRef.current) {
         return; // native scroll in list mode
       }
+      if (orderRef.current.length < 2) {
+        return;
+      }
       event.preventDefault();
-      if (animatingRef.current || dragRef.current || orderRef.current.length < 2) {
+      if (animatingRef.current || dragRef.current) {
         return;
       }
       wheelAccRef.current += event.deltaY;
@@ -460,7 +508,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
       return;
     }
     const front = getFrontNode();
-    if (!front || !front.contains(event.target) || event.target.closest('a')) {
+    if (!front?.contains(event.target) || event.target.closest('a')) {
       return;
     }
     dragRef.current = {
@@ -517,20 +565,13 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
     }
   };
 
-  const handlePointerUp = () => {
+  const resetPointerGesture = () => {
     const drag = dragRef.current;
-    if (!drag) {
-      return;
-    }
     const front = getFrontNode();
-    const wasPeeking = peekingRef.current;
-    const { axis, dx, dy } = drag;
     cancelPeek();
-    // reset the drag state BEFORE acting: dismiss() is guarded by the
-    // drag ref, and stale deltas must not leak into later interactions
     dragRef.current = null;
     setIsDragging(false);
-    if (axis) {
+    if (drag?.axis) {
       lastDragEndRef.current = performance.now();
     }
     if (front) {
@@ -538,8 +579,26 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
       front.style.transform = '';
       front.style.opacity = '';
     }
+
+    return { drag, front };
+  };
+
+  const handlePointerCancel = () => {
+    if (!dragRef.current) {
+      return;
+    }
+    resetPointerGesture();
+  };
+
+  const handlePointerUp = () => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    const wasPeeking = peekingRef.current;
+    const { axis, dx, dy } = drag;
+    const { front } = resetPointerGesture();
     if (wasPeeking) {
-      // released a long-press without dragging: open the post
       const link = front?.querySelector('a');
       if (link) {
         window.open(link.href, '_blank', 'noopener');
@@ -555,13 +614,20 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
     }
   };
 
-  const handleCardClick = (cardIndex) => (event) => {
+  const handleDeckClick = (event) => {
     if (expandedRef.current || event.target.closest('a')) {
       return;
     }
     if (performance.now() - lastDragEndRef.current < CLICK_SUPPRESS_AFTER_DRAG_MS) {
-      return; // that was a drag, not a click
+      return;
     }
+    const cardEntry = Object.entries(cardRefs.current).find(([, node]) =>
+      node?.contains(event.target),
+    );
+    if (!cardEntry) {
+      return;
+    }
+    const cardIndex = Number(cardEntry[0]);
     if (orderRef.current[0] !== cardIndex) {
       promote(cardIndex);
     }
@@ -604,33 +670,6 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
       deckRef.current.style.transform = '';
     }
   };
-
-  const runStaggerIn = useCallback((nodes) => {
-    if (prefersReducedMotion()) {
-      return;
-    }
-    nodes.forEach((node) => {
-      node.style.transition = 'none';
-      node.style.opacity = '0';
-      node.style.transform = 'translateY(16px) scale(0.98)';
-    });
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        nodes.forEach((node, index) => {
-          node.style.transition = `opacity 300ms ease ${index * 55}ms, transform 430ms cubic-bezier(0.34, 1.3, 0.64, 1) ${index * 55}ms`;
-          node.style.opacity = '';
-          node.style.transform = '';
-        });
-        setTimeout(
-          () =>
-            nodes.forEach((node) => {
-              node.style.transition = '';
-            }),
-          430 + nodes.length * 55,
-        );
-      });
-    });
-  }, []);
 
   // FLIP: glide the cards from the expanded list back into the stack
   useLayoutEffect(() => {
@@ -698,7 +737,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
             'posts-stack--expanded': isExpanded,
             'posts-stack--dragging': isDragging,
           })}
-          role="group"
+          role="region"
           aria-roledescription="carousel"
           aria-label={formatMessage(messages.deckLabel)}
           // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
@@ -706,7 +745,8 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+          onClick={handleDeckClick}
           onKeyDown={handleKeyDown}
           onMouseMove={handleMouseMove}
           onMouseLeave={handleMouseLeave}
@@ -746,7 +786,6 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
                 isPeeking={peekingCard === index}
                 isExpanded={isExpanded}
                 style={style}
-                onClick={handleCardClick(index)}
               />
             );
           })}
@@ -767,7 +806,13 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
               ? formatMessage(messages.newsDismissedCount, { count: dismissedStack.length })
               : formatMessage(messages.newsDismissed)}
           </span>
-          <button type="button" className={cx('undo-button')} onClick={undoDismiss}>
+          <button
+            type="button"
+            className={cx('undo-button')}
+            onClick={undoDismiss}
+            tabIndex={isUndoShown ? 0 : -1}
+            aria-hidden={!isUndoShown}
+          >
             {formatMessage(messages.undo)}
           </button>
         </div>

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
 import { LOGIN_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/loginPageEvents';
+import { ScrollWrapper } from 'components/main/scrollWrapper';
 import styles from './newsBlock.scss';
 import { PostBlock } from './postBlock';
 
@@ -726,70 +727,78 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
     onExpandedChange?.(nextExpanded);
   };
 
+  const postsStack = (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <section
+      ref={deckRef}
+      className={cx('posts-stack', {
+        'posts-stack--stacked': isStacked,
+        'posts-stack--expanded': isExpanded,
+        'posts-stack--dragging': isDragging,
+      })}
+      aria-roledescription="carousel"
+      aria-label={formatMessage(messages.deckLabel)}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={hasNews ? 0 : -1}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onClick={handleDeckClick}
+      onKeyDown={handleKeyDown}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      {visibleTweets.map((tweet, index) => {
+        const layer = layerByCard[index];
+        const isInStack = layer !== undefined;
+        const isDismissingThis = dismissingCard?.index === index;
+        let effectiveLayer = null;
+        if (isInStack) {
+          effectiveLayer = layer;
+        } else if (isDismissingThis) {
+          effectiveLayer = 0;
+        }
+        let style;
+        if (hiddenCards.includes(index)) {
+          style = { display: 'none' };
+        } else if (isDismissingThis) {
+          style = { top: `${dismissingCard.top}px` };
+        } else if (!isExpanded && isInStack && order.length > 1) {
+          style = { top: `${getLayerTop(Math.min(layer, MAX_VISIBLE_LAYERS), maxLayer)}px` };
+        }
+
+        return (
+          <PostBlock
+            key={getTweetKey(tweet, index)}
+            ref={(node) => {
+              cardRefs.current[index] = node;
+            }}
+            tweetData={tweet}
+            stackLayer={effectiveLayer}
+            isStacked={isStacked || isDismissingThis}
+            isStackFront={effectiveLayer === 0}
+            isHidden={isInStack && layer > MAX_VISIBLE_LAYERS}
+            isDismissing={isDismissingThis || demotingCard === index}
+            isPeeking={peekingCard === index}
+            isExpanded={isExpanded}
+            style={style}
+          />
+        );
+      })}
+    </section>
+  );
+
   return (
     <div className={cx('news-block', { 'news-block--expanded': isExpanded })}>
-      {!isEmptied && (
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-        <section
-          ref={deckRef}
-          className={cx('posts-stack', {
-            'posts-stack--stacked': isStacked,
-            'posts-stack--expanded': isExpanded,
-            'posts-stack--dragging': isDragging,
-          })}
-          aria-roledescription="carousel"
-          aria-label={formatMessage(messages.deckLabel)}
-          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-          tabIndex={hasNews ? 0 : -1}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerCancel}
-          onClick={handleDeckClick}
-          onKeyDown={handleKeyDown}
-          onMouseMove={handleMouseMove}
-          onMouseLeave={handleMouseLeave}
-        >
-          {visibleTweets.map((tweet, index) => {
-            const layer = layerByCard[index];
-            const isInStack = layer !== undefined;
-            const isDismissingThis = dismissingCard?.index === index;
-            // a card that is flying out keeps its front-card geometry
-            let effectiveLayer = null;
-            if (isInStack) {
-              effectiveLayer = layer;
-            } else if (isDismissingThis) {
-              effectiveLayer = 0;
-            }
-            let style;
-            if (hiddenCards.includes(index)) {
-              style = { display: 'none' };
-            } else if (isDismissingThis) {
-              style = { top: `${dismissingCard.top}px` };
-            } else if (!isExpanded && isInStack && order.length > 1) {
-              style = { top: `${getLayerTop(Math.min(layer, MAX_VISIBLE_LAYERS), maxLayer)}px` };
-            }
-
-            return (
-              <PostBlock
-                key={getTweetKey(tweet, index)}
-                ref={(node) => {
-                  cardRefs.current[index] = node;
-                }}
-                tweetData={tweet}
-                stackLayer={effectiveLayer}
-                isStacked={isStacked || isDismissingThis}
-                isStackFront={effectiveLayer === 0}
-                isHidden={isInStack && layer > MAX_VISIBLE_LAYERS}
-                isDismissing={isDismissingThis || demotingCard === index}
-                isPeeking={peekingCard === index}
-                isExpanded={isExpanded}
-                style={style}
-              />
-            );
-          })}
-        </section>
-      )}
+      {!isEmptied &&
+        (isExpanded ? (
+          <ScrollWrapper className={cx('posts-scroll')} hideTracksWhenNotNeeded>
+            {postsStack}
+          </ScrollWrapper>
+        ) : (
+          postsStack
+        ))}
       {isEmptied && (
         <div className={cx('empty-state')}>
           <span>{formatMessage(messages.allCaughtUp)}</span>

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
@@ -730,14 +730,13 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
     <div className={cx('news-block', { 'news-block--expanded': isExpanded })}>
       {!isEmptied && (
         // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-        <div
+        <section
           ref={deckRef}
           className={cx('posts-stack', {
             'posts-stack--stacked': isStacked,
             'posts-stack--expanded': isExpanded,
             'posts-stack--dragging': isDragging,
           })}
-          role="region"
           aria-roledescription="carousel"
           aria-label={formatMessage(messages.deckLabel)}
           // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
@@ -789,7 +788,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
               />
             );
           })}
-        </div>
+        </section>
       )}
       {isEmptied && (
         <div className={cx('empty-state')}>

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
@@ -129,9 +129,14 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
   const visibleTweets = tweets;
+  const stackSize = Math.min(MAX_TWEETS, visibleTweets.length);
 
-  // order[0] is the index (into visibleTweets) of the front card
-  const initialOrder = useMemo(() => visibleTweets.map((_, index) => index), [visibleTweets]);
+  // order[0] is the index (into visibleTweets) of the front card;
+  // the interactive stack always uses at most MAX_TWEETS cards
+  const initialOrder = useMemo(
+    () => Array.from({ length: stackSize }, (_, index) => index),
+    [stackSize],
+  );
   const [order, setOrder] = useState(initialOrder);
   const [dismissedStack, setDismissedStack] = useState([]);
   const [hiddenCards, setHiddenCards] = useState([]);
@@ -424,15 +429,20 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
     commitDismissed([]);
     setHiddenCards([]);
     setDismissingCard(null);
-    commitOrder(visibleTweets.map((_, index) => index));
+    commitOrder(Array.from({ length: Math.min(MAX_TWEETS, visibleTweets.length) }, (_, index) => index));
     hideUndo();
   }, [visibleTweets, commitOrder, commitDismissed, hideUndo]);
 
   const hasNews = visibleTweets.length > 0;
-  // keep the deck mounted while the last card is still flying out
+  // keep the deck mounted while the last card is still flying out;
+  // if the feed has more than the stack size, dismissing the stack is not "all caught up"
   const isEmptied =
-    hasNews && order.length === 0 && dismissedStack.length > 0 && !dismissingCard;
-  const hasMoreTweets = order.length > 1;
+    hasNews &&
+    order.length === 0 &&
+    dismissedStack.length > 0 &&
+    !dismissingCard &&
+    visibleTweets.length <= MAX_TWEETS;
+  const hasMoreTweets = visibleTweets.length > 1;
   const isStacked = !isExpanded && order.length > 1;
   const maxLayer = Math.min(Math.max(order.length - 1, 0), MAX_VISIBLE_LAYERS);
   const layerByCard = {};
@@ -760,7 +770,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
           effectiveLayer = 0;
         }
         let style;
-        if (hiddenCards.includes(index)) {
+        if (hiddenCards.includes(index) || (!isExpanded && index >= MAX_TWEETS)) {
           style = { display: 'none' };
         } else if (isDismissingThis) {
           style = { top: `${dismissingCard.top}px` };
@@ -792,6 +802,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
   return (
     <div className={cx('news-block', { 'news-block--expanded': isExpanded })}>
       {!isEmptied &&
+        (order.length > 0 || isExpanded) &&
         (isExpanded ? (
           <ScrollWrapper className={cx('posts-scroll')} hideTracksWhenNotNeeded>
             {postsStack}
@@ -826,7 +837,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
         </div>
         {isStacked && (
           <div className={cx('stack-dots')} aria-label={formatMessage(messages.selectNews)}>
-            {visibleTweets.map((tweet, index) =>
+            {visibleTweets.slice(0, MAX_TWEETS).map((tweet, index) =>
               dismissedStack.includes(index) ? null : (
                 <button
                   key={getTweetKey(tweet, index)}
@@ -834,7 +845,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
                   className={cx('stack-dot', { 'stack-dot--active': order[0] === index })}
                   aria-label={formatMessage(messages.newsPosition, {
                     position: index + 1,
-                    total: visibleTweets.length,
+                    total: Math.min(visibleTweets.length, MAX_TWEETS),
                   })}
                   onClick={() => promote(index)}
                 />
@@ -856,7 +867,7 @@ const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
         {hasNews && order.length
           ? formatMessage(messages.newsPosition, {
               position: order[0] + 1,
-              total: visibleTweets.length,
+              total: Math.min(visibleTweets.length, MAX_TWEETS),
             })
           : ''}
       </span>
@@ -870,11 +881,10 @@ NewsDeck.propTypes = {
 };
 
 export const NewsBlock = ({ tweets = [], onExpandedChange = null }) => {
-  const visibleTweets = useMemo(() => tweets.slice(0, MAX_TWEETS), [tweets]);
   // remount the deck whenever the feed changes so its state starts fresh
-  const deckKey = visibleTweets.map((tweet, index) => getTweetKey(tweet, index)).join('|');
+  const deckKey = tweets.map((tweet, index) => getTweetKey(tweet, index)).join('|');
 
-  return <NewsDeck key={deckKey} tweets={visibleTweets} onExpandedChange={onExpandedChange} />;
+  return <NewsDeck key={deckKey} tweets={tweets} onExpandedChange={onExpandedChange} />;
 };
 
 NewsBlock.propTypes = {

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.jsx
@@ -15,9 +15,9 @@
  */
 
 import classNames from 'classnames/bind';
-import { useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useTracking } from 'react-tracking';
 import { LOGIN_PAGE_EVENTS } from 'components/main/analytics/events/ga4Events/loginPageEvents';
 import styles from './newsBlock.scss';
@@ -27,79 +27,801 @@ const cx = classNames.bind(styles);
 
 const MAX_TWEETS = 3;
 const STACK_STEP_PX = 34;
+const MAX_VISIBLE_LAYERS = 2;
+const CYCLE_DURATION_MS = 420;
+const WHEEL_FLIP_THRESHOLD = 70;
+const WHEEL_FOLLOW_MAX_PX = 26;
+const WHEEL_IDLE_RESET_MS = 150;
+const DRAG_AXIS_LOCK_PX = 8;
+const DRAG_CYCLE_THRESHOLD_PX = 60;
+const DRAG_DISMISS_THRESHOLD_PX = 90;
+const PEEK_DELAY_MS = 350;
+const DISMISS_FLY_OUT_MS = 340;
+const UNDO_HIDE_MS = 6000;
+const CLICK_SUPPRESS_AFTER_DRAG_MS = 350;
+const PROMOTE_RETRY_MS = 90;
+const PARALLAX_MAX_DEG = 2;
+
+const messages = defineMessages({
+  undo: {
+    id: 'NewsBlock.undo',
+    defaultMessage: 'Undo',
+  },
+  newsDismissed: {
+    id: 'NewsBlock.newsDismissed',
+    defaultMessage: 'News dismissed',
+  },
+  newsDismissedCount: {
+    id: 'NewsBlock.newsDismissedCount',
+    defaultMessage: '{count} news dismissed',
+  },
+  allCaughtUp: {
+    id: 'NewsBlock.allCaughtUp',
+    defaultMessage: 'You are all caught up 🎉',
+  },
+  showNewsAgain: {
+    id: 'NewsBlock.showNewsAgain',
+    defaultMessage: 'Show news again',
+  },
+  newsPosition: {
+    id: 'NewsBlock.newsPosition',
+    defaultMessage: 'News {position} of {total}',
+  },
+  deckLabel: {
+    id: 'NewsBlock.deckLabel',
+    defaultMessage:
+      'ReportPortal news. Scroll or use arrow keys to browse, swipe a card sideways or press Delete to dismiss it.',
+  },
+  selectNews: {
+    id: 'NewsBlock.selectNews',
+    defaultMessage: 'Select news',
+  },
+});
 
 const getTweetKey = (tweet, index) =>
   tweet.id ?? tweet.created_at ?? tweet.date ?? tweet.createdAt ?? `tweet-${index}`;
 
-export const NewsBlock = ({ tweets = [], onExpandedChange }) => {
+// stack geometry, generalized from the previous static layout:
+// front card sits below all the back cards, deeper layers peek out on top
+const getLayerTop = (layer, maxLayer) => {
+  if (layer === 0) {
+    return maxLayer * STACK_STEP_PX;
+  }
+  const depth = maxLayer - Math.min(layer, MAX_VISIBLE_LAYERS);
+
+  return depth * (STACK_STEP_PX - depth * 2);
+};
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  !!window.matchMedia &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const NewsDeck = ({ tweets = [], onExpandedChange = null }) => {
+  const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
+  const visibleTweets = tweets;
+
+  // order[0] is the index (into visibleTweets) of the front card
+  const initialOrder = useMemo(() => visibleTweets.map((_, index) => index), [visibleTweets]);
+  const [order, setOrder] = useState(initialOrder);
+  const [dismissedStack, setDismissedStack] = useState([]);
+  const [hiddenCards, setHiddenCards] = useState([]);
+  const [dismissingCard, setDismissingCard] = useState(null); // { index, top }
+  const [demotingCard, setDemotingCard] = useState(null);
+  const [peekingCard, setPeekingCard] = useState(null);
   const [isExpanded, setIsExpanded] = useState(false);
-  const visibleTweets = tweets.slice(0, MAX_TWEETS);
-  const hasMoreTweets = visibleTweets.length > 1;
-  const isStacked = !isExpanded && visibleTweets.length > 1;
-  const stackedTweets = isStacked ? [...visibleTweets].reverse() : visibleTweets;
-  const maxStackLayer = visibleTweets.length - 1;
-  const stackPaddingTop = isStacked ? maxStackLayer * STACK_STEP_PX : 0;
+  const [isUndoShown, setIsUndoShown] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
 
-  const handleToggle = () => {
-    const nextExpanded = !isExpanded;
+  const deckRef = useRef(null);
+  const cardRefs = useRef({});
+  const orderRef = useRef(initialOrder);
+  const dismissedRef = useRef([]);
+  const expandedRef = useRef(false);
+  const animatingRef = useRef(false);
+  const animatingTimerRef = useRef(null);
+  const demotingTimerRef = useRef(null);
+  const wheelAccRef = useRef(0);
+  const followTimerRef = useRef(null);
+  const dragRef = useRef(null); // { startX, startY, axis, dx, dy }
+  const peekTimerRef = useRef(null);
+  const peekingRef = useRef(false);
+  const dismissTimersRef = useRef(new Map());
+  const undoTimerRef = useRef(null);
+  const promoteTimerRef = useRef(null);
+  const lastDragEndRef = useRef(0);
+  const pendingCollapseRectsRef = useRef(null);
 
-    if (nextExpanded) {
-      trackEvent(LOGIN_PAGE_EVENTS.CLICK_ON_OPEN_MORE_NEWS);
+  const commitOrder = useCallback((next) => {
+    orderRef.current = next;
+    setOrder(next);
+  }, []);
+
+  const commitDismissed = useCallback((next) => {
+    dismissedRef.current = next;
+    setDismissedStack(next);
+  }, []);
+
+  // clean up every pending timer on unmount
+  useEffect(
+    () => () => {
+      clearTimeout(animatingTimerRef.current);
+      clearTimeout(demotingTimerRef.current);
+      clearTimeout(followTimerRef.current);
+      clearTimeout(peekTimerRef.current);
+      clearTimeout(undoTimerRef.current);
+      clearTimeout(promoteTimerRef.current);
+      dismissTimersRef.current.forEach((timer) => clearTimeout(timer));
+      dismissTimersRef.current.clear();
+    },
+    [],
+  );
+
+  const getCardNode = useCallback((index) => cardRefs.current[index], []);
+  const getFrontNode = useCallback(() => cardRefs.current[orderRef.current[0]], []);
+
+  const measureStack = useCallback(() => {
+    const deck = deckRef.current;
+    const currentOrder = orderRef.current;
+    if (!deck || expandedRef.current || !currentOrder.length) {
+      return;
+    }
+    const front = getCardNode(currentOrder[0]);
+    if (!front) {
+      return;
+    }
+    const maxLayer = Math.min(currentOrder.length - 1, MAX_VISIBLE_LAYERS);
+    front.style.height = 'auto';
+    const frontHeight = front.offsetHeight;
+    const deckHeight = getLayerTop(0, maxLayer) + frontHeight;
+    // freeze heights so the cards morph smoothly and the back cards
+    // never protrude below the front card
+    currentOrder.forEach((cardIndex, layer) => {
+      const card = getCardNode(cardIndex);
+      if (!card) {
+        return;
+      }
+      if (layer === 0) {
+        card.style.height = `${frontHeight}px`;
+      } else {
+        const maxHeight = deckHeight - getLayerTop(Math.min(layer, MAX_VISIBLE_LAYERS), maxLayer);
+        card.style.height = `${Math.min(card.scrollHeight, maxHeight)}px`;
+      }
+    });
+    deck.style.height = `${deckHeight}px`;
+  }, [getCardNode]);
+
+  useLayoutEffect(() => {
+    const deck = deckRef.current;
+    if (!deck) {
+      return;
+    }
+    if (isExpanded) {
+      deck.style.height = '';
+      Object.values(cardRefs.current).forEach((card) => {
+        if (card) {
+          card.style.height = '';
+        }
+      });
+    } else {
+      measureStack();
+    }
+  }, [order, hiddenCards, isExpanded, measureStack]);
+
+  useEffect(() => {
+    const remeasure = () => measureStack();
+    window.addEventListener('resize', remeasure);
+    if (document.fonts?.ready) {
+      document.fonts.ready.then(remeasure).catch(() => {});
     }
 
-    setIsExpanded(nextExpanded);
+    return () => window.removeEventListener('resize', remeasure);
+  }, [measureStack]);
+
+  const cycle = useCallback(
+    (direction) => {
+      const currentOrder = orderRef.current;
+      if (expandedRef.current || animatingRef.current || currentOrder.length < 2) {
+        return;
+      }
+      animatingRef.current = true;
+      const movingIndex = direction > 0 ? currentOrder[0] : currentOrder[currentOrder.length - 1];
+      const movingNode = getCardNode(movingIndex);
+      if (movingNode) {
+        movingNode.style.transition = '';
+        movingNode.style.transform = '';
+      }
+      setDemotingCard(movingIndex);
+      const next =
+        direction > 0
+          ? [...currentOrder.slice(1), currentOrder[0]]
+          : [currentOrder[currentOrder.length - 1], ...currentOrder.slice(0, -1)];
+      commitOrder(next);
+      clearTimeout(animatingTimerRef.current);
+      animatingTimerRef.current = setTimeout(() => {
+        animatingRef.current = false;
+      }, CYCLE_DURATION_MS);
+      clearTimeout(demotingTimerRef.current);
+      demotingTimerRef.current = setTimeout(() => setDemotingCard(null), CYCLE_DURATION_MS);
+    },
+    [commitOrder, getCardNode],
+  );
+
+  // a function declaration (not useCallback) so the retry can reference itself
+  function promote(cardIndex) {
+    const currentOrder = orderRef.current;
+    if (
+      expandedRef.current ||
+      currentOrder[0] === cardIndex ||
+      !currentOrder.includes(cardIndex)
+    ) {
+      return;
+    }
+    if (animatingRef.current) {
+      // another animation is in flight — retry instead of dying silently
+      clearTimeout(promoteTimerRef.current);
+      promoteTimerRef.current = setTimeout(() => promote(cardIndex), PROMOTE_RETRY_MS);
+
+      return;
+    }
+    const position = currentOrder.indexOf(cardIndex);
+    cycle(position <= currentOrder.length / 2 ? 1 : -1);
+    if (orderRef.current[0] !== cardIndex) {
+      clearTimeout(promoteTimerRef.current);
+      promoteTimerRef.current = setTimeout(() => promote(cardIndex), CYCLE_DURATION_MS + 20);
+    }
+  }
+
+  const showUndo = useCallback(() => {
+    setIsUndoShown(true);
+    clearTimeout(undoTimerRef.current);
+    undoTimerRef.current = setTimeout(() => setIsUndoShown(false), UNDO_HIDE_MS);
+  }, []);
+
+  const hideUndo = useCallback(() => {
+    setIsUndoShown(false);
+    clearTimeout(undoTimerRef.current);
+  }, []);
+
+  const dismiss = useCallback(
+    (direction) => {
+      const currentOrder = orderRef.current;
+      if (
+        expandedRef.current ||
+        animatingRef.current ||
+        dragRef.current ||
+        !currentOrder.length
+      ) {
+        return;
+      }
+      const cardIndex = currentOrder[0];
+      const card = getCardNode(cardIndex);
+      const maxLayer = Math.min(currentOrder.length - 1, MAX_VISIBLE_LAYERS);
+      animatingRef.current = true;
+      if (card) {
+        if (prefersReducedMotion()) {
+          card.style.opacity = '0';
+        } else {
+          card.style.transition =
+            'transform 340ms cubic-bezier(0.32, 0.72, 0, 1), opacity 280ms ease';
+          card.style.transform = `translateX(calc(-50% + ${direction * 560}px)) rotate(${
+            direction * 5
+          }deg)`;
+          card.style.opacity = '0';
+        }
+      }
+      setDismissingCard({ index: cardIndex, top: getLayerTop(0, maxLayer) });
+      commitOrder(currentOrder.slice(1));
+      commitDismissed([...dismissedRef.current, cardIndex]);
+      const timer = setTimeout(
+        () => {
+          dismissTimersRef.current.delete(cardIndex);
+          if (card) {
+            card.style.transition = '';
+            card.style.transform = '';
+            card.style.opacity = '';
+          }
+          animatingRef.current = false;
+          setDismissingCard(null);
+          setHiddenCards((prev) => [...prev, cardIndex]);
+          showUndo();
+        },
+        prefersReducedMotion() ? 0 : DISMISS_FLY_OUT_MS,
+      );
+      dismissTimersRef.current.set(cardIndex, timer);
+    },
+    [commitOrder, commitDismissed, showUndo, getCardNode],
+  );
+
+  const undoDismiss = useCallback(() => {
+    const dismissed = dismissedRef.current;
+    if (!dismissed.length) {
+      return;
+    }
+    const cardIndex = dismissed[dismissed.length - 1];
+    // the card may still be flying out — cancel its pending hide
+    const pendingTimer = dismissTimersRef.current.get(cardIndex);
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      dismissTimersRef.current.delete(cardIndex);
+      animatingRef.current = false;
+      setDismissingCard(null);
+    }
+    const card = getCardNode(cardIndex);
+    if (card) {
+      card.style.transition = '';
+      card.style.transform = '';
+      card.style.opacity = '';
+    }
+    commitDismissed(dismissed.slice(0, -1));
+    setHiddenCards((prev) => prev.filter((index) => index !== cardIndex));
+    commitOrder([cardIndex, ...orderRef.current]); // returns to the front, like iOS undo
+    if (dismissedRef.current.length) {
+      showUndo(); // refresh the label and the hide timer
+    } else {
+      hideUndo();
+    }
+  }, [commitOrder, commitDismissed, showUndo, hideUndo, getCardNode]);
+
+  const restoreAllNews = useCallback(() => {
+    dismissTimersRef.current.forEach((timer) => clearTimeout(timer));
+    dismissTimersRef.current.clear();
+    animatingRef.current = false;
+    Object.values(cardRefs.current).forEach((card) => {
+      if (card) {
+        card.style.transition = '';
+        card.style.transform = '';
+        card.style.opacity = '';
+      }
+    });
+    commitDismissed([]);
+    setHiddenCards([]);
+    setDismissingCard(null);
+    commitOrder(visibleTweets.map((_, index) => index));
+    hideUndo();
+  }, [visibleTweets, commitOrder, commitDismissed, hideUndo]);
+
+  const hasNews = visibleTweets.length > 0;
+  // keep the deck mounted while the last card is still flying out
+  const isEmptied =
+    hasNews && order.length === 0 && dismissedStack.length > 0 && !dismissingCard;
+  const hasMoreTweets = order.length > 1;
+  const isStacked = !isExpanded && order.length > 1;
+  const maxLayer = Math.min(Math.max(order.length - 1, 0), MAX_VISIBLE_LAYERS);
+  const layerByCard = {};
+  order.forEach((cardIndex, layer) => {
+    layerByCard[cardIndex] = layer;
+  });
+
+  // wheel must be a native non-passive listener: React attaches wheel
+  // handlers as passive, so preventDefault would be ignored
+  useEffect(() => {
+    const deck = deckRef.current;
+    if (!deck) {
+      return undefined;
+    }
+    const handleWheel = (event) => {
+      if (expandedRef.current) {
+        return; // native scroll in list mode
+      }
+      event.preventDefault();
+      if (animatingRef.current || dragRef.current || orderRef.current.length < 2) {
+        return;
+      }
+      wheelAccRef.current += event.deltaY;
+      const front = getFrontNode();
+      if (Math.abs(wheelAccRef.current) >= WHEEL_FLIP_THRESHOLD) {
+        clearTimeout(followTimerRef.current);
+        if (front) {
+          front.style.transition = '';
+          front.style.transform = '';
+        }
+        cycle(wheelAccRef.current > 0 ? 1 : -1);
+        wheelAccRef.current = 0;
+
+        return;
+      }
+      // the inactivity reset must run regardless of reduced motion,
+      // or stale deltas trigger surprise flips later
+      clearTimeout(followTimerRef.current);
+      followTimerRef.current = setTimeout(() => {
+        if (front) {
+          front.style.transition = '';
+          front.style.transform = '';
+        }
+        wheelAccRef.current = 0;
+      }, WHEEL_IDLE_RESET_MS);
+      if (!prefersReducedMotion() && front) {
+        const follow = Math.max(
+          -WHEEL_FOLLOW_MAX_PX,
+          Math.min(WHEEL_FOLLOW_MAX_PX, wheelAccRef.current * 0.3),
+        );
+        front.style.transition = 'transform 60ms linear';
+        front.style.transform = `translateX(-50%) translateY(${follow}px)`;
+      }
+    };
+    deck.addEventListener('wheel', handleWheel, { passive: false });
+
+    return () => deck.removeEventListener('wheel', handleWheel);
+  }, [cycle, getFrontNode, visibleTweets, isEmptied]);
+
+  const cancelPeek = useCallback(() => {
+    clearTimeout(peekTimerRef.current);
+    peekTimerRef.current = null;
+    if (peekingRef.current) {
+      peekingRef.current = false;
+      setPeekingCard(null);
+    }
+  }, []);
+
+  const handlePointerDown = (event) => {
+    if (expandedRef.current || animatingRef.current) {
+      return;
+    }
+    const front = getFrontNode();
+    if (!front || !front.contains(event.target) || event.target.closest('a')) {
+      return;
+    }
+    dragRef.current = {
+      startX: event.clientX,
+      startY: event.clientY,
+      axis: null,
+      dx: 0,
+      dy: 0,
+    };
+    setIsDragging(true);
+    front.style.transition = 'none';
+    deckRef.current?.setPointerCapture(event.pointerId);
+    if (!prefersReducedMotion()) {
+      peekTimerRef.current = setTimeout(() => {
+        if (dragRef.current?.axis) {
+          return;
+        }
+        peekingRef.current = true;
+        setPeekingCard(orderRef.current[0]);
+        front.style.transition = 'transform 240ms cubic-bezier(0.34, 1.45, 0.64, 1)';
+        front.style.transform = 'translateX(-50%) scale(1.03)';
+      }, PEEK_DELAY_MS);
+    }
+  };
+
+  const handlePointerMove = (event) => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    drag.dx = event.clientX - drag.startX;
+    drag.dy = event.clientY - drag.startY;
+    const front = getFrontNode();
+    if (!front) {
+      return;
+    }
+    if (!drag.axis && Math.hypot(drag.dx, drag.dy) > DRAG_AXIS_LOCK_PX) {
+      drag.axis = Math.abs(drag.dx) > Math.abs(drag.dy) ? 'x' : 'y';
+      cancelPeek();
+      front.style.transition = 'none';
+    }
+    if (!drag.axis) {
+      return;
+    }
+    if (drag.axis === 'y') {
+      const damped = drag.dy * 0.55;
+      front.style.transform = `translateX(-50%) translateY(${damped}px) rotate(${
+        damped * 0.03
+      }deg)`;
+    } else {
+      // rubber-like horizontal follow with a fade, iOS notification style
+      front.style.transform = `translateX(calc(-50% + ${drag.dx}px)) rotate(${drag.dx * 0.02}deg)`;
+      front.style.opacity = String(Math.max(0.25, 1 - Math.abs(drag.dx) / 320));
+    }
+  };
+
+  const handlePointerUp = () => {
+    const drag = dragRef.current;
+    if (!drag) {
+      return;
+    }
+    const front = getFrontNode();
+    const wasPeeking = peekingRef.current;
+    const { axis, dx, dy } = drag;
+    cancelPeek();
+    // reset the drag state BEFORE acting: dismiss() is guarded by the
+    // drag ref, and stale deltas must not leak into later interactions
+    dragRef.current = null;
+    setIsDragging(false);
+    if (axis) {
+      lastDragEndRef.current = performance.now();
+    }
+    if (front) {
+      front.style.transition = '';
+      front.style.transform = '';
+      front.style.opacity = '';
+    }
+    if (wasPeeking) {
+      // released a long-press without dragging: open the post
+      const link = front?.querySelector('a');
+      if (link) {
+        window.open(link.href, '_blank', 'noopener');
+      }
+
+      return;
+    }
+    if (axis === 'y' && Math.abs(dy) > DRAG_CYCLE_THRESHOLD_PX) {
+      cycle(dy > 0 ? 1 : -1);
+    }
+    if (axis === 'x' && Math.abs(dx) > DRAG_DISMISS_THRESHOLD_PX) {
+      dismiss(dx > 0 ? 1 : -1);
+    }
+  };
+
+  const handleCardClick = (cardIndex) => (event) => {
+    if (expandedRef.current || event.target.closest('a')) {
+      return;
+    }
+    if (performance.now() - lastDragEndRef.current < CLICK_SUPPRESS_AFTER_DRAG_MS) {
+      return; // that was a drag, not a click
+    }
+    if (orderRef.current[0] !== cardIndex) {
+      promote(cardIndex);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (expandedRef.current) {
+      return;
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+      event.preventDefault();
+      cycle(1);
+    }
+    if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      cycle(-1);
+    }
+    if (event.key === 'Delete' || event.key === 'Backspace') {
+      event.preventDefault();
+      dismiss(1);
+    }
+  };
+
+  // subtle cursor parallax: the deck tilts toward the pointer
+  const handleMouseMove = (event) => {
+    const deck = deckRef.current;
+    if (!deck || expandedRef.current || dragRef.current || prefersReducedMotion()) {
+      return;
+    }
+    const rect = deck.getBoundingClientRect();
+    const nx = (event.clientX - rect.left) / rect.width - 0.5;
+    const ny = (event.clientY - rect.top) / rect.height - 0.5;
+    deck.style.transform = `perspective(900px) rotateY(${(nx * PARALLAX_MAX_DEG * 1.2).toFixed(
+      2,
+    )}deg) rotateX(${(-ny * PARALLAX_MAX_DEG).toFixed(2)}deg)`;
+  };
+
+  const handleMouseLeave = () => {
+    if (deckRef.current) {
+      deckRef.current.style.transform = '';
+    }
+  };
+
+  const runStaggerIn = useCallback((nodes) => {
+    if (prefersReducedMotion()) {
+      return;
+    }
+    nodes.forEach((node) => {
+      node.style.transition = 'none';
+      node.style.opacity = '0';
+      node.style.transform = 'translateY(16px) scale(0.98)';
+    });
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        nodes.forEach((node, index) => {
+          node.style.transition = `opacity 300ms ease ${index * 55}ms, transform 430ms cubic-bezier(0.34, 1.3, 0.64, 1) ${index * 55}ms`;
+          node.style.opacity = '';
+          node.style.transform = '';
+        });
+        setTimeout(
+          () =>
+            nodes.forEach((node) => {
+              node.style.transition = '';
+            }),
+          430 + nodes.length * 55,
+        );
+      });
+    });
+  }, []);
+
+  // FLIP: glide the cards from the expanded list back into the stack
+  useLayoutEffect(() => {
+    const prevRects = pendingCollapseRectsRef.current;
+    pendingCollapseRectsRef.current = null;
+    if (!prevRects || isExpanded || prefersReducedMotion()) {
+      return;
+    }
+    measureStack();
+    const nodes = [...prevRects.keys()];
+    nodes.forEach((node) => {
+      const prev = prevRects.get(node);
+      const now = node.getBoundingClientRect();
+      node.style.transition = 'none';
+      node.style.transform = `translateX(-50%) translate(${prev.left - now.left}px, ${
+        prev.top - now.top
+      }px)`;
+    });
+    requestAnimationFrame(() => {
+      nodes.forEach((node) => {
+        node.style.transition = '';
+        node.style.transform = '';
+      });
+    });
+  }, [isExpanded, measureStack]);
+
+  const handleToggle = () => {
+    if (animatingRef.current) {
+      return; // don't reflow mid fly-out/cycle
+    }
+    const nextExpanded = !isExpanded;
+    // handlers and layout effects read the ref synchronously,
+    // before React commits the state update
+    expandedRef.current = nextExpanded;
+    if (nextExpanded) {
+      trackEvent(LOGIN_PAGE_EVENTS.CLICK_ON_OPEN_MORE_NEWS);
+      setIsExpanded(true);
+      requestAnimationFrame(() => {
+        // stagger in DOM (chronological) order
+        const nodes = visibleTweets
+          .map((_, index) => index)
+          .filter((index) => !dismissedRef.current.includes(index))
+          .map((index) => getCardNode(index))
+          .filter(Boolean);
+        runStaggerIn(nodes);
+      });
+    } else {
+      const aliveNodes = orderRef.current.map((index) => getCardNode(index)).filter(Boolean);
+      pendingCollapseRectsRef.current = new Map(
+        aliveNodes.map((node) => [node, node.getBoundingClientRect()]),
+      );
+      setIsExpanded(false);
+    }
     onExpandedChange?.(nextExpanded);
   };
 
   return (
     <div className={cx('news-block', { 'news-block--expanded': isExpanded })}>
-      <div
-        className={cx('posts-stack', {
-          'posts-stack--stacked': isStacked,
-          'posts-stack--expanded': isExpanded,
-        })}
-        style={
-          isStacked
-            ? { paddingTop: `${stackPaddingTop}px` }
-            : { paddingTop: 0 }
-        }
-      >
-        {stackedTweets.map(
-          (tweet, index) => {
-            const stackLayer = isStacked ? visibleTweets.length - 1 - index : null;
-            const isStackFront = stackLayer === 0;
-            const adjustedStep = STACK_STEP_PX - (index * 2);
-            const stackTopOffset =
-              isStacked && stackLayer > 0
-                ? (maxStackLayer - stackLayer) * adjustedStep
-                : null;
+      {!isEmptied && (
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+        <div
+          ref={deckRef}
+          className={cx('posts-stack', {
+            'posts-stack--stacked': isStacked,
+            'posts-stack--expanded': isExpanded,
+            'posts-stack--dragging': isDragging,
+          })}
+          role="group"
+          aria-roledescription="carousel"
+          aria-label={formatMessage(messages.deckLabel)}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={hasNews ? 0 : -1}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onKeyDown={handleKeyDown}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+        >
+          {visibleTweets.map((tweet, index) => {
+            const layer = layerByCard[index];
+            const isInStack = layer !== undefined;
+            const isDismissingThis = dismissingCard?.index === index;
+            // a card that is flying out keeps its front-card geometry
+            let effectiveLayer = null;
+            if (isInStack) {
+              effectiveLayer = layer;
+            } else if (isDismissingThis) {
+              effectiveLayer = 0;
+            }
+            let style;
+            if (hiddenCards.includes(index)) {
+              style = { display: 'none' };
+            } else if (isDismissingThis) {
+              style = { top: `${dismissingCard.top}px` };
+            } else if (!isExpanded && isInStack && order.length > 1) {
+              style = { top: `${getLayerTop(Math.min(layer, MAX_VISIBLE_LAYERS), maxLayer)}px` };
+            }
 
             return (
-            <PostBlock
+              <PostBlock
                 key={getTweetKey(tweet, index)}
+                ref={(node) => {
+                  cardRefs.current[index] = node;
+                }}
                 tweetData={tweet}
-                stackLayer={stackLayer}
-                isStacked={isStacked}
-                isStackFront={isStackFront}
-                stackTopOffset={stackTopOffset}
+                stackLayer={effectiveLayer}
+                isStacked={isStacked || isDismissingThis}
+                isStackFront={effectiveLayer === 0}
+                isHidden={isInStack && layer > MAX_VISIBLE_LAYERS}
+                isDismissing={isDismissingThis || demotingCard === index}
+                isPeeking={peekingCard === index}
                 isExpanded={isExpanded}
+                style={style}
+                onClick={handleCardClick(index)}
               />
             );
-          }
+          })}
+        </div>
+      )}
+      {isEmptied && (
+        <div className={cx('empty-state')}>
+          <span>{formatMessage(messages.allCaughtUp)}</span>
+          <button type="button" className={cx('restore-link')} onClick={restoreAllNews}>
+            {formatMessage(messages.showNewsAgain)}
+          </button>
+        </div>
+      )}
+      <div className={cx('deck-controls')}>
+        <div className={cx('undo-pill', { 'undo-pill--shown': isUndoShown })}>
+          <span>
+            {dismissedStack.length > 1
+              ? formatMessage(messages.newsDismissedCount, { count: dismissedStack.length })
+              : formatMessage(messages.newsDismissed)}
+          </span>
+          <button type="button" className={cx('undo-button')} onClick={undoDismiss}>
+            {formatMessage(messages.undo)}
+          </button>
+        </div>
+        {isStacked && (
+          <div className={cx('stack-dots')} aria-label={formatMessage(messages.selectNews)}>
+            {visibleTweets.map((tweet, index) =>
+              dismissedStack.includes(index) ? null : (
+                <button
+                  key={getTweetKey(tweet, index)}
+                  type="button"
+                  className={cx('stack-dot', { 'stack-dot--active': order[0] === index })}
+                  aria-label={formatMessage(messages.newsPosition, {
+                    position: index + 1,
+                    total: visibleTweets.length,
+                  })}
+                  onClick={() => promote(index)}
+                />
+              ),
+            )}
+          </div>
+        )}
+        {hasMoreTweets && !isEmptied && (
+          <button type="button" className={cx('toggle-button')} onClick={handleToggle}>
+            {isExpanded ? (
+              <FormattedMessage id="NewsBlock.close" defaultMessage="Close" />
+            ) : (
+              <FormattedMessage id="NewsBlock.openMoreNews" defaultMessage="Open more news" />
+            )}
+          </button>
         )}
       </div>
-      {hasMoreTweets && (
-        <button type="button" className={cx('toggle-button')} onClick={handleToggle}>
-          {isExpanded ? (
-            <FormattedMessage id="NewsBlock.close" defaultMessage="Close" />
-          ) : (
-            <FormattedMessage id="NewsBlock.openMoreNews" defaultMessage="Open more news" />
-          )}
-        </button>
-      )}
+      <span className={cx('visually-hidden')} aria-live="polite">
+        {hasNews && order.length
+          ? formatMessage(messages.newsPosition, {
+              position: order[0] + 1,
+              total: visibleTweets.length,
+            })
+          : ''}
+      </span>
     </div>
   );
+};
+
+NewsDeck.propTypes = {
+  tweets: PropTypes.array,
+  onExpandedChange: PropTypes.func,
+};
+
+export const NewsBlock = ({ tweets = [], onExpandedChange = null }) => {
+  const visibleTweets = useMemo(() => tweets.slice(0, MAX_TWEETS), [tweets]);
+  // remount the deck whenever the feed changes so its state starts fresh
+  const deckKey = visibleTweets.map((tweet, index) => getTweetKey(tweet, index)).join('|');
+
+  return <NewsDeck key={deckKey} tweets={visibleTweets} onExpandedChange={onExpandedChange} />;
 };
 
 NewsBlock.propTypes = {
@@ -107,7 +829,3 @@ NewsBlock.propTypes = {
   onExpandedChange: PropTypes.func,
 };
 
-NewsBlock.defaultProps = {
-  tweets: [],
-  onExpandedChange: null,
-};

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.scss
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.scss
@@ -55,6 +55,11 @@ $stack-speed: 420ms;
   max-width: 100%;
   outline: none;
 
+  &:focus-visible {
+    border-radius: 18px;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85);
+  }
+
   &--stacked {
     cursor: grab;
     /* both axes are consumed by the deck gestures */
@@ -62,11 +67,6 @@ $stack-speed: 420ms;
     transition:
       height $stack-speed $stack-soft-easing,
       transform 300ms $stack-soft-easing;
-
-    &:focus-visible {
-      border-radius: 18px;
-      box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85);
-    }
 
     @media (prefers-reduced-motion: reduce) {
       transition: none;
@@ -110,11 +110,13 @@ $stack-speed: 420ms;
   font-size: 12px;
   color: var(--rp-ui-base-bg-000);
   opacity: 0;
+  visibility: hidden;
   transform: translateY(6px) scale(0.92);
   pointer-events: none;
   transition:
     opacity 240ms ease,
-    transform 340ms $stack-spring-easing;
+    transform 340ms $stack-spring-easing,
+    visibility 0s linear 340ms;
 
   @media (prefers-reduced-motion: reduce) {
     transition: none;
@@ -122,8 +124,13 @@ $stack-speed: 420ms;
 
   &--shown {
     opacity: 1;
+    visibility: visible;
     transform: none;
     pointer-events: auto;
+    transition:
+      opacity 240ms ease,
+      transform 340ms $stack-spring-easing,
+      visibility 0s;
   }
 }
 
@@ -145,28 +152,43 @@ $stack-speed: 420ms;
 
 .stack-dots {
   display: flex;
-  gap: 7px;
+  gap: 0;
 }
 
 .stack-dot {
-  width: 6px;
-  height: 6px;
+  position: relative;
+  width: 20px;
+  height: 20px;
   padding: 0;
   border: none;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.4);
+  background: transparent;
   cursor: pointer;
-  transition:
-    background 200ms ease,
-    transform 200ms ease;
 
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.4);
+    transform: translate(-50%, -50%);
+    transition:
+      background 200ms ease,
+      transform 200ms ease;
+    content: '';
   }
 
-  &:hover {
+  @media (prefers-reduced-motion: reduce) {
+    &::before {
+      transition: none;
+    }
+  }
+
+  &:hover::before {
     background: rgba(255, 255, 255, 0.75);
-    transform: scale(1.25);
+    transform: translate(-50%, -50%) scale(1.25);
   }
 
   &:focus-visible {
@@ -174,7 +196,7 @@ $stack-speed: 420ms;
     outline-offset: 2px;
   }
 
-  &--active {
+  &--active::before {
     background: var(--rp-ui-base-bg-000);
   }
 }

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.scss
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.scss
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+$stack-spring-easing: cubic-bezier(0.34, 1.45, 0.64, 1);
+$stack-soft-easing: cubic-bezier(0.33, 1, 0.42, 1);
+$stack-speed: 420ms;
+
 .news-block {
   display: flex;
   flex-direction: column;
@@ -49,11 +53,28 @@
   position: relative;
   width: 479px;
   max-width: 100%;
+  outline: none;
 
   &--stacked {
-    position: relative;
-    padding-bottom: 8px;
-    min-height: 120px;
+    cursor: grab;
+    /* both axes are consumed by the deck gestures */
+    touch-action: none;
+    transition:
+      height $stack-speed $stack-soft-easing,
+      transform 300ms $stack-soft-easing;
+
+    &:focus-visible {
+      border-radius: 18px;
+      box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  &--dragging {
+    cursor: grabbing;
   }
 
   &--expanded {
@@ -64,9 +85,136 @@
     overflow-y: auto;
     padding-top: 0;
     align-content: end;
-    .post-block + .post-block {
-      margin-top: 16px;
-    }
+    touch-action: auto;
+  }
+}
+
+.deck-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.undo-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(20px);
+  font-family: var(--rp-ui-base-font-family);
+  font-weight: var(--rp-ui-base-fw-medium);
+  font-size: 12px;
+  color: var(--rp-ui-base-bg-000);
+  opacity: 0;
+  transform: translateY(6px) scale(0.92);
+  pointer-events: none;
+  transition:
+    opacity 240ms ease,
+    transform 340ms $stack-spring-easing;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  &--shown {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+  }
+}
+
+.undo-button {
+  padding: 3px 10px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--rp-ui-base-dark-topaz-main);
+  font-family: var(--rp-ui-base-font-family);
+  font-weight: var(--rp-ui-base-fw-medium);
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--rp-ui-base-bg-000);
+  }
+}
+
+.stack-dots {
+  display: flex;
+  gap: 7px;
+}
+
+.stack-dot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  transition:
+    background 200ms ease,
+    transform 200ms ease;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.75);
+    transform: scale(1.25);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-ui-base-bg-000);
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: var(--rp-ui-base-bg-000);
+  }
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: 479px;
+  max-width: 100%;
+  padding: 28px 20px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(20px);
+  color: var(--rp-ui-base-bg-000);
+  font-family: var(--rp-ui-base-font-family);
+  font-weight: var(--rp-ui-base-fw-medium);
+  font-size: 14px;
+  text-align: center;
+  box-sizing: border-box;
+  animation: empty-state-pop-in 420ms $stack-spring-easing;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.restore-link {
+  border: none;
+  background: transparent;
+  color: var(--rp-ui-base-bg-000);
+  font-family: var(--rp-ui-base-font-family);
+  font-size: 12px;
+  text-decoration: underline;
+  cursor: pointer;
+  opacity: 0.85;
+
+  &:hover {
+    opacity: 1;
   }
 }
 
@@ -82,9 +230,29 @@
   color: var(--rp-ui-base-bg-000);
   cursor: pointer;
   text-decoration: none;
-  margin-top: 3px;
 
   &:hover {
     opacity: 1;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@keyframes empty-state-pop-in {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
   }
 }

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.scss
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlock.scss
@@ -78,15 +78,21 @@ $stack-speed: 420ms;
   }
 
   &--expanded {
-    flex: 1;
-    min-height: 0;
     width: 100%;
     max-width: 479px;
-    overflow-y: auto;
+    min-height: 100%;
     padding-top: 0;
     align-content: end;
     touch-action: auto;
+    box-sizing: border-box;
   }
+}
+
+.posts-scroll {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  max-width: 479px;
 }
 
 .deck-controls {

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlockWithData.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/newsBlockWithData.jsx
@@ -33,7 +33,7 @@ export class NewsBlockWithData extends Component {
   };
 
   componentDidMount() {
-    fetchJsonp('https://status.reportportal.io/twitter?count=3', {
+    fetchJsonp('https://status.reportportal.io/twitter', {
       jsonpCallback: 'jsonp',
     })
       .then((res) => res.json())

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.jsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { forwardRef } from 'react';
 import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
 import Parser from 'html-react-parser';
@@ -26,6 +27,7 @@ import styles from './postBlock.scss';
 const cx = classNames.bind(styles);
 
 const POST_CONTENT_SANITIZE_CONFIG = { ADD_ATTR: ['target', 'rel'] };
+const MAX_VISIBLE_STACK_LAYER = 2;
 
 const ensureLinkOpensInNewTab = (node) => {
   if (node.tagName === 'A') {
@@ -85,57 +87,77 @@ const formatTweetDate = (tweetData, locale) => {
   return date.toLocaleDateString(locale, { month: 'short', day: 'numeric' });
 };
 
-export const PostBlock = ({ tweetData, stackLayer, isStacked, isStackFront, stackTopOffset, isExpanded }) => {
-  const { locale } = useIntl();
-  const formattedDate = formatTweetDate(tweetData, locale);
+export const PostBlock = forwardRef(
+  (
+    {
+      tweetData = {},
+      stackLayer = null,
+      isStacked = false,
+      isStackFront = false,
+      isHidden = false,
+      isDismissing = false,
+      isPeeking = false,
+      isExpanded = false,
+      style = null,
+      onClick = null,
+    },
+    ref,
+  ) => {
+    const { locale } = useIntl();
+    const formattedDate = formatTweetDate(tweetData, locale);
+    const visibleLayer = stackLayer === null ? null : Math.min(stackLayer, MAX_VISIBLE_STACK_LAYER);
 
-  return (
-    <div
-      className={cx('post-block', {
-        'post-block--stacked': isStacked && stackLayer !== null,
-        'post-block--stack-front': isStacked && isStackFront,
-        'post-block--stack-back': isStacked && !isStackFront,
-        [`post-block--stack-layer-${stackLayer}`]: isStacked && stackLayer !== null,
-        'post-block--expanded': isExpanded,
-      })}
-      style={stackTopOffset !== null ? { top: `${stackTopOffset}px` } : undefined}
-    >
-      <div className={cx('post-header')}>
-        <div className={cx('post-avatar')} />
-        <div className={cx('post-meta')}>
-          <div className={cx('post-author')}>
-            <span className={cx('post-name')}>ReportPortal.io</span>
-            <span className={cx('post-handle')}>@ReportPortal.io</span>
-            {formattedDate && (
-              <>
-                <span className={cx('post-separator')}>•</span>
-                <span className={cx('post-date')}>{formattedDate}</span>
-              </>
-            )}
+    return (
+      <div
+        ref={ref}
+        className={cx('post-block', {
+          'post-block--stacked': isStacked && stackLayer !== null,
+          'post-block--stack-front': isStacked && isStackFront,
+          'post-block--stack-back': isStacked && !isStackFront,
+          [`post-block--stack-layer-${visibleLayer}`]:
+            isStacked && visibleLayer !== null && !isHidden,
+          'post-block--stack-hidden': isStacked && isHidden,
+          'post-block--dismissing': isDismissing,
+          'post-block--peeking': isPeeking,
+          'post-block--expanded': isExpanded,
+        })}
+        style={style}
+        onClick={onClick}
+      >
+        <div className={cx('post-header')}>
+          <div className={cx('post-avatar')} />
+          <div className={cx('post-meta')}>
+            <div className={cx('post-author')}>
+              <span className={cx('post-name')}>ReportPortal.io</span>
+              <span className={cx('post-handle')}>@ReportPortal.io</span>
+              {formattedDate && (
+                <>
+                  <span className={cx('post-separator')}>•</span>
+                  <span className={cx('post-date')}>{formattedDate}</span>
+                </>
+              )}
+            </div>
           </div>
         </div>
+        <div className={cx('post-content')}>
+          {Parser(sanitizePostContent(getPostContent(tweetData.text)))}
+        </div>
       </div>
-      <div className={cx('post-content')}>
-        {Parser(sanitizePostContent(getPostContent(tweetData.text)))}
-      </div>
-    </div>
-  );
-};
+    );
+  },
+);
+
+PostBlock.displayName = 'PostBlock';
 
 PostBlock.propTypes = {
   tweetData: PropTypes.object,
   stackLayer: PropTypes.number,
   isStacked: PropTypes.bool,
   isStackFront: PropTypes.bool,
-  stackTopOffset: PropTypes.number,
+  isHidden: PropTypes.bool,
+  isDismissing: PropTypes.bool,
+  isPeeking: PropTypes.bool,
   isExpanded: PropTypes.bool,
-};
-
-PostBlock.defaultProps = {
-  tweetData: {},
-  stackLayer: null,
-  isStacked: false,
-  isStackFront: false,
-  stackTopOffset: null,
-  isExpanded: false,
+  style: PropTypes.object,
+  onClick: PropTypes.func,
 };

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.jsx
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.jsx
@@ -99,7 +99,6 @@ export const PostBlock = forwardRef(
       isPeeking = false,
       isExpanded = false,
       style = null,
-      onClick = null,
     },
     ref,
   ) => {
@@ -122,7 +121,6 @@ export const PostBlock = forwardRef(
           'post-block--expanded': isExpanded,
         })}
         style={style}
-        onClick={onClick}
       >
         <div className={cx('post-header')}>
           <div className={cx('post-avatar')} />
@@ -159,5 +157,4 @@ PostBlock.propTypes = {
   isPeeking: PropTypes.bool,
   isExpanded: PropTypes.bool,
   style: PropTypes.object,
-  onClick: PropTypes.func,
 };

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.scss
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.scss
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+$stack-spring-easing: cubic-bezier(0.34, 1.45, 0.64, 1);
+$stack-soft-easing: cubic-bezier(0.33, 1, 0.42, 1);
+$stack-speed: 420ms;
+
 .post-block {
   position: relative;
   display: block;
@@ -27,6 +31,20 @@
   line-height: 18px;
   box-sizing: border-box;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  transition:
+    top $stack-speed $stack-spring-easing,
+    transform $stack-speed $stack-spring-easing,
+    width $stack-speed $stack-soft-easing,
+    height $stack-speed $stack-soft-easing,
+    padding $stack-speed $stack-soft-easing,
+    opacity $stack-speed $stack-soft-easing,
+    filter $stack-speed $stack-soft-easing,
+    box-shadow 200ms ease;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 
   &--expanded {
     margin-bottom: 8px;
@@ -81,6 +99,13 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;
+  transition:
+    width $stack-speed $stack-soft-easing,
+    height $stack-speed $stack-soft-easing;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 
   .post-block--stack-layer-2 & {
     width: 19px;
@@ -187,15 +212,13 @@
 }
 
 .post-block--stacked {
-  &.post-block--stack-back {
-    position: absolute;
-    left: 50%;
-    right: auto;
-    transform: translateX(-50%);
-  }
+  position: absolute;
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+  will-change: top, width, opacity, transform;
 
   &.post-block--stack-front {
-    position: relative;
     width: 479px;
     max-width: 100%;
 
@@ -209,7 +232,9 @@
     max-width: calc(100% - 24px);
     padding: 9px 14px;
     opacity: 0.1;
+    filter: blur(0.8px);
     z-index: 1;
+    cursor: pointer;
 
     @media (max-width: $SCREEN_XS_MAX) {
       width: calc(100% - 32px);
@@ -220,8 +245,10 @@
     width: 419px;
     max-width: calc(100% - 12px);
     opacity: 0.5;
+    filter: blur(0.4px);
     padding: 11px 16px;
     z-index: 2;
+    cursor: pointer;
 
     @media (max-width: $SCREEN_XS_MAX) {
       width: calc(100% - 16px);
@@ -232,4 +259,25 @@
     opacity: 1;
     z-index: 3;
   }
+
+  &.post-block--stack-hidden {
+    width: 355px;
+    max-width: calc(100% - 24px);
+    padding: 9px 14px;
+    opacity: 0;
+    z-index: 0;
+    pointer-events: none;
+
+    @media (max-width: $SCREEN_XS_MAX) {
+      width: calc(100% - 32px);
+    }
+  }
+}
+
+.post-block--dismissing {
+  z-index: 5;
+}
+
+.post-block--peeking {
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.2);
 }

--- a/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.scss
+++ b/app/src/pages/outside/loginPage/socialSection/newsBlock/postBlock/postBlock.scss
@@ -274,7 +274,7 @@ $stack-speed: 420ms;
   }
 }
 
-.post-block--dismissing {
+.post-block--stacked.post-block--dismissing {
   z-index: 5;
 }
 


### PR DESCRIPTION
## What

The news stack on the login page becomes an interactive, iOS-notification-style deck:

- **Mouse wheel** browses the stack: the front card follows the wheel for a direct-manipulation feel, then flips to the back of the deck with spring easing
- **Vertical drag** flips the deck; **horizontal swipe** dismisses a card — an **Undo pill** appears (with a running count), and dismissing everything shows an **"all caught up" empty state** with a restore link
- **Click on a background card** brings it to the front; **dot indicators** show the position and are clickable
- **Long-press peek** lifts the front card and opens the post on release
- Subtle **cursor parallax** tilt on the deck, **blur depth** on background cards
- "Open more news" now **staggers** the cards into the list; "Close" glides them back into the stack (FLIP)
- **Keyboard**: arrows browse, Delete/Backspace dismisses; aria-live position status; `prefers-reduced-motion` disables all motion

## How

- `newsBlock.jsx`: deck state (`order` / dismissed stack) with gesture handlers; wheel is a native non-passive listener (React attaches `wheel` as passive, so `preventDefault` would be ignored); dismiss timers are cancellable so Undo works mid fly-out; the deck remounts via `key` when the feed changes
- Stack geometry is generalized from the fixed 3-card layout, so the deck works with any number of posts (`MAX_TWEETS` still 3)
- `postBlock.jsx`: `forwardRef` + layer props (`isHidden`, `isDismissing`, `isPeeking`); all stacked cards are absolutely positioned so they can morph between layers
- New strings go through `react-intl` (`defineMessages`); the existing `CLICK_ON_OPEN_MORE_NEWS` GA event is kept

## Verification

- `eslint`, `stylelint`, `tsc --noEmit` — clean; jest — green; webpack compiles
- Manually exercised on a local dev server against the beta feed: wheel/drag cycling, swipe dismiss → Undo (including mid-animation), dismiss-all → empty state → restore, expand/collapse, keyboard, peek, parallax — no console errors

Visual parity with the current login page is preserved (same geometry, typography, and colors); the only visible addition in the idle state is the dot indicators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Updates from UI team
* Added custom scroll instead of default
* If user clicks "Open more news", all available news (15 max) will be displayed within scroll area.

### Visuals

https://github.com/user-attachments/assets/45a47942-bbf2-495c-aa27-c32bd82b4fb9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the news list with an interactive carousel-style card deck supporting drag/swipe dismissal, mouse wheel/arrow-key navigation, long-press peeking, and an undoable dismiss flow.
  * Added position indicators, undo/dismiss messaging, and an animated empty state when all items are removed.
  * Enhanced motion with smooth transitions, cursor tilt, and reduced-motion support; limited the deck to a maximum number of posts.
* **Refactor**
  * Updated the post card component to support hidden/dismissing/peeking stacked states with improved styling control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->