### PR TITLE
EPMRPP-114398 || Fix redirect to All Organizations after Service unavailable refresh

### DIFF
--- a/app/src/components/containers/initialDataContainer/initialDataContainer.jsx
+++ b/app/src/components/containers/initialDataContainer/initialDataContainer.jsx
@@ -25,7 +25,7 @@ import {
   serviceAvailabilitySelector,
   LAST_VISITED_PATH_STORAGE_KEY,
 } from 'controllers/initialData';
-import { getSessionItem, removeSessionItem } from 'common/utils';
+import { removeSessionItem } from 'common/utils';
 import { ServiceUnavailableScreen } from './serviceUnavailableScreen';
 
 @connect(
@@ -62,28 +62,15 @@ export class InitialDataContainer extends Component {
   componentDidUpdate(prevProps) {
     if (
       prevProps.isInitialDataReady !== this.props.isInitialDataReady &&
-      this.props.isInitialDataReady
+      this.props.isInitialDataReady &&
+      !this.props.serviceAvailability.apiUnavailable
     ) {
       this.props.initialDispatch();
     }
   }
 
   refreshPage = () => {
-    const storedLastPath = getSessionItem(LAST_VISITED_PATH_STORAGE_KEY);
     removeSessionItem(LAST_VISITED_PATH_STORAGE_KEY);
-
-    const currentPath = window.location.hash.replace(/^#/, '');
-    const fallbackPath = currentPath.startsWith('/') ? currentPath : '/login';
-    const targetPath =
-      typeof storedLastPath === 'string' && storedLastPath.startsWith('/')
-        ? storedLastPath
-        : fallbackPath;
-    const normalizedHash = targetPath.startsWith('#') ? targetPath : `#${targetPath}`;
-
-    if (window.location.hash !== normalizedHash) {
-      window.location.hash = normalizedHash;
-    }
-
     window.location.reload();
   };
 


### PR DESCRIPTION
## Summary

Fixes wrong navigation after clicking **Refresh page** on the **Service unavailable** screen: the user was sent to **All Organizations** (via `/login`) instead of the page they were on (e.g. Filters).

## Problem

When API is down and the app reloads:

1. `setInitialDataReady` still runs, so `initialDispatch` starts routing while the user is not authorized yet.
2. `onBeforeRouteChange` redirects to `/login` and overwrites `lastVisitedPath` in session storage with `/login`.
3. **Refresh page** restored that stored path, then after a successful load the authorized user on the login route was redirected by `getLastPathRoute || getRedirectRoute` — often to **All Organizations**.

## Solution

- Skip `initialDispatch` while `serviceAvailability.apiUnavailable` is true, so the current URL (e.g. Filters) is not replaced by `/login`.
- On **Refresh page**, only clear `lastVisitedPath` and reload — do not rewrite `window.location.hash` from session storage (which could still hold a stale `/login`).


## Visuals


https://github.com/user-attachments/assets/6428b11d-d178-4b33-a3d9-e42e7077c063



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial data loading behavior when the API becomes available.
  * Simplified page refresh handling to ensure the stored last-visited path is cleared before reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->