### PR TITLE
EPMRPP-118311 || Prevent 401 errors on logout by avoiding data refetch when unauthorized

### DIFF
--- a/app/src/controllers/milestone/sagas.ts
+++ b/app/src/controllers/milestone/sagas.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { takeLatest, call, select, all, put } from 'redux-saga/effects';
+import { call, select, all, put, fork, cancel, takeEvery } from 'redux-saga/effects';
+import { Task } from 'redux-saga';
 
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
@@ -22,6 +23,7 @@ import { fetchSuccessAction, fetchErrorAction } from 'controllers/fetch';
 import { FETCH_START } from 'controllers/fetch/constants';
 import { showErrorNotification } from 'controllers/notification';
 import { projectKeySelector } from 'controllers/project';
+import { LOGOUT } from 'controllers/auth';
 
 import {
   GET_MILESTONES,
@@ -31,7 +33,7 @@ import {
 } from './constants';
 import type { GetMilestonesAction } from './types';
 
-function* getMilestones(action: GetMilestonesAction): Generator {
+function* getMilestones(action: GetMilestonesAction, abortController: AbortController): Generator {
   try {
     const projectKey = (yield select(projectKeySelector)) as string;
 
@@ -49,7 +51,9 @@ function* getMilestones(action: GetMilestonesAction): Generator {
         }
       : defaultMilestoneQueryParams;
 
-    const data = (yield call(fetch, URLS.tmsMilestone(projectKey, params))) as TmsMilestonePageRS;
+    const data = (yield call(fetch, URLS.tmsMilestone(projectKey, params), {
+      signal: abortController.signal,
+    })) as TmsMilestonePageRS;
 
     yield put(
       fetchSuccessAction(MILESTONES_NAMESPACE, {
@@ -57,17 +61,46 @@ function* getMilestones(action: GetMilestonesAction): Generator {
       }),
     );
   } catch (error) {
-    yield put(fetchErrorAction(MILESTONES_NAMESPACE, error));
-    yield put(
-      showErrorNotification({
-        messageId: 'milestoneLoadingFailed',
-      }),
-    );
+    // Ignore abort errors
+    if (error instanceof Error && error.message !== 'REQUEST_CANCELED') {
+      yield put(fetchErrorAction(MILESTONES_NAMESPACE, error));
+      yield put(
+        showErrorNotification({
+          messageId: 'milestoneLoadingFailed',
+        }),
+      );
+    }
+  }
+}
+
+let getMilestonesTask: Task | undefined;
+let abortController: AbortController | undefined;
+
+function* handleGetMilestones(action: GetMilestonesAction): Generator {
+  if (getMilestonesTask) {
+    yield cancel(getMilestonesTask);
+  }
+  if (abortController) {
+    abortController.abort();
+  }
+
+  abortController = new AbortController();
+  getMilestonesTask = (yield fork(getMilestones, action, abortController)) as Task;
+}
+
+function* handleLogoutDuringMilestonesFetch(): Generator {
+  if (getMilestonesTask) {
+    yield cancel(getMilestonesTask);
+  }
+  if (abortController) {
+    abortController.abort();
+    abortController = undefined;
   }
 }
 
 function* watchGetMilestones() {
-  yield takeLatest(GET_MILESTONES, getMilestones);
+  yield takeEvery(GET_MILESTONES, handleGetMilestones);
+  yield takeEvery(LOGOUT, handleLogoutDuringMilestonesFetch);
 }
 
 export function* milestoneSagas() {

--- a/app/src/controllers/milestone/sagas.ts
+++ b/app/src/controllers/milestone/sagas.ts
@@ -36,6 +36,7 @@ let abortController: AbortController | undefined;
 
 function* getMilestones(action: GetMilestonesAction): Generator {
   const controller = new AbortController();
+  abortController?.abort();
   abortController = controller;
 
   try {

--- a/app/src/controllers/milestone/sagas.ts
+++ b/app/src/controllers/milestone/sagas.ts
@@ -66,8 +66,9 @@ function* getMilestones(action: GetMilestonesAction): Generator {
       }),
     );
   } catch (error) {
-    // Ignore abort errors
-    if (error instanceof Error && error.message !== 'REQUEST_CANCELED') {
+    const isCancellation = error instanceof Error && error.message === 'REQUEST_CANCELED';
+
+    if (!isCancellation) {
       yield put(fetchErrorAction(MILESTONES_NAMESPACE, error));
       yield put(
         showErrorNotification({

--- a/app/src/controllers/milestone/sagas.ts
+++ b/app/src/controllers/milestone/sagas.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { call, select, all, put, fork, cancel, takeEvery } from 'redux-saga/effects';
-import { Task } from 'redux-saga';
+import { call, select, all, put, takeEvery, takeLatest } from 'redux-saga/effects';
 
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
@@ -33,7 +32,11 @@ import {
 } from './constants';
 import type { GetMilestonesAction } from './types';
 
-function* getMilestones(action: GetMilestonesAction, abortController: AbortController): Generator {
+let abortController: AbortController | undefined;
+
+function* getMilestones(action: GetMilestonesAction): Generator {
+  abortController = new AbortController();
+
   try {
     const projectKey = (yield select(projectKeySelector)) as string;
 
@@ -73,25 +76,7 @@ function* getMilestones(action: GetMilestonesAction, abortController: AbortContr
   }
 }
 
-let getMilestonesTask: Task | undefined;
-let abortController: AbortController | undefined;
-
-function* handleGetMilestones(action: GetMilestonesAction): Generator {
-  if (getMilestonesTask) {
-    yield cancel(getMilestonesTask);
-  }
-  if (abortController) {
-    abortController.abort();
-  }
-
-  abortController = new AbortController();
-  getMilestonesTask = (yield fork(getMilestones, action, abortController)) as Task;
-}
-
-function* handleLogoutDuringMilestonesFetch(): Generator {
-  if (getMilestonesTask) {
-    yield cancel(getMilestonesTask);
-  }
+function handleLogoutDuringMilestonesFetch(): void {
   if (abortController) {
     abortController.abort();
     abortController = undefined;
@@ -99,7 +84,7 @@ function* handleLogoutDuringMilestonesFetch(): Generator {
 }
 
 function* watchGetMilestones() {
-  yield takeEvery(GET_MILESTONES, handleGetMilestones);
+  yield takeLatest(GET_MILESTONES, getMilestones);
   yield takeEvery(LOGOUT, handleLogoutDuringMilestonesFetch);
 }
 

--- a/app/src/controllers/milestone/sagas.ts
+++ b/app/src/controllers/milestone/sagas.ts
@@ -35,7 +35,8 @@ import type { GetMilestonesAction } from './types';
 let abortController: AbortController | undefined;
 
 function* getMilestones(action: GetMilestonesAction): Generator {
-  abortController = new AbortController();
+  const controller = new AbortController();
+  abortController = controller;
 
   try {
     const projectKey = (yield select(projectKeySelector)) as string;
@@ -55,7 +56,7 @@ function* getMilestones(action: GetMilestonesAction): Generator {
       : defaultMilestoneQueryParams;
 
     const data = (yield call(fetch, URLS.tmsMilestone(projectKey, params), {
-      signal: abortController.signal,
+      signal: controller.signal,
     })) as TmsMilestonePageRS;
 
     yield put(
@@ -77,10 +78,9 @@ function* getMilestones(action: GetMilestonesAction): Generator {
 }
 
 function handleLogoutDuringMilestonesFetch(): void {
-  if (abortController) {
-    abortController.abort();
-    abortController = undefined;
-  }
+  const controller = abortController;
+  abortController = undefined;
+  controller?.abort();
 }
 
 function* watchGetMilestones() {

--- a/app/src/controllers/user/sagas.js
+++ b/app/src/controllers/user/sagas.js
@@ -350,7 +350,7 @@ function* watchDeleteUserAccount() {
 }
 
 function* watchFetchUserInfo() {
-  yield takeEvery(FETCH_USER_INFO, fetchUserInfo);
+  yield takeEvery(FETCH_USER_INFO, fetchUserWorker);
 }
 
 function* watchLoadProjectSettings() {

--- a/app/src/controllers/user/sagas.js
+++ b/app/src/controllers/user/sagas.js
@@ -350,7 +350,7 @@ function* watchDeleteUserAccount() {
 }
 
 function* watchFetchUserInfo() {
-  yield takeEvery(FETCH_USER_INFO, fetchUserWorker);
+  yield takeEvery(FETCH_USER_INFO, fetchUserInfo);
 }
 
 function* watchLoadProjectSettings() {

--- a/app/src/layouts/common/appSidebar/userControl/userControl.jsx
+++ b/app/src/layouts/common/appSidebar/userControl/userControl.jsx
@@ -34,12 +34,14 @@ const UserControl = ({ onClick }) => {
   return (
     <button type="button" className={cx('user-block-wrapper')} onClick={onClick}>
       <span className={cx('avatar-block')}>
-        <UserAvatar
-          className={cx('user-avatar')}
-          userId={id}
-          timestamp={photoTimeStamp}
-          thumbnail
-        />
+        {id && (
+          <UserAvatar
+            className={cx('user-avatar')}
+            userId={id}
+            timestamp={photoTimeStamp}
+            thumbnail
+          />
+        )}
       </span>
       <div className={cx('user-control')}>
         <div className={cx('user-details')}>

--- a/app/src/pages/inside/testPlansPage/milestonesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/milestonesPage.tsx
@@ -141,8 +141,8 @@ export const MilestonesPage = () => {
                 variant="text"
                 data-automation-id="refreshPageButton"
                 icon={<RefreshIcon />}
-                disabled={loading}
-                onClick={() => dispatch(getMilestonesAction(queryParams))}
+                disabled={loading || !isAuthorized}
+                onClick={() => isAuthorized && dispatch(getMilestonesAction(queryParams))}
               >
                 {formatMessage(commonMessages.refreshPage)}
               </Button>

--- a/app/src/pages/inside/testPlansPage/milestonesPage.tsx
+++ b/app/src/pages/inside/testPlansPage/milestonesPage.tsx
@@ -40,6 +40,7 @@ import {
 } from 'controllers/milestone';
 import { useUserPermissions } from 'hooks/useUserPermissions';
 import { useQueryParams } from 'common/hooks';
+import { isAuthorizedSelector } from 'controllers/auth';
 
 import {
   EmptyMilestones,
@@ -69,6 +70,7 @@ export const MilestonesPage = () => {
   ) as ProjectDetails;
   const milestones = useSelector(milestonesSelector);
   const milestonesLoading = useSelector(milestonesLoadingSelector);
+  const isAuthorized = useSelector(isAuthorizedSelector);
   const projectLink = { type: PROJECT_DASHBOARD_PAGE, payload: { organizationSlug, projectSlug } };
   const breadcrumbDescriptors = [
     { id: 'project', title: <PreservedText>{projectName}</PreservedText>, link: projectLink },
@@ -77,10 +79,10 @@ export const MilestonesPage = () => {
   const queryParams = useMemo(() => ({ offset, limit }), [offset, limit]);
 
   useEffect(() => {
-    if (isUndefined(milestones) && !milestonesLoading) {
+    if (isUndefined(milestones) && !milestonesLoading && isAuthorized) {
       dispatch(getMilestonesAction(queryParams));
     }
-  }, [dispatch, milestones, milestonesLoading, queryParams]);
+  }, [dispatch, milestones, milestonesLoading, queryParams, isAuthorized]);
 
   const hasTrackedViewRef = useRef(false);
 


### PR DESCRIPTION
## Description

This PR fixes issue EPMRPP-118311 where users see multiple "401 Unauthorized" error toasters after clicking the logout button.

### Root Cause

The issue occurred due to a race condition during the logout flow:

1. **Milestones Page**: When logout is triggered, `onBeforeRouteChange` dispatches `clearPageStateAction()` which resets the milestone reducer to its initial state. The page component is still mounted at this point, and its `useEffect` hook detects `milestones === undefined` and immediately re-fetches data. However, the token has already been cleared or is about to be cleared, so the fetch returns a 401 error, which then triggers an error notification.

2. **User Avatar**: The sidebar avatar component renders `<UserAvatar userId={id} />` with the user's ID. During logout, the user reducer is cleared and `id` becomes `undefined`, causing the component to render an `<img src="/api/users/undefined/avatar">` tag. The browser automatically fetches this URL, receives 401, and triggers error handling in the axios interceptor.

### Solution

Three complementary fixes were implemented:

1. **Milestones Page Fix**: Added `isAuthorized` selector check to the `useEffect` dependency array. The effect now only triggers data refetch when the user is still authorized. This prevents unnecessary fetch calls after logout starts.

2. **Milestone Saga Enhancement**: Added `AbortController` signal to milestone fetch calls and implemented LOGOUT event handler to cancel in-flight requests. This ensures that any milestones fetch already in progress is properly aborted when logout occurs.

3. **Avatar Rendering**: Added conditional rendering check in `UserControl` component - the `UserAvatar` component is only rendered when `id` exists. This prevents the browser from attempting to load the avatar image with an undefined user ID.

### Changes

- `pages/inside/testPlansPage/milestonesPage.tsx`: Added `isAuthorized` selector and guard clause in useEffect
- `controllers/milestone/sagas.ts`: Added AbortController signal and LOGOUT cancellation handler
- `layouts/common/appSidebar/userControl/userControl.jsx`: Added conditional rendering for UserAvatar based on id existence

### Impact

- Users no longer see "401 Unauthorized" error toasters when logging out
- No unnecessary API requests are made after logout has been initiated
- Avatar component gracefully handles logout state transitions


### Visuals

**Before:**

https://github.com/user-attachments/assets/a5142c55-f982-45b3-815f-ffd87ef64ab4

**After:**

https://github.com/user-attachments/assets/0e7d2d8d-f029-4f32-a8ab-0a80678ad85b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved milestone loading reliability by canceling outdated requests and safely handling canceled operations.
  - Prevented milestone fetches and refresh actions when authorization is unavailable.
  - Ensured milestone requests are canceled when signing out.
  - Prevented user avatars from appearing when no user identity is available.
  - Improved error handling so genuine milestone request failures still provide appropriate notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->