### PR TITLE
EPMRPP-117867 || Render static attachment icons without async Image fetch

### DIFF
--- a/app/src/pages/inside/logsPage/logsGrid/attachmentBlock/attachmentBlock.jsx
+++ b/app/src/pages/inside/logsPage/logsGrid/attachmentBlock/attachmentBlock.jsx
@@ -33,6 +33,7 @@ import {
 } from 'controllers/log/attachments';
 import { AttachmentActions } from 'pages/inside/logsPage/attachmentActions';
 import { LOGS_SIZE, DEFAULT_LOGS_SIZE } from 'common/constants/logsSettings';
+import { IMAGE } from 'common/constants/fileTypes';
 import styles from './attachmentBlock.scss';
 
 const cx = classNames.bind(styles);
@@ -79,6 +80,7 @@ export class AttachmentBlock extends Component {
   render() {
     const { value, customProps, projectKey } = this.props;
     const { consoleView, logsSize = DEFAULT_LOGS_SIZE } = customProps;
+    const isImage = value.contentType?.toLowerCase().split('/')[0] === IMAGE;
     const isValidToOpenInModal = isFileActionAllowed(
       value.contentType,
       OPEN_ATTACHMENT_IN_MODAL_ACTION,
@@ -96,6 +98,7 @@ export class AttachmentBlock extends Component {
               className={cx('attachment', `attachment-size-${logsSize}`)}
               src={getFileIconSource(value, projectKey, true)}
               alt={value.contentType}
+              isStatic={!isImage}
               onClick={isValidToOpenInModal ? this.openAttachmentInModal : null}
             />
             <AttachmentActions


### PR DESCRIPTION
## Summary

Fixes layout jump on the All Logs grid when non-image attachment icons (e.g. Mobitru `video/mp4`) load after **Jump to Log** from the Remote device tab (EPMRPP-117867). Async fetch of a static SVG icon changed row height after scroll, so the highlighted target log moved out of place.

## Changes

- In `AttachmentBlock`, pass `isStatic={!isImage}` to `Image` so non-image previews (static SVG from `getFileIconSource`) render immediately without loader/fetch, matching the existing pattern in attachments carousel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment previews by distinguishing image files from other attachment types.
  * Non-image attachments now display appropriately while preserving existing download and modal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->