### PR TITLE
EPMRPP-117927 || Increase the max length of BTS Password field

### DIFF
--- a/app/localization/translated/be.json
+++ b/app/localization/translated/be.json
@@ -216,7 +216,7 @@
   "BtsCommonMessages.authTypeLabel": "Тып аўтарызацыі",
   "BtsCommonMessages.btsBoardIdHint": "Ідэнтыфікатар панэлі павінен мець памер ад 1 да 55 знакаў",
   "BtsCommonMessages.btsIntegrationNameHint": "Памер імя Інтэграцыі павінен быць ад 1 да 55",
-  "BtsCommonMessages.btsPasswordHint": "Пароль павінен быць памерам ад 1 да 55",
+  "BtsCommonMessages.btsPasswordHint": "Пароль павінен быць памерам ад 1 да 512",
   "BtsCommonMessages.btsProjectIdHint": "ID праекта павінен быць памерам ад 1 да 55",
   "BtsCommonMessages.btsProjectKeyHint": "Ключ праекта павіннен быць памерам ад 1 да 55",
   "BtsCommonMessages.btsUrlHint": "Калі ласка, падайце сапраўдную спасылку ў САХ",

--- a/app/localization/translated/es.json
+++ b/app/localization/translated/es.json
@@ -216,7 +216,7 @@
   "BtsCommonMessages.authTypeLabel": "Tipo de autorización",
   "BtsCommonMessages.btsBoardIdHint": "El identificador del tablero debe tener entre 1 y 55 caracteres",
   "BtsCommonMessages.btsIntegrationNameHint": "El nombre de la integración debe tener entre 1 y 55 caracteres",
-  "BtsCommonMessages.btsPasswordHint": "La contraseña debe tener entre 1 y 55 caracteres",
+  "BtsCommonMessages.btsPasswordHint": "La contraseña debe tener entre 1 y 512 caracteres",
   "BtsCommonMessages.btsProjectIdHint": "El ID del proyecto debe tener entre 1 y 55 caracteres",
   "BtsCommonMessages.btsProjectKeyHint": "La clave del proyecto debe tener entre 1 y 55 caracteres",
   "BtsCommonMessages.btsUrlHint": "Por favor, proporciona un enlace válido al sistema de gestión de incidencias",

--- a/app/localization/translated/ru.json
+++ b/app/localization/translated/ru.json
@@ -216,7 +216,7 @@
   "BtsCommonMessages.authTypeLabel": "Тип авторизации",
   "BtsCommonMessages.btsBoardIdHint": "Идентификатор панели должен иметь размер от 1 до 55 символов",
   "BtsCommonMessages.btsIntegrationNameHint": "Размер имени Интеграции должен быть от 1 до 55",
-  "BtsCommonMessages.btsPasswordHint": "Пароль должен быть длиной от 1 до 55",
+  "BtsCommonMessages.btsPasswordHint": "Пароль должен быть длиной от 1 до 512",
   "BtsCommonMessages.btsProjectIdHint": "ID проекта должен быть длиной от 1 до 55",
   "BtsCommonMessages.btsProjectKeyHint": "Ключ проекта должен быть длиной от 1 до 55",
   "BtsCommonMessages.btsUrlHint": "Пожалуйста, предоставьте действительную ссылку в СОД",

--- a/app/localization/translated/uk.json
+++ b/app/localization/translated/uk.json
@@ -216,7 +216,7 @@
   "BtsCommonMessages.authTypeLabel": "Тип авторизації",
   "BtsCommonMessages.btsBoardIdHint": "Ідентифікатор панелі повинен мати розмір від 1 до 55 символів",
   "BtsCommonMessages.btsIntegrationNameHint": "Розмір імені Інтеграції повинен бути від 1 до 55",
-  "BtsCommonMessages.btsPasswordHint": "Пароль має бути довжиною від 1 до 55",
+  "BtsCommonMessages.btsPasswordHint": "Пароль має бути довжиною від 1 до 512",
   "BtsCommonMessages.btsProjectIdHint": "ID проекту має бути довжиною від 1 до 55",
   "BtsCommonMessages.btsProjectKeyHint": "Ключ проекту має бути довжиною від 1 до 55",
   "BtsCommonMessages.btsUrlHint": "Будь ласка, надайте в дійсну посилання СОД",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -216,7 +216,7 @@
   "BtsCommonMessages.authTypeLabel": "认证类型",
   "BtsCommonMessages.btsBoardIdHint": "Board ID should have size from 1 to 55 characters",
   "BtsCommonMessages.btsIntegrationNameHint": "集成名称的长度应为1到55个字符",
