### PR TITLE
EPMRPP-118434 || Add environment-aware Cache-Control headers for static assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,13 @@ COPY --from=build-frontend /usr/src/app/build /usr/share/nginx/html
 COPY --from=generate-build-info /usr/src/app/build /usr/share/nginx/html
 
 RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /etc/nginx/nginx.conf.template
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 USER $UID
 
 EXPOSE 8080
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+if [ "$APP_ENV" = "prod" ]; then
+    export STATIC_CACHE_CONTROL="public, max-age=2592000, s-maxage=31536000"
+else
+    export STATIC_CACHE_CONTROL="public, must-revalidate"
+fi
+
+echo "Generating nginx.conf from template..."
+
+if ! envsubst '${STATIC_CACHE_CONTROL}' < /etc/nginx/nginx.conf.template > /tmp/nginx.conf; then
+    echo "Error: Failed to generate nginx.conf from template"
+    exit 1
+fi
+
+echo "Starting nginx..."
+
+exec nginx -c /tmp/nginx.conf -g 'daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,7 +15,7 @@ http {
     client_max_body_size 16M;
 
     # MIME
-    include mime.types;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
     # HSTS: only set when the request was proxied over HTTPS
@@ -86,7 +86,7 @@ http {
 
         # media, fonts
         location ~* ([^/\\&\?]+\.+(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2))$ {
-            add_header Cache-Control "public, must-revalidate";
+            add_header Cache-Control "${STATIC_CACHE_CONTROL}";
             add_header Strict-Transport-Security $hsts_header always;
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";
@@ -96,7 +96,7 @@ http {
 
         # assets
         location ~* ([^/\\&\?]+\.+(js|css|ico))$ {
-            add_header Cache-Control "public, must-revalidate";
+            add_header Cache-Control "${STATIC_CACHE_CONTROL}";
             add_header Strict-Transport-Security $hsts_header always;
             add_header X-Content-Type-Options "nosniff";
             add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
## Problem

Static assets in the service-ui Docker image are served with a hardcoded header:

`Cache-Control: public, must-revalidate`

This prevents Cloudflare CDN from caching assets on edge servers, increasing load on the origin and missing CDN benefits ahead of Cloudflare integration.

## Solution

Introduce runtime environment-aware `Cache-Control` headers for static assets:

- **Default / non-prod** (when `APP_ENV` is unset or not `prod`): `public, must-revalidate`
- **Production** (`APP_ENV=prod`): `public, max-age=2592000, s-maxage=31536000`

Implementation details:

- `nginx.conf` is copied as `/etc/nginx/nginx.conf.template` with a `${STATIC_CACHE_CONTROL}` placeholder for static asset locations (js, css, ico, media, fonts).
- New `entrypoint.sh` selects the cache policy based on `APP_ENV`, runs `envsubst` for `${STATIC_CACHE_CONTROL}` only, writes the generated config to `/tmp/nginx.conf`, and starts nginx as the unprivileged user.
- `include` for MIME types uses an absolute path (`/etc/nginx/mime.types`) because nginx is started with `-c /tmp/nginx.conf`.

HTML routes, `/info`, and health endpoints keep their existing cache behavior.

## Deployment

Set `APP_ENV=prod` in the production container environment. If the variable is omitted, the container keeps the current dev-safe default (`public, must-revalidate`).
