### PR TITLE
EPMRPP-117890 || Pre-fill attributes in Duplicate Test Plan modal

### DIFF
--- a/app/src/pages/inside/testPlansPage/testPlanModals/duplicateTestPlanModal/duplicateTestPlanModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanModals/duplicateTestPlanModal/duplicateTestPlanModal.tsx
@@ -47,7 +47,7 @@ export const DuplicateTestPlanModal = ({ data, onSuccess }: DuplicateTestPlanMod
       initialValues={{
         name: `${data.name} (1)`,
         description: data.description,
-        attributes: [],
+        attributes: data.attributes || [],
       }}
       onSubmit={duplicateTestPlan}
     />


### PR DESCRIPTION
## Summary

Fixes Duplicate Test Plan modal not pre-filling Test plan attributes from the original plan (EPMRPP-117890). Name and description were already copied; attributes were reset to an empty list, so the duplicated plan was created without them.

## Changes

- Initialize Duplicate Test Plan modal `attributes` from `data.attributes` (same pattern as Edit Test Plan)

## Visuals

https://github.com/user-attachments/assets/ca21c80b-a4cf-458f-9174-ab602bf9bf7b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicating a test plan now pre-fills its attributes from the original plan when available.
  * Preserves existing attribute selections during the duplication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->