### PR TITLE
EPMRPP-116864 || Fix Execution side panel header flicker in Safari when changing status

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/executionStatusPopover/executionStatusPopover.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/executionStatusPopover/executionStatusPopover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FC, ReactNode } from 'react';
+import { ComponentProps, FC, ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { Popover } from '@reportportal/ui-kit';
@@ -42,6 +42,8 @@ interface ExecutionStatusPopoverProps {
   setIsOpened: (isOpened: boolean) => void;
   place: ExecutionStatusChangePlace;
   children: ReactNode;
+  shouldUsePortal?: ComponentProps<typeof Popover>['shouldUsePortal'];
+  strategy?: ComponentProps<typeof Popover>['strategy'];
 }
 
 export const ExecutionStatusPopover: FC<ExecutionStatusPopoverProps> = ({
@@ -51,6 +53,8 @@ export const ExecutionStatusPopover: FC<ExecutionStatusPopoverProps> = ({
   setIsOpened,
   place,
   children,
+  shouldUsePortal,
+  strategy,
 }) => {
   const { formatMessage } = useIntl();
   const { openModal } = useExecutionStatusModal();
@@ -112,6 +116,8 @@ export const ExecutionStatusPopover: FC<ExecutionStatusPopoverProps> = ({
       isOpened={isOpened}
       setIsOpened={setIsOpened}
       isCentered={false}
+      shouldUsePortal={shouldUsePortal}
+      strategy={strategy}
     >
       {children}
     </Popover>

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
@@ -308,6 +308,8 @@ export const ExecutionSidePanel = ({ executionId, onClose }: ExecutionSidePanelP
           setIsOpened={setIsStatusPopoverOpen}
           currentStatus={currentStatus}
           place={MANUAL_LAUNCHES_PLACE.EXECUTION_DETAILS_SIDEBAR}
+          shouldUsePortal
+          strategy="fixed"
         >
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary

In Safari, the header of the test execution side panel on Manual launches blinked while using **Change Status** (open popover or pick an option).

The execution sidebar uses ui-kit `SidePanel`, which applies a CSS `transform` on the open panel. The status popover used default Floating UI positioning (`absolute`, no portal) with continuous `autoUpdate`, which in WebKit repeatedly invalidated the panel layer and caused visible header flicker. Chrome and Firefox did not show the issue.

For the execution details sidebar only, **Change Status** now uses `shouldUsePortal` and `strategy="fixed"` so the popover is positioned against the viewport outside the transformed panel. `ExecutionStatusPopover` accepts optional portal and strategy props and forwards them to ui-kit `Popover`; other call sites keep previous defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution status popover positioning and rendering in the execution side panel.
  * Popovers now remain correctly positioned in fixed layouts and support more reliable display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->