### PR TITLE
EPMRPP-118293 || White stripe is shown around expand arrow controller for a failed item on Step level

### DIFF
--- a/app/src/pages/inside/stepPage/stepGrid/stepGrid.scss
+++ b/app/src/pages/inside/stepPage/stepGrid/stepGrid.scss
@@ -89,6 +89,7 @@
 
 .failed {
   background-color: $COLOR--light-red;
+  --background-color: #{$COLOR--light-red};
 }
 
 .error-message-wrapper {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
When a grid row has `failed` status, the accordion block was showing a white background instead of matching the row's light-red background. Added `--background-color` CSS custom property to the `.failed` class so the `.accordion-block` (which uses `var(--background-color, $COLOR--white-two)`) correctly inherits the red background color.

## Links
[EPMRPP-118293](https://jiraeu.epam.com/browse/EPMRPP-118293)

## Visuals
**_Before:_**
<img width="1919" height="558" alt="Screenshot 2026-07-31 154237" src="https://github.com/user-attachments/assets/e42e9e79-e135-4cba-9ea6-8ae0b0917b13" />

**_After:_**
<img width="1919" height="572" alt="Screenshot 2026-07-31 154249" src="https://github.com/user-attachments/assets/07e75ad3-89b7-4611-a1ef-b264f8ee0324" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved styling for failed-step indicators by centralizing their background color for more consistent visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->