### PR TITLE
EPMRPP-117883 || Empty page is loaded when switching between steps with and without "Remote device" tab

### DIFF
--- a/app/src/pages/inside/logsPage/constants.js
+++ b/app/src/pages/inside/logsPage/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 EPAM Systems
+ * Copyright 2026 EPAM Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
  * limitations under the License.
  */
 
-export const COMMANDS_TAB = 'commands';
-export { LOGS_TAB } from '../../constants';
-export const METADATA_TAB = 'metadata';
-
-export const COMMAND_FIELD = 'command';
-export const PARAMETERS_FIELD = 'parameters';
-export const RESPONSE_FIELD = 'response';
+export const LOGS_TAB = 'logs';

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -264,6 +264,10 @@ export class LogItemInfoTabs extends Component {
               [tabId]: isVisible,
             },
           }));
+
+          if (!isVisible && this.props.activeTabId === tabId) {
+            this.props.setActiveTabId('logs');
+          }
         })
         .catch(() => {
           if (requestId !== this.logTabVisibilityRequestId) {
@@ -276,6 +280,10 @@ export class LogItemInfoTabs extends Component {
               [tabId]: false,
             },
           }));
+
+          if (this.props.activeTabId === tabId) {
+            this.props.setActiveTabId('logs');
+          }
         });
     });
   };
@@ -500,7 +508,12 @@ export class LogItemInfoTabs extends Component {
     if (tabs.find((tab) => tab.id === activeTabId)) {
       return activeTabId;
     }
-    return null;
+    // Previously selected tab may be gone after step navigation (e.g. Remote device
+    // missing on the next nested step). Fall back to All Logs so content is shown.
+    if (tabs.find((tab) => tab.id === 'logs')) {
+      return 'logs';
+    }
+    return tabs[0]?.id ?? null;
   };
 
   render() {

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -508,8 +508,6 @@ export class LogItemInfoTabs extends Component {
     if (tabs.find((tab) => tab.id === activeTabId)) {
       return activeTabId;
     }
-    // Previously selected tab may be gone after step navigation (e.g. Remote device
-    // missing on the next nested step). Fall back to All Logs so content is shown.
     if (tabs.find((tab) => tab.id === 'logs')) {
       return 'logs';
     }

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -51,6 +51,7 @@ import { getSauceLabsConfig } from 'components/integrations/integrationProviders
 import { availableIntegrationsByPluginNameSelector } from 'controllers/plugins';
 import { uiExtensionLogTabSelector } from 'controllers/plugins/uiExtensions';
 import { StackTrace } from 'pages/inside/common/stackTrace';
+import { LOGS_TAB } from '../../constants';
 import { SauceLabsIntegrationButton } from './sauceLabsIntegrationButton';
 import { InfoTabs } from '../infoTabs';
 import { LogItemDetails } from './logItemDetails';
@@ -154,7 +155,7 @@ export class LogItemInfoTabs extends Component {
     lastActivity: null,
     fetchFirstAttachments: () => {},
     attachments: [],
-    activeTabId: 'logs',
+    activeTabId: LOGS_TAB,
     setActiveTabId: () => {},
     noLogsCollapsing: false,
     logTabExtensions: [],
@@ -266,7 +267,7 @@ export class LogItemInfoTabs extends Component {
           }));
 
           if (!isVisible && this.props.activeTabId === tabId) {
-            this.props.setActiveTabId('logs');
+            this.props.setActiveTabId(LOGS_TAB);
           }
         })
         .catch(() => {
@@ -282,7 +283,7 @@ export class LogItemInfoTabs extends Component {
           }));
 
           if (this.props.activeTabId === tabId) {
-            this.props.setActiveTabId('logs');
+            this.props.setActiveTabId(LOGS_TAB);
           }
         });
     });
@@ -370,7 +371,7 @@ export class LogItemInfoTabs extends Component {
         logId,
         shouldClearSearchFilter: Boolean(logQuery[LOG_MESSAGE_FILTER_KEY]),
       });
-      setActiveTabId('logs');
+      setActiveTabId(LOGS_TAB);
     } catch {
       showNotificationAction({
         message: formatMessage(messages.jumpToLogFailed),
@@ -413,7 +414,7 @@ export class LogItemInfoTabs extends Component {
         },
       },
       {
-        id: 'logs',
+        id: LOGS_TAB,
         label: formatMessage(messages.logsTab),
         icon: LogIcon,
         stroked: true,
@@ -476,7 +477,7 @@ export class LogItemInfoTabs extends Component {
 
   toggleSauceLabsIntegrationContent = () => {
     // TODO: Handle SauceLabs integration as independent tab
-    this.props.setActiveTabId('logs');
+    this.props.setActiveTabId(LOGS_TAB);
     this.props.onToggleSauceLabsIntegrationView();
   };
 
@@ -508,8 +509,8 @@ export class LogItemInfoTabs extends Component {
     if (tabs.some((tab) => tab.id === activeTabId)) {
       return activeTabId;
     }
-    if (tabs.some((tab) => tab.id === 'logs')) {
-      return 'logs';
+    if (tabs.some((tab) => tab.id === LOGS_TAB)) {
+      return LOGS_TAB;
     }
     return tabs[0]?.id ?? null;
   };

--- a/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
+++ b/app/src/pages/inside/logsPage/logItemInfo/logItemInfoTabs/logItemInfoTabs.jsx
@@ -505,10 +505,10 @@ export class LogItemInfoTabs extends Component {
 
   getActiveTabId = (tabs) => {
     const { activeTabId } = this.props;
-    if (tabs.find((tab) => tab.id === activeTabId)) {
+    if (tabs.some((tab) => tab.id === activeTabId)) {
       return activeTabId;
     }
-    if (tabs.find((tab) => tab.id === 'logs')) {
+    if (tabs.some((tab) => tab.id === 'logs')) {
       return 'logs';
     }
     return tabs[0]?.id ?? null;


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
Set the "Logs" tab as the default when the "Remote Device" tab is not available for the current step. This ensures that after navigating from a step with a "Remote Device" tab to one without it, the "Logs" tab is selected automatically.

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab navigation when a selected tab is unavailable or visibility checks fail.
  * Automatically falls back to the Logs tab, or the first available tab, so a valid tab remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->