### PR TITLE
EPMRPP-118312 || Fix unexpected warning toaster on logout from Test Plan page

### DIFF
--- a/app/src/controllers/testPlan/sagas.ts
+++ b/app/src/controllers/testPlan/sagas.ts
@@ -15,7 +15,7 @@
  */
 
 import { Action } from 'redux';
-import { takeLatest, call, select, all, put } from 'redux-saga/effects';
+import { takeLatest, takeEvery, call, select, all, put } from 'redux-saga/effects';
 
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
@@ -31,6 +31,7 @@ import {
 import { projectKeySelector } from 'controllers/project';
 import { locationSelector, PROJECT_MILESTONES_PAGE } from 'controllers/pages';
 import { LocationInfo } from 'controllers/pages/typed-selectors';
+import { LOGOUT } from 'controllers/auth';
 
 import {
   GET_TEST_PLANS,
@@ -45,6 +46,8 @@ import {
 import { GetTestPlansParams, GetTestPlanParams } from './actionCreators';
 import type { TestPlanDto, TestPlanFoldersDto, TestPlanTestCaseDto } from './types';
 import { Page } from '../../types/common';
+
+let abortController: AbortController | undefined;
 
 interface GetTestPlansAction extends Action<typeof GET_TEST_PLANS> {
   payload?: GetTestPlansParams;
@@ -92,6 +95,10 @@ function* getTestPlans(action: GetTestPlansAction): Generator {
 }
 
 function* getTestPlan(action: GetTestPlanAction): Generator {
+  const controller = new AbortController();
+  abortController?.abort();
+  abortController = controller;
+
   const projectKey = (yield select(projectKeySelector)) as string;
   const location = (yield select(locationSelector)) as LocationInfo;
   const { testPlanId, offset, limit, testCasesSearchParams } = action.payload;
@@ -111,29 +118,36 @@ function* getTestPlan(action: GetTestPlanAction): Generator {
         meta: { namespace: ACTIVE_TEST_PLAN_NAMESPACE },
       });
 
-      const data = (yield call(fetch, URLS.testPlanById(projectKey, testPlanId))) as TestPlanDto;
+      const data = (yield call(fetch, URLS.testPlanById(projectKey, testPlanId), {
+        signal: controller.signal,
+      })) as TestPlanDto;
       const planFolders = (yield call(
         fetch,
         URLS.testFolders(projectKey, { 'filter.eq.testPlanId': testPlanId }),
+        { signal: controller.signal },
       )) as TestPlanFoldersDto;
 
       yield put(fetchSuccessAction(ACTIVE_TEST_PLAN_NAMESPACE, data));
       yield put(fetchSuccessAction(TEST_PLAN_FOLDERS_NAMESPACE, planFolders));
     }
   } catch (error) {
-    yield put(fetchErrorAction(ACTIVE_TEST_PLAN_NAMESPACE, error, true));
-    yield put(
-      showNotification({
-        messageId: 'testPlanRedirectWarningMessage',
-        type: NOTIFICATION_TYPES.WARNING,
-        typographyColor: NOTIFICATION_TYPOGRAPHY_COLOR_TYPES.BLACK,
-        duration: WARNING_NOTIFICATION_DURATION,
-      }),
-    );
-    yield put({
-      type: PROJECT_MILESTONES_PAGE,
-      payload: location.payload,
-    });
+    const isCancellation = error instanceof Error && error.message === 'REQUEST_CANCELED';
+
+    if (!isCancellation) {
+      yield put(fetchErrorAction(ACTIVE_TEST_PLAN_NAMESPACE, error, true));
+      yield put(
+        showNotification({
+          messageId: 'testPlanRedirectWarningMessage',
+          type: NOTIFICATION_TYPES.WARNING,
+          typographyColor: NOTIFICATION_TYPOGRAPHY_COLOR_TYPES.BLACK,
+          duration: WARNING_NOTIFICATION_DURATION,
+        }),
+      );
+      yield put({
+        type: PROJECT_MILESTONES_PAGE,
+        payload: location.payload,
+      });
+    }
 
     return;
   }
@@ -151,17 +165,23 @@ function* getTestPlan(action: GetTestPlanAction): Generator {
       planTestCases = (yield call(
         fetch,
         URLS.testPlanTestCases(projectKey, testPlanId, params),
+        { signal: controller.signal },
       )) as TestPlanTestCaseDto;
     } else {
       planTestCases = (yield call(
         fetch,
-        URLS.testPlanTestCases(projectKey, testPlanId, { 'filter.eq.testFolderId': action.payload.folderId, ...params })
+        URLS.testPlanTestCases(projectKey, testPlanId, { 'filter.eq.testFolderId': action.payload.folderId, ...params }),
+        { signal: controller.signal },
       )) as TestPlanTestCaseDto;
     }
 
     yield put(fetchSuccessAction(TEST_PLAN_TEST_CASES_NAMESPACE, planTestCases));
   } catch (error) {
-    yield put(fetchErrorAction(TEST_PLAN_TEST_CASES_NAMESPACE, error));
+    const isCancellation = error instanceof Error && error.message === 'REQUEST_CANCELED';
+
+    if (!isCancellation) {
+      yield put(fetchErrorAction(TEST_PLAN_TEST_CASES_NAMESPACE, error));
+    }
   }
 }
 
