### PR TITLE
EPMRPP-104090 || User email is not truncated when no enough space

### DIFF
--- a/app/src/pages/inside/dashboardPage/dashboardList/dashboardTable/dashboardTable.scss
+++ b/app/src/pages/inside/dashboardPage/dashboardList/dashboardTable/dashboardTable.scss
@@ -46,6 +46,14 @@
   line-height: 22px;
 }
 
+.owner-name {
+  width: 0;
+  min-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .icon-cell {
   width: 6.5%;
   padding: 15px 0;
@@ -195,5 +203,14 @@
     @media (max-width: $SCREEN_SM_MAX) {
       display: none;
     }
+  }
+
+  .owner-name {
+    width: auto;
+    display: inline;
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    word-break: break-all;
   }
 }

--- a/app/src/pages/inside/dashboardPage/dashboardList/dashboardTable/dashboardTableColumns.jsx
+++ b/app/src/pages/inside/dashboardPage/dashboardList/dashboardTable/dashboardTableColumns.jsx
@@ -18,6 +18,7 @@ import { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames/bind';
 import PropTypes from 'prop-types';
 import { useTracking } from 'react-tracking';
+import { useEllipsisTitle } from '@reportportal/ui-kit';
 import { Icon } from 'components/main/icon';
 import { NavLink } from 'components/main/navLink';
 import { DASHBOARD_EVENTS } from 'analyticsEvents/dashboardsPageEvents';
@@ -38,7 +39,7 @@ import { messages } from './messages';
 
 const cx = classNames.bind(styles);
 
-export const NameColumn = ({ value, customProps: { getLink }, className }) => {
+export const NameColumn = ({ value = {}, customProps: { getLink } = {}, className = '' }) => {
   const { trackEvent } = useTracking();
   const { id: dashboardId, name, locked } = value;
 
@@ -70,13 +71,7 @@ NameColumn.propTypes = {
   className: PropTypes.string,
 };
 
-NameColumn.defaultProps = {
-  value: {},
-  customProps: {},
-  className: '',
-};
-
-export const DescriptionColumn = ({ value, className }) => (
+export const DescriptionColumn = ({ value = '', className = '' }) => (
   <div className={cx(className, 'description', { empty: !value })}>{value}</div>
 );
 DescriptionColumn.propTypes = {
@@ -84,27 +79,24 @@ DescriptionColumn.propTypes = {
   className: PropTypes.string,
 };
 
-DescriptionColumn.defaultProps = {
-  value: '',
-  className: '',
-};
+export const OwnerColumn = ({ value = '', className = '' }) => {
+  const { ref, title } = useEllipsisTitle(value);
 
-export const OwnerColumn = ({ value, className }) => (
-  <div className={cx(className, 'owner')}>{value}</div>
-);
+  return (
+    <div className={cx(className, 'owner')}>
+      <div ref={ref} title={title} className={cx('owner-name')}>
+        {value}
+      </div>
+    </div>
+  );
+};
 
 OwnerColumn.propTypes = {
   value: PropTypes.string,
   className: PropTypes.string,
 };
 
-OwnerColumn.defaultProps = {
-  value: '',
-  className: '',
-};
-
-
-export const DuplicateColumn = ({ value, customProps, className }) => {
+export const DuplicateColumn = ({ value = {}, customProps = {}, className = '' }) => {
   const { trackEvent } = useTracking();
   const { formatMessage } = useIntl();
   const [opened, setOpened] = useState(false);
@@ -202,13 +194,7 @@ DuplicateColumn.propTypes = {
   className: PropTypes.string,
 };
 
-DuplicateColumn.defaultProps = {
-  value: {},
-  customProps: {},
-  className: '',
-};
-
-export const EditColumn = ({ value, customProps, className }) => {
+export const EditColumn = ({ value = {}, customProps = {}, className = '' }) => {
   const { trackEvent } = useTracking();
   const { onEdit } = customProps;
   const { id, locked } = value;
@@ -236,13 +222,8 @@ EditColumn.propTypes = {
   customProps: PropTypes.object,
   className: PropTypes.string,
 };
-EditColumn.defaultProps = {
-  value: {},
-  customProps: {},
-  className: '',
-};
 
-export const DeleteColumn = ({ value, customProps, className }) => {
+export const DeleteColumn = ({ value = {}, customProps = {}, className = '' }) => {
   const { trackEvent } = useTracking();
   const { id, locked } = value;
   const canLock = useCanLockDashboard();
@@ -268,9 +249,4 @@ DeleteColumn.propTypes = {
   value: PropTypes.object,
   customProps: PropTypes.object,
   className: PropTypes.string,
-};
-DeleteColumn.defaultProps = {
-  value: {},
-  customProps: {},
-  className: '',
 };

--- a/app/src/pages/inside/filtersPage/filterGrid/filterGrid.jsx
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterGrid.jsx
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames/bind';
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
+import { useEllipsisTitle } from '@reportportal/ui-kit';
 import { ALIGN_CENTER, Grid } from 'components/main/grid';
 import {
   PROJECT_LAUNCHES_PAGE,
@@ -42,7 +43,7 @@ const messages = defineMessages({
   deleteCol: { id: 'MembersGrid.deleteCol', defaultMessage: 'Delete' },
 });
 
-const NameColumn = ({ className, value, customProps }) => {
+const NameColumn = ({ className, value = {}, customProps = {} }) => {
   const { organizationSlug, projectSlug, editable = true } = customProps;
   return (
     <div className={cx('name-col', className)}>
@@ -67,12 +68,8 @@ NameColumn.propTypes = {
   value: PropTypes.object,
   customProps: PropTypes.object,
 };
-NameColumn.defaultProps = {
-  value: {},
-  customProps: {},
-};
 
-const OptionsColumn = ({ className, value }) => (
+const OptionsColumn = ({ className, value = {} }) => (
   <div className={cx('options-col', className)}>
     <FilterOptions entities={value.conditions} sort={value.orders} />
   </div>
@@ -81,27 +78,27 @@ OptionsColumn.propTypes = {
   className: PropTypes.string.isRequired,
   value: PropTypes.object,
 };
-OptionsColumn.defaultProps = {
-  value: {},
-};
 
-const OwnerColumn = ({ className, value }) => (
-  <div className={cx('owner-col', className)}>
-    <div className={cx('mobile-label', 'owner-label')}>
-      <FormattedMessage id={'OwnerColumn.owner'} defaultMessage={'Owner:'} />
+const OwnerColumn = ({ className, value = {} }) => {
+  const { ref, title } = useEllipsisTitle(value.owner);
+
+  return (
+    <div className={cx('owner-col', className)}>
+      <div className={cx('mobile-label', 'owner-label')}>
+        <FormattedMessage id={'OwnerColumn.owner'} defaultMessage={'Owner:'} />
+      </div>
+      <div ref={ref} title={title} className={cx('owner-name')}>
+        {value.owner}
+      </div>
     </div>
-    {value.owner}
-  </div>
-);
+  );
+};
 OwnerColumn.propTypes = {
   className: PropTypes.string.isRequired,
   value: PropTypes.object,
 };
-OwnerColumn.defaultProps = {
-  value: {},
-};
 
-const DisplayOnLaunchColumn = ({ className, value, customProps }) => {
+const DisplayOnLaunchColumn = ({ className, value = {}, customProps = {} }) => {
   const { onChangeDisplay, userFilters, readOnly } = customProps;
   return (
     <div className={cx('display-col', className)}>
@@ -120,12 +117,8 @@ DisplayOnLaunchColumn.propTypes = {
   value: PropTypes.object,
   customProps: PropTypes.object,
 };
-DisplayOnLaunchColumn.defaultProps = {
-  value: {},
-  customProps: {},
-};
 
-const DeleteColumn = ({ className, value, customProps }) => {
+const DeleteColumn = ({ className, value = {}, customProps = {} }) => {
   const { disabled, onDelete } = customProps;
 
   return (
@@ -138,10 +131,6 @@ DeleteColumn.propTypes = {
   className: PropTypes.string.isRequired,
   value: PropTypes.object,
   customProps: PropTypes.object,
-};
-DeleteColumn.defaultProps = {
-  value: {},
-  customProps: {},
 };
 
 @connect((state) => ({

--- a/app/src/pages/inside/filtersPage/filterGrid/filterGrid.scss
+++ b/app/src/pages/inside/filtersPage/filterGrid/filterGrid.scss
@@ -47,7 +47,6 @@
   padding: 15px;
   line-height: 22px;
   box-sizing: border-box;
-  word-break: break-all;
   font-size: 13px;
 
   @media (max-width: $SCREEN_XS_MAX) {
@@ -57,6 +56,24 @@
     text-align: left;
   }
 }
+
+.owner-name {
+  width: 0;
+  min-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (max-width: $SCREEN_XS_MAX) {
+    width: auto;
+    display: inline;
+    overflow: visible;
+    text-overflow: unset;
+    white-space: normal;
+    word-break: break-all;
+  }
+}
+
 .owner-label {
   vertical-align: unset;
 }


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Links
[EPMRPP-104090](https://jiraeu.epam.com/browse/EPMRPP-104090)

## Changes
1. Added ellipsis truncation for long Owner values on the Dashboards and Filters list tables.
- Wrap owner text in an inner element with `width: 0; min-width: 100%` so table cells keep their width and don’t expand for long emails.
> table layout with `table-layout: auto` calculates column widths based on the content size. A long non-wrapping value (`white-space: nowrap`) increases the column's minimum required width, causing the table cell to expand beyond its defined percentage.
- Use `useEllipsisTitle` to show a native title tooltip only when the text is truncated.
2. Removed deprecated `defaultProps` 

## Visuals
### Dashboards
**Before:**
<img width="1919" height="799" alt="Screenshot 2026-08-06 161918" src="https://github.com/user-attachments/assets/3be3828e-e66e-4d6c-a6df-f64e3de45e5f" />

**_After:_**
<img width="1919" height="751" alt="Screenshot 2026-08-06 161931" src="https://github.com/user-attachments/assets/eb50014e-dd0d-4495-9f2c-5fa2ee49d293" />

**Before:**
<img width="942" height="868" alt="Screenshot 2026-08-06 161855" src="https://github.com/user-attachments/assets/320eea36-6416-4bcd-9ef1-93486fe53dec" />

**_After:_**
<img width="944" height="822" alt="Screenshot 2026-08-06 161904" src="https://github.com/user-attachments/assets/489cbaf5-9532-4f3e-88e1-37244194d56a" />

### Filters
**Before:**
<img width="1919" height="724" alt="Screenshot 2026-08-06 164403" src="https://github.com/user-attachments/assets/4289858d-4ff4-41c2-a69e-d307a28d54cd" />

**_After:_**
<img width="1919" height="720" alt="Screenshot 2026-08-06 164410" src="https://github.com/user-attachments/assets/783d11ee-eb2d-49a8-86dd-60f5e7f32fd9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved owner-name display in dashboard and filter lists.
  * Long owner names now truncate with an ellipsis on larger screens and wrap naturally on smaller screens.
  * Added full-name titles when text is truncated for easier identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->