### PR TITLE
EPMRPP-117868 || Avoid nested scan when Jump to Log cannot find the log

### DIFF
--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -22,6 +22,7 @@ import { DEFAULT_PAGE_SIZE, PAGE_KEY, SIZE_KEY } from 'controllers/pagination';
 
 const LEVEL_FILTER_KEYS = [LOG_LEVEL_FILTER_KEY, 'filter.eq.level'];
 const NESTED_QUERY_OMIT_KEYS = [...LEVEL_FILTER_KEYS, PAGE_KEY, SIZE_KEY];
+const LOG_ID_FILTER_KEY = 'filter.eq.logId';
 
 const LOCATION_QUERY_VARIANTS = [
   { 'filter.eq.level': 'mobitru' },
@@ -40,6 +41,9 @@ const getRootPageSize = (logQueryParams = {}) =>
 const buildNestedGridQueryParams = (logQueryParams = {}) =>
   omit(logQueryParams, NESTED_QUERY_OMIT_KEYS);
 
+const getLocationsSearchUrl = (projectKey, retryId) =>
+  URLS.searchLogs(projectKey, retryId).split('?')[0];
+
 const normalizePageResponse = (response) => {
   if (Array.isArray(response)) {
     return { content: response, page: { totalPages: 1 } };
@@ -49,6 +53,22 @@ const normalizePageResponse = (response) => {
     content: response?.content ?? [],
     page: response?.page ?? { totalPages: 1 },
   };
+};
+
+const searchLogLocationById = async ({ fetchFn, projectKey, retryId, logId, logQueryParams }) => {
+  const response = await fetchFn(getLocationsSearchUrl(projectKey, retryId), {
+    params: {
+      excludeLogContent: true,
+      [SIZE_KEY]: getRootPageSize(logQueryParams),
+      [PAGE_KEY]: 1,
+      ...(logQueryParams['page.sort'] ? { 'page.sort': logQueryParams['page.sort'] } : {}),
+      [LOG_ID_FILTER_KEY]: logId,
+    },
+  });
+
+  const { content } = normalizePageResponse(response);
+
+  return findLogInLocationsPage(content, logId) || null;
 };
 
 const fetchLocationsPage = ({ fetchFn, url, page, logQueryParams, extraParams }) =>
@@ -365,17 +385,14 @@ const resolveMobitruLogFromNestedGrid = async ({
   });
 };
 
-export const resolveMobitruLogForJump = async ({
+const resolveMobitruLogViaLegacyFallback = async ({
   fetchFn,
   projectKey,
   retryId,
   itemId,
   logId,
-  logQuery,
+  logQueryParams,
 }) => {
-  const url = URLS.searchLogs(projectKey, retryId).split('?')[0];
-  const logQueryParams = buildLocationQueryParams(logQuery);
-
   const nestedResult = await resolveMobitruLogFromNestedGrid({
     fetchFn,
     projectKey,
@@ -389,12 +406,53 @@ export const resolveMobitruLogForJump = async ({
     return nestedResult;
   }
 
-  const logInfoFromLocations = await searchWithQueryVariants({
+  return searchWithQueryVariants({
     fetchFn,
-    url,
+    url: getLocationsSearchUrl(projectKey, retryId),
     logId,
     logQueryParams,
   });
+};
 
-  return logInfoFromLocations;
+export const resolveMobitruLogForJump = async ({
+  fetchFn,
+  projectKey,
+  retryId,
+  itemId,
+  logId,
+  logQuery,
+}) => {
+  const logQueryParams = buildLocationQueryParams(logQuery);
+
+  try {
+    const logInfoFromSearch = await searchLogLocationById({
+      fetchFn,
+      projectKey,
+      retryId,
+      logId,
+      logQueryParams,
+    });
+
+    if (!logInfoFromSearch) {
+      return null;
+    }
+  } catch {
+    return resolveMobitruLogViaLegacyFallback({
+      fetchFn,
+      projectKey,
+      retryId,
+      itemId,
+      logId,
+      logQueryParams,
+    });
+  }
+
+  return resolveMobitruLogViaLegacyFallback({
+    fetchFn,
+    projectKey,
+    retryId,
+    itemId,
+    logId,
+    logQueryParams,
+  });
 };

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.js
@@ -68,7 +68,7 @@ const searchLogLocationById = async ({ fetchFn, projectKey, retryId, logId, logQ
 
   const { content } = normalizePageResponse(response);
 
-  return findLogInLocationsPage(content, logId) || null;
+  return content?.some((log) => +log.id === +logId) || null;
 };
 
 const fetchLocationsPage = ({ fetchFn, url, page, logQueryParams, extraParams }) =>

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -96,6 +96,31 @@ describe('resolveMobitruLogForJump', () => {
     expect(fetchFn.mock.calls[2][1].params['page.page']).toBe(2);
   });
 
+  test('should treat search hit without pagesLocation as existing and resolve via nested grid', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 10 }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 10, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 100,
+      logId: 10,
+    });
+
+    expect(result).toEqual({ id: 10, pagesLocation: [{ 10: 1 }] });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn.mock.calls[1][0]).toContain('/log/nested/');
+  });
+
   test('should use nested step page size matching loadStep pagination offset', async () => {
     const fetchFn = jest
       .fn()

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/utils/resolveMobitruLogForJump.test.js
@@ -18,9 +18,44 @@ import { PAGINATION_OFFSET } from 'controllers/log/nestedSteps/constants';
 import { resolveMobitruLogForJump } from './resolveMobitruLogForJump';
 
 describe('resolveMobitruLogForJump', () => {
-  test('should resolve log via nested grid using active root page size', async () => {
+  test('should fail fast with null when locations search has no hit', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      content: [],
+      page: { totalPages: 1, totalElements: 0 },
+    });
+
+    const result = await resolveMobitruLogForJump({
+      fetchFn,
+      projectKey: 'default_personal',
+      retryId: 100,
+      itemId: 100,
+      logId: 99,
+    });
+
+    expect(result).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringMatching(/\/log\/locations\/search\/\d+$/),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          'filter.eq.logId': 99,
+          excludeLogContent: true,
+        }),
+      }),
+    );
+  });
+
+  test('should ignore search pagesLocation and resolve via nested grid when log exists', async () => {
+    const wrongSearchLocation = {
+      id: 10,
+      pagesLocation: [{ 10: 1 }],
+    };
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [wrongSearchLocation],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [{ id: 1 }],
         page: { totalPages: 2 },
@@ -40,6 +75,14 @@ describe('resolveMobitruLogForJump', () => {
     });
 
     expect(result).toEqual({ id: 10, pagesLocation: [{ 10: 2 }] });
+    expect(fetchFn.mock.calls[0][0]).toMatch(/\/log\/locations\/search\/\d+$/);
+    expect(fetchFn.mock.calls[0][1].params).toEqual(
+      expect.objectContaining({
+        'filter.eq.logId': 10,
+        'page.size': 10,
+        'page.sort': 'logTime,ASC',
+      }),
+    );
     expect(fetchFn).toHaveBeenCalledWith(
       expect.stringContaining('/log/nested/'),
       expect.objectContaining({
@@ -49,13 +92,17 @@ describe('resolveMobitruLogForJump', () => {
         }),
       }),
     );
-    expect(fetchFn.mock.calls[1][1].params['page.size']).toBe(10);
-    expect(fetchFn.mock.calls[1][1].params['page.page']).toBe(2);
+    expect(fetchFn.mock.calls[2][1].params['page.size']).toBe(10);
+    expect(fetchFn.mock.calls[2][1].params['page.page']).toBe(2);
   });
 
   test('should use nested step page size matching loadStep pagination offset', async () => {
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 300, pagesLocation: [{ 200: 1 }, { 300: 1 }] }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -82,14 +129,18 @@ describe('resolveMobitruLogForJump', () => {
       id: 300,
       pagesLocation: [{ 200: 1 }, { 300: 2 }],
     });
-    expect(fetchFn.mock.calls[0][1].params['page.size']).toBe(10);
-    expect(fetchFn.mock.calls[1][1].params['page.size']).toBe(PAGINATION_OFFSET);
+    expect(fetchFn.mock.calls[1][1].params['page.size']).toBe(10);
     expect(fetchFn.mock.calls[2][1].params['page.size']).toBe(PAGINATION_OFFSET);
+    expect(fetchFn.mock.calls[3][1].params['page.size']).toBe(PAGINATION_OFFSET);
   });
 
   test('should resolve nested step mobitru log via nested grid', async () => {
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 300, pagesLocation: [{ 200: 9 }, { 300: 9 }] }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -116,6 +167,10 @@ describe('resolveMobitruLogForJump', () => {
   test('should resolve deeply nested mobitru log via recursive nested grid', async () => {
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 400, pagesLocation: [{ 200: 1 }, { 300: 1 }, { 400: 1 }] }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -145,14 +200,18 @@ describe('resolveMobitruLogForJump', () => {
       id: 400,
       pagesLocation: [{ 200: 1 }, { 300: 1 }, { 400: 1 }],
     });
-    expect(fetchFn.mock.calls[0][1].params['page.size']).toBe(50);
-    expect(fetchFn.mock.calls[2][1].params['page.size']).toBe(PAGINATION_OFFSET);
+    expect(fetchFn.mock.calls[1][1].params['page.size']).toBe(50);
     expect(fetchFn.mock.calls[3][1].params['page.size']).toBe(PAGINATION_OFFSET);
+    expect(fetchFn.mock.calls[4][1].params['page.size']).toBe(PAGINATION_OFFSET);
   });
 
   test('should resolve nested log by recursion when itemId is missing', async () => {
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 300, pagesLocation: [{ 200: 1 }, { 300: 1 }] }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
@@ -179,6 +238,10 @@ describe('resolveMobitruLogForJump', () => {
   test('should resolve nested log on page two via recursive nested grid', async () => {
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [{ id: 300, pagesLocation: [{ 200: 1 }, { 300: 1 }] }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [{ id: 1 }],
         page: { totalPages: 2 },
@@ -210,6 +273,10 @@ describe('resolveMobitruLogForJump', () => {
     const fetchFn = jest
       .fn()
       .mockResolvedValueOnce({
+        content: [{ id: 300, pagesLocation: [{ 200: 1 }, { 300: 1 }] }],
+        page: { totalPages: 1, totalElements: 1 },
+      })
+      .mockResolvedValueOnce({
         content: [{ id: 200, hasContent: true }],
         page: { totalPages: 1 },
       })
@@ -240,10 +307,14 @@ describe('resolveMobitruLogForJump', () => {
     });
   });
 
-  test('should fall back to locations search when nested grid cannot resolve log', async () => {
+  test('should fall back to locations level variants when nested grid cannot resolve log', async () => {
     const logInfo = { id: 10, pagesLocation: [{ 10: 1 }] };
     const fetchFn = jest
       .fn()
+      .mockResolvedValueOnce({
+        content: [logInfo],
+        page: { totalPages: 1, totalElements: 1 },
+      })
       .mockResolvedValueOnce({
         content: [],
         page: { totalPages: 1 },
@@ -277,25 +348,38 @@ describe('resolveMobitruLogForJump', () => {
     );
   });
 
-  test('should return null when log is not found', async () => {
-    const fetchFn = jest.fn().mockResolvedValue({
-      content: [],
-      page: { totalPages: 1 },
-    });
+  test('should fall back to nested grid when locations search request fails', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Search unavailable'))
+      .mockResolvedValueOnce({
+        content: [{ id: 200, hasContent: true }],
+        page: { totalPages: 1 },
+      })
+      .mockResolvedValueOnce({
+        content: [{ id: 300, level: 'mobitru' }],
+        page: { totalPages: 1 },
+      });
 
     const result = await resolveMobitruLogForJump({
       fetchFn,
       projectKey: 'default_personal',
       retryId: 100,
-      itemId: 100,
-      logId: 99,
+      itemId: 200,
+      logId: 300,
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      id: 300,
+      pagesLocation: [{ 200: 1 }, { 300: 1 }],
+    });
   });
 
-  test('should propagate nested grid API errors to caller', async () => {
-    const fetchFn = jest.fn().mockRejectedValue(new Error('Nested grid unavailable'));
+  test('should propagate nested grid API errors when locations search fails', async () => {
+    const fetchFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Search unavailable'))
+      .mockRejectedValueOnce(new Error('Nested grid unavailable'));
 
     await expect(
       resolveMobitruLogForJump({
@@ -311,6 +395,7 @@ describe('resolveMobitruLogForJump', () => {
   test('should propagate locations API errors when nested grid misses the log', async () => {
     const fetchFn = jest
       .fn()
+      .mockRejectedValueOnce(new Error('Search unavailable'))
       .mockResolvedValueOnce({
         content: [],
         page: { totalPages: 1 },


### PR DESCRIPTION
## Summary

Fixes a long delay (about 10–20 seconds) and a burst of API requests between **Jump to Log** on the Remote device tab and the error toaster when the target Mobitru log is deleted or cannot be resolved (EPMRPP-117868).

## Changes

- Before resolving `pagesLocation`, call `log/locations/search` with `filter.eq.logId`; empty result returns immediately so the error toaster can show without scanning nested pages
- When the log exists, keep resolving `pagesLocation` via the nested grid (root `page.size` + nested page size 300) so Jump still lands on the correct row after pagination changes
- On search request failure, keep the previous nested grid / locations level-filter fallback
- Extend unit tests for fail-fast, nested resolution, and fallback paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation to Mobitru log entries from jump links.
  * Added a faster, more precise way to locate logs by their identifier.
  * Preserved fallback behavior when the primary log search is unavailable or cannot find a match.
  * Improved handling of missing logs and search failures, providing more reliable navigation results.
* **Tests**
  * Expanded coverage for successful lookups, missing results, pagination, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->