### PR TITLE
EPMRPP-118140 || Manual Launch details sidebar Done button is disabled when To Run is zero

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/launchSidePanel/launchSidePanel.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/launchSidePanel/launchSidePanel.tsx
@@ -122,7 +122,14 @@ export const LaunchSidePanel = memo(
       );
     }
 
+    const { total, passed, failed, skipped, toRun, inProgress } = launchDetails.executionStatistic;
+
     const handleToRunClick = () => {
+      if (toRun === 0) {
+        onClose();
+        return;
+      }
+
       if (launchId) {
         trackEvent(
           MANUAL_LAUNCHES_PAGE_EVENTS.clickShowToRun(MANUAL_LAUNCHES_PLACE.LAUNCH_DETAILS_SIDEBAR),
@@ -153,8 +160,6 @@ export const LaunchSidePanel = memo(
         console.error('Failed to copy ID:', error);
       });
     };
-
-    const { total, passed, failed, skipped, toRun, inProgress } = launchDetails.executionStatistic;
 
     const { testPlan, owner, type, startTime } = launchDetails;
 
@@ -271,7 +276,6 @@ export const LaunchSidePanel = memo(
           variant="primary"
           className={cx('action-button', 'last-button')}
           onClick={handleToRunClick}
-          disabled={toRun === 0}
           data-automation-id="launch-to-run"
         >
           {formatMessage(toRun ? messages.toRunWithCount : COMMON_LOCALE_KEYS.DONE, {


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

before condition fix :

https://github.com/user-attachments/assets/b36968f8-ab31-46c9-b5e1-5deb03f43dd9

after condition fix :

https://github.com/user-attachments/assets/54cd8984-4429-44ef-b6fb-4fdc3c2149d3


<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch side-panel behavior when there are no remaining items to run.
  * Selecting the primary action in this state now closes the panel without triggering unnecessary navigation or actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->