### PR TITLE
EPMRPP-117064 || Allow copying confirmation word in Delete Milestone modal on WebKit

### DIFF
--- a/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/deleteMilestoneModal.scss
+++ b/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/deleteMilestoneModal.scss
@@ -58,4 +58,14 @@
       opacity: 1;
     }
   }
+
+  &__confirm-label {
+    @include ms.milestone-body-13-medium;
+
+    margin-bottom: 4px;
+    color: var(--rp-ui-color-text);
+    cursor: pointer;
+    user-select: text;
+    -webkit-user-select: text;
+  }
 }

--- a/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/deleteMilestoneModal.tsx
+++ b/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/deleteMilestoneModal.tsx
@@ -16,6 +16,7 @@
 
 import {
   ChangeEvent,
+  type KeyboardEvent,
   type PointerEvent,
   type ReactNode,
   useId,
@@ -27,6 +28,7 @@ import { FieldText, Modal } from '@reportportal/ui-kit';
 import { VoidFn } from '@reportportal/ui-kit/common';
 
 import { createClassnames } from 'common/utils';
+import { isEnterOrSpaceKey } from 'common/utils/helperUtils/eventUtils';
 import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { LoadingSubmitButton } from 'components/loadingSubmitButton';
 import { useModalButtons } from 'hooks/useModalButtons';
@@ -60,6 +62,13 @@ export const DeleteMilestoneModal = ({ data }: DeleteMilestoneModalProps) => {
     setConfirmText(event.target.value);
   };
 
+  const focusConfirmInput = () => {
+    if (isLoading) {
+      return;
+    }
+    confirmInputRef.current?.focus();
+  };
+
   const handleInstructionPointerDown = (event: PointerEvent<HTMLDivElement>) => {
     instructionPointerRef.current = {
       x: event.clientX,
@@ -82,9 +91,6 @@ export const DeleteMilestoneModal = ({ data }: DeleteMilestoneModalProps) => {
   };
 
   const handleInstructionClick = () => {
-    if (isLoading) {
-      return;
-    }
     const pointer = instructionPointerRef.current;
     instructionPointerRef.current = null;
     if (pointer?.moved) {
@@ -93,7 +99,15 @@ export const DeleteMilestoneModal = ({ data }: DeleteMilestoneModalProps) => {
     if (window.getSelection()?.toString()) {
       return;
     }
-    confirmInputRef.current?.focus();
+    focusConfirmInput();
+  };
+
+  const handleInstructionKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isEnterOrSpaceKey(event)) {
+      return;
+    }
+    event.preventDefault();
+    focusConfirmInput();
   };
 
   const handleSubmit = () => {
@@ -137,10 +151,13 @@ export const DeleteMilestoneModal = ({ data }: DeleteMilestoneModalProps) => {
             <>
               <div
                 id={confirmInstructionId}
+                role="button"
+                tabIndex={0}
                 className={cx('delete-milestone-modal__confirm-label')}
                 onPointerDown={handleInstructionPointerDown}
                 onPointerMove={handleInstructionPointerMove}
                 onClick={handleInstructionClick}
+                onKeyDown={handleInstructionKeyDown}
               >
                 {formatMessage(messages.typeDeleteInstructionLabel)}
               </div>

--- a/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/deleteMilestoneModal.tsx
+++ b/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/deleteMilestoneModal.tsx
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, type ReactNode, useState } from 'react';
+import {
+  ChangeEvent,
+  type PointerEvent,
+  type ReactNode,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import { useIntl } from 'react-intl';
-import { Modal, FieldText } from '@reportportal/ui-kit';
+import { FieldText, Modal } from '@reportportal/ui-kit';
 import { VoidFn } from '@reportportal/ui-kit/common';
 
 import { createClassnames } from 'common/utils';
@@ -27,7 +34,7 @@ import { useModalButtons } from 'hooks/useModalButtons';
 import { useDeleteMilestone } from './useDeleteMilestone';
 import { messages } from './messages';
 import type { DeleteMilestoneModalProps } from './types';
-import { isDeleteMilestoneConfirmationValid } from './utils';
+import { isDeleteMilestoneConfirmationValid, needsLabelTextSelectionFix } from './utils';
 
 import styles from './deleteMilestoneModal.scss';
 
@@ -35,10 +42,59 @@ const cx = createClassnames(styles);
 
 const renderDeleteConfirmationBold = (chunks: ReactNode) => <strong>{chunks}</strong>;
 
+const INSTRUCTION_POINTER_MOVE_THRESHOLD_PX = 3;
+
 export const DeleteMilestoneModal = ({ data }: DeleteMilestoneModalProps) => {
   const { formatMessage } = useIntl();
+  const confirmInstructionId = useId();
+  const confirmInputId = useId();
+  const confirmInputRef = useRef<HTMLInputElement>(null);
+  const instructionPointerRef = useRef<{ x: number; y: number; moved: boolean } | null>(null);
   const [confirmText, setConfirmText] = useState('');
+  const [useWebKitInstruction] = useState(() => needsLabelTextSelectionFix());
   const { isLoading, deleteMilestone } = useDeleteMilestone();
+
+  const confirmPlaceholder = formatMessage(messages.confirmPlaceholder);
+
+  const handleConfirmTextChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setConfirmText(event.target.value);
+  };
+
+  const handleInstructionPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    instructionPointerRef.current = {
+      x: event.clientX,
+      y: event.clientY,
+      moved: false,
+    };
+  };
+
+  const handleInstructionPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const pointer = instructionPointerRef.current;
+    if (!pointer) {
+      return;
+    }
+    if (
+      Math.abs(event.clientX - pointer.x) > INSTRUCTION_POINTER_MOVE_THRESHOLD_PX ||
+      Math.abs(event.clientY - pointer.y) > INSTRUCTION_POINTER_MOVE_THRESHOLD_PX
+    ) {
+      pointer.moved = true;
+    }
+  };
+
+  const handleInstructionClick = () => {
+    if (isLoading) {
+      return;
+    }
+    const pointer = instructionPointerRef.current;
+    instructionPointerRef.current = null;
+    if (pointer?.moved) {
+      return;
+    }
+    if (window.getSelection()?.toString()) {
+      return;
+    }
+    confirmInputRef.current?.focus();
+  };
 
   const handleSubmit = () => {
     if (!data || !isDeleteMilestoneConfirmationValid(confirmText)) return;
@@ -77,14 +133,38 @@ export const DeleteMilestoneModal = ({ data }: DeleteMilestoneModalProps) => {
           })}
         </p>
         <div className={cx('delete-milestone-modal__confirm-field')}>
-          <FieldText
-            label={formatMessage(messages.typeDeleteInstructionLabel)}
-            defaultWidth={false}
-            value={confirmText}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setConfirmText(e.target.value)}
-            placeholder={formatMessage(messages.confirmPlaceholder)}
-            disabled={isLoading}
-          />
+          {useWebKitInstruction ? (
+            <>
+              <div
+                id={confirmInstructionId}
+                className={cx('delete-milestone-modal__confirm-label')}
+                onPointerDown={handleInstructionPointerDown}
+                onPointerMove={handleInstructionPointerMove}
+                onClick={handleInstructionClick}
+              >
+                {formatMessage(messages.typeDeleteInstructionLabel)}
+              </div>
+              <FieldText
+                ref={confirmInputRef}
+                id={confirmInputId}
+                aria-labelledby={confirmInstructionId}
+                defaultWidth={false}
+                value={confirmText}
+                onChange={handleConfirmTextChange}
+                placeholder={confirmPlaceholder}
+                disabled={isLoading}
+              />
+            </>
+          ) : (
+            <FieldText
+              label={formatMessage(messages.typeDeleteInstructionLabel)}
+              defaultWidth={false}
+              value={confirmText}
+              onChange={handleConfirmTextChange}
+              placeholder={confirmPlaceholder}
+              disabled={isLoading}
+            />
+          )}
         </div>
       </div>
     </Modal>

--- a/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/utils.ts
+++ b/app/src/pages/inside/testPlansPage/milestones/milestoneModals/deleteMilestoneModal/utils.ts
@@ -18,3 +18,17 @@ import { DELETE_MILESTONE_CONFIRM_WORD } from './constants';
 
 export const isDeleteMilestoneConfirmationValid = (value: string) =>
   value.trim().toLowerCase() === DELETE_MILESTONE_CONFIRM_WORD;
+
+export const needsLabelTextSelectionFix = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const { userAgent } = navigator;
+
+  if (/Chrome|Chromium|CriOS|Edg\//i.test(userAgent)) {
+    return false;
+  }
+
+  return /AppleWebKit/i.test(userAgent);
+};


### PR DESCRIPTION
## Summary

Users could not select and copy the word “delete” from the confirmation instruction because an associated `<label htmlFor>` moved focus to the input immediately.

On WebKit (Safari and other non-Chromium browsers using AppleWebKit), the instruction is rendered as selectable text linked to the input via `aria-labelledby`, with a single click on the instruction focusing the field when the pointer did not drag to select text.

On Chromium-based browsers, the modal keeps the standard `FieldText` with `label` so native label behavior is unchanged (text selection and click-to-focus).

Browser branching uses a small `needsLabelTextSelectionFix()` helper in modal utils (no new dependency; consistent with existing UA checks in the project).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the delete milestone confirmation flow in WebKit-based browsers.
  * Users can select and copy the confirmation instruction text without accidentally focusing the input.
  * Confirmation input focus is now handled more reliably during pointer interactions and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->