### PR TITLE
EPMRPP-117286 || Fix Auto-analysis badge clipping for long launch names in Safari

### DIFF
--- a/app/src/pages/inside/common/itemInfo/itemInfo.jsx
+++ b/app/src/pages/inside/common/itemInfo/itemInfo.jsx
@@ -179,6 +179,7 @@ export class ItemInfo extends Component {
               )}
             </ItemNameTooltip>
           </NameLink>
+          <wbr />
           <span className={cx('edit-number-box')}>
             <NameLink
               itemId={value.id}
@@ -189,12 +190,12 @@ export class ItemInfo extends Component {
               {value.number && <span className={cx('number')}>#{value.number}</span>}
             </NameLink>
             {autoAnalysisLabel && (
-              <div className={cx('item-badge', 'auto-analysis')}>Auto-analysis</div>
+              <span className={cx('item-badge', 'auto-analysis')}>Auto-analysis</span>
             )}
             {patternAnalyzingLabel && (
-              <div className={cx('item-badge', 'pattern-analysis')}>Pattern-analysis</div>
+              <span className={cx('item-badge', 'pattern-analysis')}>Pattern-analysis</span>
             )}
-            {value.rerun && <div className={cx('item-badge', 'rerun')}>Rerun</div>}
+            {value.rerun && <span className={cx('item-badge', 'rerun')}>Rerun</span>}
             {!hideEdit && (
               <span className={cx('edit-icon')} onClick={this.handleEditItem}>
                 {Parser(PencilIcon)}

--- a/app/src/pages/inside/common/itemInfo/itemInfo.scss
+++ b/app/src/pages/inside/common/itemInfo/itemInfo.scss
@@ -80,7 +80,9 @@
 }
 
 .edit-number-box {
+  display: inline-block;
   white-space: nowrap;
+  vertical-align: baseline;
 }
 
 .number {


### PR DESCRIPTION
## Summary

Fixes Safari UI issue where the "Auto-analysis" badge (and related launch badges) was clipped for launches with long names.

Keeps the number and badges in the normal inline flow after the launch name, so they follow the end of the wrapped name instead of being cut by overflow.

## Changes

- Make `.edit-number-box` an `inline-block` unit so Safari can wrap it as a whole when it does not fit on the current line
- Add a `<wbr />` before the number/badges block to provide an explicit break opportunity
- Replace badge `div` elements with `span` to keep valid inline markup inside the number box


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved item name wrapping to prevent awkward line breaks around external-link icons.
  * Updated analysis and rerun status badges for more consistent inline display.
  * Improved alignment of editable item numbers while preserving no-wrap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->