-  "BtsCommonMessages.btsPasswordHint": "Password should have size from 1 to 512",
+  "BtsCommonMessages.btsPasswordHint": "密码长度应为1到512个字符",
   "BtsCommonMessages.btsProjectIdHint": "项目ID的长度取值范围是1~55个字符",
   "BtsCommonMessages.btsProjectKeyHint": "项目键长度取值范围是1~55个字符",
   "BtsCommonMessages.btsUrlHint": "请提供一个有效的BTS链接",

--- a/app/localization/translated/zh.json
+++ b/app/localization/translated/zh.json
@@ -216,7 +216,7 @@
   "BtsCommonMessages.authTypeLabel": "认证类型",
   "BtsCommonMessages.btsBoardIdHint": "Board ID should have size from 1 to 55 characters",
   "BtsCommonMessages.btsIntegrationNameHint": "集成名称的长度应为1到55个字符",
-  "BtsCommonMessages.btsPasswordHint": "Password should have size from 1 to 55",
+  "BtsCommonMessages.btsPasswordHint": "Password should have size from 1 to 512",
   "BtsCommonMessages.btsProjectIdHint": "项目ID的长度取值范围是1~55个字符",
   "BtsCommonMessages.btsProjectKeyHint": "项目键长度取值范围是1~55个字符",
   "BtsCommonMessages.btsUrlHint": "请提供一个有效的BTS链接",

--- a/app/src/common/utils/validation/validate.js
+++ b/app/src/common/utils/validation/validate.js
@@ -73,7 +73,7 @@ export const projectName = composeValidators([isNotEmpty, regex(/^[0-9a-zA-Z-_]{
 export const btsIntegrationName = composeValidators([isNotEmpty, maxLength(55)]);
 export const btsProject = composeValidators([isNotEmpty, maxLength(55)]);
 export const btsUserName = composeValidators([isNotEmpty, maxLength(55)]);
-export const btsPassword = composeValidators([isNotEmpty, maxLength(55)]);
+export const btsPassword = composeValidators([isNotEmpty, maxLength(512)]);
 export const patternNameLength = composeValidators([isNotEmpty, maxLength(55)]);
 export const ruleNameLength = composeValidators([isNotEmpty, maxLength(55)]);
 export const createNameUniqueValidator = (itemId, items) => (newName) =>

--- a/app/src/components/fields/fieldErrorHint/fieldErrorHint.jsx
+++ b/app/src/components/fields/fieldErrorHint/fieldErrorHint.jsx
@@ -202,7 +202,7 @@ const messages = defineMessages({
   },
   btsPasswordHint: {
     id: 'BtsCommonMessages.btsPasswordHint',
-    defaultMessage: 'Password should have size from 1 to 55',
+    defaultMessage: 'Password should have size from 1 to 512',
   },
   portFieldHint: {
     id: 'EmailFormFields.portFieldHint',

--- a/app/src/components/integrations/integrationProviders/jiraIntegration/jiraConnectionFormFields/jiraConnectionFormFields.jsx
+++ b/app/src/components/integrations/integrationProviders/jiraIntegration/jiraConnectionFormFields/jiraConnectionFormFields.jsx
@@ -147,7 +147,7 @@ export class JiraConnectionFormFields extends Component {
           dataAutomationId="passwordBTSField"
         >
           <FieldErrorHint provideHint={false}>
-            <FieldText defaultWidth={false} type="password" />
+            <FieldText defaultWidth={false} type="password" maxLength={null} />
           </FieldErrorHint>
         </FieldElement>
       </Fragment>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
- Jira Server `btsPassword` validation was increased from `55` to `512` in validate.js.
- The Jira Server password input now uses `maxLength={null}` (so browser-side `256` truncation is disabled and validation feedback can appear) in jiraConnectionFormFields.jsx.
- Error text for `BtsCommonMessages.btsPasswordHint` was updated to `1..512` in fieldErrorHint.jsx.
- Translations for the same key were updated to `1..512` in localized JSON files (e.g. ru.json, es.json, be.json, uk.json, zh.json).

## Links
[EPMRPP-117927](https://jiraeu.epam.com/browse/EPMRPP-117927)

## Visuals
**_Before:_**
<img width="491" height="850" alt="Screenshot 2026-08-04 152227" src="https://github.com/user-attachments/assets/38d92899-5b54-4330-affe-5fb85522acd2" />

**_After:_**
<img width="493" height="723" alt="Screenshot 2026-08-04 163015" src="https://github.com/user-attachments/assets/a3207d1e-3db1-42d6-bf56-bdc62884388f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum allowed BTS password length from 55 to 512 characters.
  * Updated validation messages across supported languages to reflect the new limit.
  * Removed the maximum-length restriction from the Jira password field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->