### PR TITLE
EPMRPP-118337 ||  No scroll option for when Test Case Library on the project is empty

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/emptyState/mainPage/mainPageEmptyState.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/emptyState/mainPage/mainPageEmptyState.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.main-page-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 32px 32px 60px;
+  gap: 80px;
+}

--- a/app/src/pages/inside/testCaseLibraryPage/emptyState/mainPage/mainPageEmptyState.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/emptyState/mainPage/mainPageEmptyState.tsx
@@ -21,15 +21,19 @@ import { useTracking } from 'react-tracking';
 import { TEST_CASE_LIBRARY_EVENTS } from 'analyticsEvents/testCaseLibraryPageEvents';
 import { NumerableBlock } from 'pages/common/numerableBlock';
 import { EmptyStatePage } from 'pages/inside/common/emptyStatePage';
-import { referenceDictionary } from 'common/utils';
+import { createClassnames, referenceDictionary } from 'common/utils';
 import { useUserPermissions } from 'hooks/useUserPermissions';
 import { useCreateFolderModal } from 'pages/inside/testCaseLibraryPage/testCaseFolders/modals/createFolderModal';
+import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 
 import { messages } from '../messages';
 import { commonMessages } from '../../commonMessages';
-import { COMMON_LOCALE_KEYS } from 'common/constants/localization';
 import { useCreateTestCaseModal } from '../../createTestCaseModal';
 import { useImportTestCaseModal } from '../../importTestCaseModal';
+
+import styles from './mainPageEmptyState.scss';
+
+const cx = createClassnames(styles);
 
 export const MainPageEmptyState = () => {
   const { formatMessage } = useIntl();
@@ -62,31 +66,33 @@ export const MainPageEmptyState = () => {
     (translation) => Parser(formatMessage(translation, {}, { ignoreTag: true })),
   );
 
-  const buttons = canManageTestCases ? [
-    {
-      name: formatMessage(commonMessages.createFolder),
-      dataAutomationId: 'createFolderButton',
-      isCompact: true,
-      handleButton: handleCreateFolder,
-    },
-    {
-      name: formatMessage(commonMessages.createTestCase),
-      dataAutomationId: 'createTestCaseButton',
-      isCompact: true,
-      variant: 'ghost',
-      handleButton: handleCreateTestCase,
-    },
-    {
-      name: formatMessage(COMMON_LOCALE_KEYS.IMPORT),
-      dataAutomationId: 'importTestCaseButton',
-      isCompact: false,
-      variant: 'ghost',
-      handleButton: handleImportTestCase,
-    },
-  ] : [];
+  const buttons = canManageTestCases
+    ? [
+        {
+          name: formatMessage(commonMessages.createFolder),
+          dataAutomationId: 'createFolderButton',
+          isCompact: true,
+          handleButton: handleCreateFolder,
+        },
+        {
+          name: formatMessage(commonMessages.createTestCase),
+          dataAutomationId: 'createTestCaseButton',
+          isCompact: true,
+          variant: 'ghost',
+          handleButton: handleCreateTestCase,
+        },
+        {
+          name: formatMessage(COMMON_LOCALE_KEYS.IMPORT),
+          dataAutomationId: 'importTestCaseButton',
+          isCompact: false,
+          variant: 'ghost',
+          handleButton: handleImportTestCase,
+        },
+      ]
+    : [];
 
   return (
-    <>
+    <div className={cx('main-page-empty-state')}>
       <EmptyStatePage
         title={formatMessage(messages.emptyPageTitle)}
         description={formatMessage(messages.emptyPageDescription)}
@@ -100,6 +106,6 @@ export const MainPageEmptyState = () => {
         title={formatMessage(messages.numerableBlockTitle)}
         fullWidth
       />
-    </>
+    </div>
   );
 };

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.scss
@@ -50,11 +50,23 @@
     justify-content: center;
     align-items: center;
     flex-grow: 1;
+    min-height: 0;
     padding: 32px 32px 60px;
     gap: 80px;
 
     &--no-padding {
       padding: 0;
+    }
+
+    &--empty {
+      justify-content: flex-start;
+      align-items: stretch;
+      padding: 0;
+      gap: 0;
+
+      > * {
+        height: 100%;
+      }
     }
   }
 

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
@@ -183,7 +183,7 @@ export const TestCaseLibraryPage = () => {
     }
 
     return (
-      <ScrollWrapper resetRequired hideTracksWhenNotNeeded>
+      <ScrollWrapper hideTracksWhenNotNeeded>
         <MainPageEmptyState />
       </ScrollWrapper>
     );

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseLibraryPage.tsx
@@ -46,6 +46,7 @@ import {
 import { areFoldersLoadingSelector, foldersSelector, isLoadingFilteredFoldersSelector } from 'controllers/testCase';
 import { useUserPermissions } from 'hooks/useUserPermissions';
 import { SearchField } from 'components/fields/searchField';
+import { ScrollWrapper } from 'components/main/scrollWrapper';
 import { TestCasePageDefaultValues } from 'pages/inside/common/testCaseList/constants';
 import {
   FilterSidePanel,
@@ -170,6 +171,8 @@ export const TestCaseLibraryPage = () => {
     !!location?.query?.filterPriorities ||
     !!location?.query?.filterTags;
 
+  const showEmptyState = !areFoldersLoading && !hasFolders && !hasActiveSearchOrFilters;
+
   const renderContent = () => {
     if (areFoldersLoading) {
       return <BubblesLoader />;
@@ -179,7 +182,11 @@ export const TestCaseLibraryPage = () => {
       return <TestCaseFolders />;
     }
 
-    return <MainPageEmptyState />;
+    return (
+      <ScrollWrapper resetRequired hideTracksWhenNotNeeded>
+        <MainPageEmptyState />
+      </ScrollWrapper>
+    );
   };
 
   return (
@@ -255,7 +262,8 @@ export const TestCaseLibraryPage = () => {
           </div>
           <div
             className={cx('test-case-library-page__content', {
-              'test-case-library-page__content--no-padding': hasFolders,
+              'test-case-library-page__content--no-padding': hasFolders || hasActiveSearchOrFilters,
+              'test-case-library-page__content--empty': showEmptyState,
             })}
           >
             {renderContent()}


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
added scroll option for test case library page so after zoom the user can scroll and use the empty state page buttons

## Visuals
before:

https://github.com/user-attachments/assets/7aaa87d7-4978-4685-bfa9-22f0fdd1697e


after: 

https://github.com/user-attachments/assets/b1490f05-479f-4f0e-a466-69474e1f48b9



<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state layout and spacing in the test case library.
  * Ensured empty-state content fills the available page height and aligns correctly.
  * Added scrolling support for empty-state content.
  * Preserved appropriate padding and content sizing when folders, filters, or search are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->