### PR TITLE
EPMRPP-117908 || TMS. Impossible to Post and Link issue

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/BTSIssuesModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/BTSIssuesModal.tsx
@@ -25,8 +25,11 @@ import { fetch, commonValidators, uniqueId, createClassnames } from 'common/util
 import { URLS } from 'common/urls';
 import { withModal } from 'controllers/modal';
 import { showSuccessNotification, showErrorNotification } from 'controllers/notification';
-import { projectKeySelector } from 'controllers/project';
+import { projectKeySelector, projectInfoSelector } from 'controllers/project';
+import { activeOrganizationIdSelector } from 'controllers/organization';
 import { useModalButtons } from 'hooks/useModalButtons';
+import { buildPluginCommandRQ } from 'controllers/plugins/utils';
+import { COMMAND_POST_ISSUE } from 'controllers/plugins/uiExtensions/constants';
 import {
   getDefaultIssueModalConfig,
   getDefaultOptionValueKey,
@@ -101,6 +104,8 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
   >;
   const userId = useSelector(userIdSelector);
   const projectKey = useSelector(projectKeySelector);
+  const projectInfo = useSelector(projectInfoSelector);
+  const organizationId = useSelector(activeOrganizationIdSelector);
   const launchId = useManualLaunchId();
   const execution = useSelector(activeManualLaunchExecutionSelector);
 
@@ -266,14 +271,59 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
 
   const postIssue = useCallback(
     (issueData: Record<string, unknown>, onSuccess: () => void) => {
-      const url = URLS.btsIntegrationPostTicket(projectKey, integrationId);
+      const integration = namedBtsIntegrations[pluginName]?.find(
+        (item: BTSIntegration) => item.id === integrationId,
+      );
+
+      if (!integration) {
+        return;
+      }
+
+      const {
+        integrationParameters: { project: btsProject, url: btsUrl },
+      } = integration;
+      const allowedCommands: string[] = integration.integrationType?.details?.allowedCommands ?? [];
+      const isCommandAvailable = allowedCommands.includes(COMMAND_POST_ISSUE);
+      const requestParams: { data: Record<string, unknown>; method: string } = {
+        data: issueData,
+        method: 'POST',
+      };
+      let url = URLS.btsIntegrationPostTicket(projectKey, integrationId);
+
+      if (isCommandAvailable) {
+        url = URLS.pluginsCommandsCommon(pluginName, COMMAND_POST_ISSUE);
+        requestParams.data = buildPluginCommandRQ({
+          integrationId,
+          organizationId,
+          projectId: projectInfo.projectId,
+          projectKey,
+          arguments: {
+            projectId: projectInfo.projectId,
+            entity: issueData,
+          },
+        });
+      }
 
       setIsLoading(true);
 
-      fetch(url, {
-        method: 'POST',
-        data: issueData,
-      })
+      fetch(url, requestParams)
+        .then((response: { id: string; url: string }) => {
+          return fetch(URLS.testItemsLinkIssues(projectKey), {
+            method: 'PUT',
+            data: {
+              issues: [
+                {
+                  ticketId: response.id,
+                  url: response.url,
+                  btsProject,
+                  btsUrl,
+                  pluginName,
+                },
+              ],
+              testItemIds: [execution.testItemId],
+            },
+          });
+        })
         .then(() => {
           if (!isMountedRef.current) return;
           setIsLoading(false);
@@ -295,7 +345,18 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
           );
         });
     },
-    [projectKey, integrationId, dispatch, formatMessage, refreshExecutionData],
+    [
+      projectKey,
+      integrationId,
+      pluginName,
+      namedBtsIntegrations,
+      organizationId,
+      projectInfo,
+      execution,
+      dispatch,
+      formatMessage,
+      refreshExecutionData,
+    ],
   );
 
   const linkIssue = useCallback(

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/BTSIssuesModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/BTSIssuesModal.tsx
@@ -306,6 +306,8 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
 
       setIsLoading(true);
 
+      const testItemId = execution.testItemId || executionId;
+
       fetch(url, requestParams)
         .then((response: { id: string; url: string }) => {
           return fetch(URLS.testItemsLinkIssues(projectKey), {
@@ -320,7 +322,7 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
                   pluginName,
                 },
               ],
-              testItemIds: [execution.testItemId],
+              testItemIds: [testItemId],
             },
           });
         })
@@ -414,13 +416,15 @@ const BTSIssuesModalComponent: FC<BTSIssuesModalProps> = ({
         return;
       }
 
+      const testItemId = execution.testItemId || executionId;
+
       setIsLoading(true);
 
       fetch(url, {
         method: 'PUT',
         data: {
           issues,
-          testItemIds: [execution.testItemId],
+          testItemIds: [testItemId],
         },
       })
         .then(() => {

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/types.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/BTSIssuesModal/types.ts
@@ -30,6 +30,7 @@ export interface BTSIntegration {
   integrationType: {
     details: {
       name: string;
+      allowedCommands?: string[];
     };
   };
   integrationParameters: {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Root cause**
`BTSIssuesModal` (Manual Launches → Post or Link Issue) had two broken flows:

**Post Issue**
The original implementation only did a single POST to BTS (e.g. `/bts/{project}/{integrationId}/ticket`) and never followed up to link the created ticket to the test item in ReportPortal, so the ticket was posted in Jira but not stored anywhere in RP.

Additionally, the URL/request-params logic was incomplete — it always used `btsIntegrationPostTicket`, ignoring the `allowedCommands`/plugin-commands flow required for plugin-based integrations (e.g. Jira via command).

**Changes made (BTSIssuesModal.tsx)**
- Added `isCommandAvailable` check: switches URL to `pluginsCommandsCommon` and builds request via `buildPluginCommandRQ` (matching `postIssueModal` logic exactly)
- Added a second PUT to `testItemsLinkIssues` after a successful POST, to register the new ticket in RP against the test item
- Extracted `btsProject` / `btsUrl` from the integration (needed for the link payload)
- Added missing selectors: `projectInfoSelector`, `activeOrganizationIdSelector`
- Updated `useCallback` deps accordingly

**Changes made (types.ts)**
- Added `allowedCommands?: string[]` to `BTSIntegration.integrationType.details`

## Links
[EPMRPP-117908](https://jiraeu.epam.com/browse/EPMRPP-117908)

## Visuals

https://github.com/user-attachments/assets/0a4623b0-4349-46da-943c-28181edb8f9c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for posting BTS issues through compatible plugin commands.
  * Automatically uses the standard ticket flow when plugin-command posting is unavailable.
  * Links newly created tickets to the related test item with project and integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->