### PR TITLE
EPMRPP-118361 || Test cases folders are displayed for some time when applying search/filters for no results

### DIFF
--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.scss
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.scss
@@ -175,7 +175,7 @@
 
   &__search-wrapper {
     @include flex-center(row, center, center);
-    
+
     flex-shrink: 0;
     padding: 7px 8px;
     background-color: var(--rp-ui-base-bg-200);
@@ -268,7 +268,8 @@
     flex-direction: column;
   }
 
-  &__no-search-results {
+  &__no-search-results,
+  &__search-loading {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useDrop } from 'react-dnd';
 import { isEmpty } from 'es-toolkit/compat';
@@ -169,25 +169,7 @@ export const ExpandedOptions = ({
 
   const totalTestCases = hasFolderSidebarFilters ? filteredTotalTestCases : allTestCasesTotal;
 
-  const sidebarFilterKey = useMemo(
-    () => `${pageSearchQuery ?? ''}|${JSON.stringify(searchExtraFilters ?? {})}`,
-    [pageSearchQuery, searchExtraFilters],
-  );
-  const [respondedSidebarFilterKey, setRespondedSidebarFilterKey] = useState<string | null>(null);
-  const prevSidebarLoadingRef = useRef(isSearchFilteredLoading);
-
-  useEffect(() => {
-    if (prevSidebarLoadingRef.current && !isSearchFilteredLoading) {
-      setRespondedSidebarFilterKey(sidebarFilterKey);
-    }
-    prevSidebarLoadingRef.current = isSearchFilteredLoading;
-  }, [isSearchFilteredLoading, sidebarFilterKey]);
-
-  const isSidebarFilterStale =
-    hasFolderSidebarFilters && respondedSidebarFilterKey !== sidebarFilterKey;
-
-  const isSidebarResolving = isSearchFilteredLoading || isSidebarFilterStale;
-
+  const isSidebarResolving = isSearchFilteredLoading;
   const showNoSearchResults =
     hasFolderSidebarFilters && !isSidebarResolving && !hasSearchFilteredFolders;
   const hideSidebar =

--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
@@ -20,7 +20,13 @@ import { useDrop } from 'react-dnd';
 import { isEmpty } from 'es-toolkit/compat';
 import Parser from 'html-react-parser';
 import { useSelector } from 'react-redux';
-import { BaseIconButton, SearchIcon, FieldText, useTreeDropValidation } from '@reportportal/ui-kit';
+import {
+  BaseIconButton,
+  BubblesLoader,
+  SearchIcon,
+  FieldText,
+  useTreeDropValidation,
+} from '@reportportal/ui-kit';
 import { TreeSortableContainer, DragLayer } from '@reportportal/ui-kit/sortable';
 import type { TreeDragItem, TreeDropPosition } from '@reportportal/ui-kit/common';
 
@@ -181,19 +187,12 @@ export const ExpandedOptions = ({
     hasFolderSidebarFilters && respondedSidebarFilterKey !== sidebarFilterKey;
 
   const isSidebarResolving = isSearchFilteredLoading || isSidebarFilterStale;
-  const [stableHidePageSearchSidebar, setStableHidePageSearchSidebar] = useState(false);
 
-  useEffect(() => {
-    if (!hasFolderSidebarFilters) {
-      setStableHidePageSearchSidebar(false);
-      return;
-    }
-    if (!isSidebarResolving) {
-      setStableHidePageSearchSidebar(!hasSearchFilteredFolders);
-    }
-  }, [hasFolderSidebarFilters, isSidebarResolving, hasSearchFilteredFolders]);
-
-  const hideSidebar = stableHidePageSearchSidebar || hideFolderSidebar;
+  const showNoSearchResults =
+    hasFolderSidebarFilters && !isSidebarResolving && !hasSearchFilteredFolders;
+  const hideSidebar =
+    hideFolderSidebar ||
+    (hasFolderSidebarFilters && (isSidebarResolving || !hasSearchFilteredFolders));
 
   const handleMoveFolder = useCallback(
     (draggedItem: TreeDragItem, targetId: string | number, position: TreeDropPosition) => {
@@ -244,6 +243,42 @@ export const ExpandedOptions = ({
       expandedIds: effectiveExpandedIds,
     });
   }, [isFlatView, searchQuery, folderSearchSource, activeFolderId, effectiveExpandedIds]);
+
+  const renderContentArea = () => {
+    if (showNoSearchResults) {
+      return (
+        <div className={cx('expanded-options__content-scroll')}>
+          <div className={cx('expanded-options__content')}>
+            <div className={cx('expanded-options__no-search-results')}>
+              <EmptyPageState
+                label={formatMessage(COMMON_LOCALE_KEYS.NO_RESULTS)}
+                description={formatMessage(testCaseListMessages.noResultsDescription)}
+                emptyIcon={NoResultsIcon}
+              />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (hasFolderSidebarFilters && isSidebarResolving) {
+      return (
+        <div className={cx('expanded-options__content-scroll')}>
+          <div className={cx('expanded-options__content')}>
+            <div className={cx('expanded-options__search-loading')}>
+              <BubblesLoader />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <ScrollWrapper className={cx('expanded-options__content-scroll')}>
+        <div className={cx('expanded-options__content')}>{children}</div>
+      </ScrollWrapper>
+    );
+  };
 
   const renderContent = () => (
     <>
@@ -352,23 +387,7 @@ export const ExpandedOptions = ({
             )}
           </div>
         )}
-        {stableHidePageSearchSidebar ? (
-          <div className={cx('expanded-options__content-scroll')}>
-            <div className={cx('expanded-options__content')}>
-              <div className={cx('expanded-options__no-search-results')}>
-                <EmptyPageState
-                  label={formatMessage(COMMON_LOCALE_KEYS.NO_RESULTS)}
-                  description={formatMessage(testCaseListMessages.noResultsDescription)}
-                  emptyIcon={NoResultsIcon}
-                />
-              </div>
-            </div>
-          </div>
-        ) : (
-          <ScrollWrapper className={cx('expanded-options__content-scroll')}>
-            <div className={cx('expanded-options__content')}>{children}</div>
-          </ScrollWrapper>
-        )}
+        {renderContentArea()}
       </div>
     </>
   );


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

before: 

https://github.com/user-attachments/assets/afb76a65-b358-4d78-bb00-cdba28cfb878

after: 

https://github.com/user-attachments/assets/fa93eded-3e2d-494a-816a-2af777670a8e

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar search behavior to clearly distinguish between loading, no results, and available content.
  - Added a centered loading indicator while filtered results are being prepared.
  - Updated empty-state presentation for completed searches with no matching results.
  - Preserved normal content display when results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->