@@ -169,8 +189,15 @@ function* watchGetTestPlans() {
   yield takeLatest(GET_TEST_PLANS, getTestPlans);
 }
 
+function handleLogoutDuringTestPlanFetch(): void {
+  const controller = abortController;
+  abortController = undefined;
+  controller?.abort();
+}
+
 function* watchGetTestPlan() {
   yield takeLatest(GET_TEST_PLAN, getTestPlan);
+  yield takeEvery(LOGOUT, handleLogoutDuringTestPlanFetch);
 }
 
 export function* testPlanSagas() {

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanDetailsPage.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanDetailsPage.tsx
@@ -36,6 +36,7 @@ import {
   locationSelector,
   updatePagePropertiesAction,
 } from 'controllers/pages';
+import { isAuthorizedSelector } from 'controllers/auth';
 import {
   showNotification,
   NOTIFICATION_TYPES,
@@ -100,6 +101,7 @@ export const TestPlanDetailsPage = () => {
   const testCases = useTestPlanSelector(testPlanTestCasesSelector);
 
   const location = useSelector(locationSelector);
+  const isAuthorized = useSelector(isAuthorizedSelector);
   const isLoadingFilteredFolders = useSelector(isLoadingFilteredFoldersSelector);
   const areFoldersLoading = useSelector(areFoldersLoadingSelector);
   const areFoldersFetched = useSelector(areFoldersFetchedSelector);
@@ -240,7 +242,7 @@ export const TestPlanDetailsPage = () => {
   }, [isLoading, areFoldersLoading, testPlan, testPlanFolders, testPlanId, trackEvent]);
 
   useEffect(() => {
-    if (!isLoading && isEmpty(testPlan)) {
+    if (!isLoading && isEmpty(testPlan) && isAuthorized) {
       dispatch(
         showNotification({
           type: NOTIFICATION_TYPES.WARNING,
@@ -255,7 +257,7 @@ export const TestPlanDetailsPage = () => {
         payload: { organizationSlug, projectSlug },
       });
     }
-  }, [isLoading, testPlan, dispatch, organizationSlug, projectSlug, formatMessage]);
+  }, [isLoading, testPlan, isAuthorized, dispatch, organizationSlug, projectSlug, formatMessage]);
 
   const breadcrumbDescriptors = [
     {


### PR DESCRIPTION
## Problem

When a user adds test cases to a Test Plan and then logs out, a yellow warning toaster ("Test plan not found") appeared unexpectedly.

**Root cause:** On logout, the Redux store is synchronously reset in `configureStore.js`, which clears the `testPlan` slice before the `TestPlanDetailsPage` component unmounts. A `useEffect` in the component observed `!isLoading && isEmpty(testPlan)` as `true` and dispatched a `WARNING` notification — while the user was already in the process of logging out.

The saga-level fix (AbortController) was a correct secondary improvement but did not address the actual source of the toaster, which was in the component.

## Changes

### `controllers/testPlan/sagas.ts`

- Added `AbortController` to cancel in-flight requests when a new `GET_TEST_PLAN` action is dispatched or when `LOGOUT` fires.
- Added `isCancellation` guard in both `catch` blocks so that aborted requests do not produce error or warning notifications.
- Added `handleLogoutDuringTestPlanFetch` + `takeEvery(LOGOUT, ...)` — follows the same pattern already established in `milestone/sagas.ts`.

### `pages/inside/testPlansPage/testPlanDetailsPage/testPlanDetailsPage.tsx`

- Added `isAuthorized` from `isAuthorizedSelector` to the "test plan not found" `useEffect`.
- The notification and redirect now only fire when the user is still authenticated (`&& isAuthorized`), preventing the false positive during logout.
- `isAuthorized` added to the effect's dependency array.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| Logout from Test Plan page | Yellow warning toaster appears | No toaster |
| Navigate to a deleted/missing Test Plan | Warning toaster + redirect to Milestones | Unchanged |

## Visuals
TBD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-plan loading by canceling outdated requests when a new request starts or when logging out.
  * Prevented canceled requests from triggering error notifications, redirects, or misleading test-case errors.
  * Restricted missing-test-plan warnings and redirects to authorized users only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->