### PR TITLE
EPMRPP-117287 || Undefined word is displayed instead of Project abbreviation when logging out

### DIFF
--- a/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
+++ b/app/src/layouts/organizationLayout/organizationSidebar/organizationSidebar.jsx
@@ -115,7 +115,7 @@ export const OrganizationSidebar = ({ onClickNavBtn }) => {
     payload: { organizationSlug },
   };
   const titles = {
-    shortTitle: `${organizationName?.[0]}${organizationName?.[organizationName.length - 1]}`,
+    entityName: organizationName,
     topTitle: formatMessage(messages.allOrganizations),
     bottomTitle: <PreservedText>{organizationName}</PreservedText>,
     level: 'organization',

--- a/app/src/layouts/organizationsControl/organizationsControl.jsx
+++ b/app/src/layouts/organizationsControl/organizationsControl.jsx
@@ -24,6 +24,7 @@ import { SIDEBAR_EVENTS } from 'components/main/analytics/events';
 import ArrowLeftIcon from './img/arrow-left-inline.svg';
 import OpenPopoverIcon from './img/open-popover-inline.svg';
 import { OrganizationsPopover } from './organizationsPopover/organizationsPopover';
+import { useShortTitle } from './useShortTitle';
 import styles from './organizationsControl.scss';
 
 const cx = classNames.bind(styles);
@@ -38,11 +39,11 @@ export const OrganizationsControl = ({
   isSidebarExpanded = true,
 }) => {
   const { trackEvent } = useTracking();
+  const shortTitle = useShortTitle(titles.entityName, titles.shortTitle);
+
   return (
     <button type="button" className={cx('organizations-control-wrapper')} onClick={onClick}>
-      <span className={cx('short-title', { 'no-uppercase': !isExtendedNav })}>
-        {titles.shortTitle}
-      </span>
+      <span className={cx('short-title')}>{shortTitle}</span>
       <span className={cx('organizations-control')} inert={!isSidebarExpanded || undefined}>
         <div className={cx('organizations-control-content')}>
           <div

--- a/app/src/layouts/organizationsControl/organizationsControl.scss
+++ b/app/src/layouts/organizationsControl/organizationsControl.scss
@@ -230,7 +230,6 @@
   border-radius: 8px;
   cursor: pointer;
   color: var(--rp-ui-base-dark-e-100);
-  text-transform: uppercase;
   text-align: center;
   font-size: 13px;
   line-height: 20px;
@@ -247,8 +246,4 @@
     font-size: 13px;
     line-height: 20px;
   }
-}
-
-.no-uppercase {
-  text-transform: none;
 }

--- a/app/src/layouts/organizationsControl/useShortTitle.js
+++ b/app/src/layouts/organizationsControl/useShortTitle.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getShortTitle } from './utils';
+
+let cachedShortTitle = '';
+
+export const useShortTitle = (entityName, fallback = '') => {
+  if (entityName) {
+    cachedShortTitle = getShortTitle(entityName).toUpperCase();
+  } else if (fallback) {
+    cachedShortTitle = fallback;
+  }
+
+  return entityName ? cachedShortTitle : fallback || cachedShortTitle;
+};

--- a/app/src/layouts/organizationsControl/utils.js
+++ b/app/src/layouts/organizationsControl/utils.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const getShortTitle = (name) => {
+  if (!name) {
+    return '';
+  }
+
+  return `${name[0]}${name[name.length - 1]}`;
+};

--- a/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
+++ b/app/src/layouts/projectLayout/projectSidebar/projectSidebar.jsx
@@ -268,7 +268,7 @@ export const ProjectSidebar = ({ onClickNavBtn }) => {
     payload: { organizationSlug, projectSlug },
   };
   const titles = {
-    shortTitle: `${projectName[0]}${projectName[projectName.length - 1]}`,
+    entityName: projectName,
     topTitle: (
       <PreservedText>
         {formatMessage(messages.organization)}: {organizationName}


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
Fixed sidebar short title flashing as “NEDUNDE” on logout and when switching organization/project levels. The root cause was interpolating first/last characters of a missing name into `"undefinedundefined"`. Short titles are now derived safely via a shared cached helper in OrganizationsControl, which keeps the last valid abbreviation (or “All” on instance level) until a real entity name is available.

**Checklist**
- No more unsafe `` `${name[0]}${name[last]}` `` in org/project sidebars → no `"undefinedundefined"` / **NEDUNDE**
- Shared `useShortTitle` in `OrganizationsControl` with module cache → keeps last abbreviation on logout / level switch when name is cleared
- Instance still uses `"All"` as fallback; org/project pass `entityName`
- Uppercase via JS on abbreviations only (no CSS `text-transform`), so `"All"` stays correct

## Links
[EPMRPP-117287](https://jiraeu.epam.com/browse/EPMRPP-117287)

## Visuals

https://github.com/user-attachments/assets/ea7f3f12-807a-47e7-b058-67518d067f64




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated organization and project navigation labels to generate short titles consistently.
  * Preserved short-title displays when switching between navigation contexts.
  * Improved label casing so names appear naturally without forced uppercase styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->