### PR TITLE
EPMRPP-118310 || Grant TMS manage permissions to Organization Manager

### DIFF
--- a/app/src/common/constants/permissions.ts
+++ b/app/src/common/constants/permissions.ts
@@ -126,6 +126,11 @@ export const PERMISSIONS_MAP: PermissionsMap = {
     [ACTIONS.SEE_ROW_ACTION_MENU]: true,
     [ACTIONS.CHANGE_STATUS]: true,
     [ACTIONS.LOCK_DASHBOARD]: true,
+    // TMS FEATURES:
+    [ACTIONS.CREATE_MANUAL_LAUNCH]: true,
+    [ACTIONS.MANAGE_TEST_CASES]: true,
+    [ACTIONS.MANAGE_TEST_PLANS]: true,
+    [ACTIONS.MANAGE_EXECUTIONS]: true,
   },
   [MEMBER]: {
     [VIEWER]: {


### PR DESCRIPTION
## Description

Organization Managers could open Milestones / Manual Launches / Test Case Library, but Create / Import / edit / delete actions were hidden.

Root cause: TMS actions (`CREATE_MANUAL_LAUNCH`, `MANAGE_TEST_CASES`, `MANAGE_TEST_PLANS`, `MANAGE_EXECUTIONS`) existed only under `MEMBER → EDITOR` in `PERMISSIONS_MAP`. For Organization Manager, permission checks use `PERMISSIONS_MAP[MANAGER]` and never fall through to project role — so TMS flags always resolved to `false`.

**Fix:** add the same TMS permissions to the `MANAGER` role map.

Project Editors (org Member + project Editor) were already correct and are unchanged.

**Note:** Manual Launches list page has no Create button by design; launches are created from Test Plans / Test Case Library. This fix unlocks those create/manage entry points for Managers.

## Changes

- `app/src/common/constants/permissions.ts` — enable TMS permissions for `MANAGER`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managers can now create manual launches and manage test cases, test plans, and executions in TMS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->