### PR TITLE
EPMRPP-117853 || The row with '+New' button is hidden for 'Attribute Presence' column

### DIFF
--- a/app/src/componentLibrary/autocompletes/common/autocompleteOptions.jsx
+++ b/app/src/componentLibrary/autocompletes/common/autocompleteOptions.jsx
@@ -40,6 +40,7 @@ export class AutocompleteOptions extends Component {
     createWithoutConfirmation: PropTypes.bool,
     variant: autocompleteVariantType,
     creatable: PropTypes.bool,
+    optionsMaxHeight: PropTypes.number,
   };
 
   static defaultProps = {
@@ -55,6 +56,7 @@ export class AutocompleteOptions extends Component {
     createWithoutConfirmation: false,
     variant: 'light',
     creatable: true,
+    optionsMaxHeight: 140,
   };
 
   filterStaticOptions = () => {
@@ -124,13 +126,13 @@ export class AutocompleteOptions extends Component {
   };
 
   render() {
-    const { async, options, createWithoutConfirmation, creatable } = this.props;
+    const { async, options, createWithoutConfirmation, creatable, optionsMaxHeight } = this.props;
     const availableOptions = async ? options : this.filterStaticOptions();
     const prompt = this.getPrompt(options);
     if (prompt) return prompt;
     return (
       <div className={cx({ container: options.length })}>
-        <ScrollWrapper autoHeight autoHeightMax={140}>
+        <ScrollWrapper autoHeight autoHeightMax={optionsMaxHeight}>
           {this.renderItems(availableOptions)}
         </ScrollWrapper>
         {!createWithoutConfirmation &&

--- a/app/src/componentLibrary/autocompletes/singleAutocomplete/singleAutocomplete.jsx
+++ b/app/src/componentLibrary/autocompletes/singleAutocomplete/singleAutocomplete.jsx
@@ -26,7 +26,18 @@ import { scrollIntoAutocompleteMenu } from '../common/scrollIntoAutocompleteMenu
 
 const DEFAULT_OPTIONS_INDEX = 0;
 
+const DEFAULT_OPTIONS_MAX_HEIGHT = 140;
+const MIN_OPTIONS_MAX_HEIGHT = 60;
+const MENU_BASE_OVERHEAD = 20; // .menu margin-top (4) + .container margins (8 + 8)
+const NEW_ITEM_OVERHEAD = 53; // divider (1 + 8 + 8) + .new-item min-height (36)
+
 export class SingleAutocomplete extends Component {
+  referenceEl = null;
+
+  state = {
+    optionsMaxHeight: DEFAULT_OPTIONS_MAX_HEIGHT,
+  };
+
   static propTypes = {
     options: PropTypes.array,
     loading: PropTypes.bool,
@@ -56,6 +67,9 @@ export class SingleAutocomplete extends Component {
     stateReducer: PropTypes.func,
     variant: autocompleteVariantType,
     useFixedPositioning: PropTypes.bool,
+    // Opt-in: clamp options list height to fit space below the field, so the menu
+    // never overflows the viewport.
+    adaptiveOptionsHeight: PropTypes.bool,
     creatable: PropTypes.bool,
   };
 
@@ -87,7 +101,29 @@ export class SingleAutocomplete extends Component {
     stateReducer: (state, changes) => changes,
     variant: 'light',
     useFixedPositioning: false,
+    adaptiveOptionsHeight: false,
     creatable: true,
+  };
+
+  setReferenceEl = (popperRef) => (el) => {
+    popperRef(el);
+    this.referenceEl = el;
+  };
+
+  // Shrink the options list to fit the space below the field, so the menu never
+  // overflows the viewport. The new-item row is rendered outside the ScrollWrapper
+  // and always stays visible.
+  recalcOptionsMaxHeight = () => {
+    if (!this.referenceEl) return;
+    const { createWithoutConfirmation, creatable } = this.props;
+    const hasNewItemRow = creatable && !createWithoutConfirmation;
+    const overhead = MENU_BASE_OVERHEAD + (hasNewItemRow ? NEW_ITEM_OVERHEAD : 0);
+    const { bottom } = this.referenceEl.getBoundingClientRect();
+    const available = window.innerHeight - bottom - overhead;
+    const next = Math.min(DEFAULT_OPTIONS_MAX_HEIGHT, Math.max(MIN_OPTIONS_MAX_HEIGHT, available));
+    if (next !== this.state.optionsMaxHeight) {
+      this.setState({ optionsMaxHeight: next });
+    }
   };
 
   getOptionProps = (getItemProps, highlightedIndex, selectedItem) => ({ item, index, ...rest }) =>
@@ -132,6 +168,7 @@ export class SingleAutocomplete extends Component {
       stateReducer,
       variant,
       useFixedPositioning,
+      adaptiveOptionsHeight,
       creatable,
       ...props
     } = this.props;
@@ -141,7 +178,13 @@ export class SingleAutocomplete extends Component {
           onChange={onChange}
           itemToString={parseValueToString}
           selectedItem={value}
-          onStateChange={onStateChange}
+          onStateChange={(changes, ...args) => {
+            onStateChange?.(changes, ...args);
+
+            if (adaptiveOptionsHeight && changes?.isOpen) {
+              this.recalcOptionsMaxHeight();
+            }
+          }}
           defaultHighlightedIndex={DEFAULT_OPTIONS_INDEX}
           stateReducer={stateReducer}
           scrollIntoView={scrollIntoAutocompleteMenu}
@@ -158,7 +201,7 @@ export class SingleAutocomplete extends Component {
             <div>
               <Reference>
                 {({ ref }) => (
-                  <div ref={ref}>
+                  <div ref={this.setReferenceEl(ref)}>
                     <FieldText
                       {...getInputProps({
                         placeholder: !disabled ? placeholder : '',
@@ -227,6 +270,7 @@ export class SingleAutocomplete extends Component {
                     createWithoutConfirmation={createWithoutConfirmation}
                     className={menuClassName}
                     options={options}
+                    optionsMaxHeight={this.state.optionsMaxHeight}
                     variant={variant}
                     creatable={creatable}
                     {...props}


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes

**Problem.** `SingleAutocomplete` uses a fixed `optionsMaxHeight = 140`. When the field sits near the viewport bottom, the menu (options + divider + "+ New value" row) overflows below the viewport. `react-popper` v1 has no viewport-height awareness.

**Fix.** Added an opt-in prop `adaptiveOptionsHeight` on `SingleAutocomplete`. On menu open it clamps the internal `ScrollWrapper` height to the space between the field and the viewport bottom, accounting for menu padding and margins and, when present, the "+ New value" row + divider. The row is rendered outside the scroll area and remains visible. Default is `false`, so existing consumers are unaffected.

**Files changed.**
- singleAutocomplete.jsx
- autocompleteOptions.jsx

## Links
[EPMRPP-117853](https://jiraeu.epam.com/browse/EPMRPP-117853)

## Visuals
**_Before:_**

https://github.com/user-attachments/assets/d7b63171-e9e4-4e37-86f5-6b28d4f62bfd

**_After:_**

https://github.com/user-attachments/assets/d6397daf-d5d0-4c4d-8bc9-708b69ccf75b




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum heights for autocomplete option menus.
  * Added an opt-in adaptive height mode that adjusts the menu to fit available screen space.
  * Improved autocomplete usability near the bottom of the viewport by preventing menus from extending beyond visible space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->