### PR TITLE
EPMRPP-115035 || cross icon is missing in Project field

### DIFF
--- a/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
+++ b/app/src/pages/inside/common/assignments/instanceAssignment/instanceAssignment.tsx
@@ -503,7 +503,7 @@ export const InstanceAssignment = ({
                 key={`project-${selectedOrganizationId}-${invitedUserId}`}
                 inputProps={{
                   label: formatMessage(messages.project),
-                  clearable: totalProjects > 0 && !!selectedOrganizationId,
+                  clearable: !!selectedOrganizationId,
                   placeholder: formatMessage(invitationMessages.selectSearchProject),
                   onClear: () => {
                     dispatch(change(formName, FORM_FIELDS.ORGANIZATION.PROJECTS.NAME, null));
@@ -526,8 +526,6 @@ export const InstanceAssignment = ({
                     ? formatMessage(invitationMessages.noProjectsCreated)
                     : formatMessage(COMMON_LOCALE_KEYS.NO_AVAILABLE_OPTIONS)
                 }
-                isDropdownMode={totalProjects === 0 && selectedOrganizationId}
-                icon={totalProjects === 0 && selectedOrganizationId ? <div /> : undefined}
                 useFixedPositioning
                 dropdownMatchInputWidth
               />


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
fixed conditions to show the clear icon, in Invite user modal, create user modal, manage assignments modal

## Visuals
before:

https://github.com/user-attachments/assets/c4513d99-6f7d-46b6-bddb-9f0f51fe5845

after: 

https://github.com/user-attachments/assets/cf168524-802d-453c-86b2-ac42aa137e95




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project selection in the instance add-organization form by ensuring the clear option is available whenever an organization is selected.
  - Restored the standard dropdown and icon behavior for project selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->