### PR TITLE
EPMRPP-118684 || Retention in Project Settings is set incorrectly after updating Billing plan and retention in Organization settings

### DIFF
--- a/app/src/pages/inside/projectSettingsPageContainer/generalTab/generalTab.jsx
+++ b/app/src/pages/inside/projectSettingsPageContainer/generalTab/generalTab.jsx
@@ -138,6 +138,7 @@ export class GeneralTab extends Component {
   static defaultProps = {
     lang: 'en',
     organizationSettings: {},
+    formValues: {},
     isLoading: false,
     userRoles: {},
   };
@@ -241,7 +242,19 @@ export class GeneralTab extends Component {
     return !retentionLimit || retentionLimit > value ? value : retentionLimit;
   };
 
-  getRetentionOptions = (fieldName) => {
+  sortValues = (a, b) => {
+    if (a.value === 0) {
+      return 1;
+    }
+
+    if (b.value === 0) {
+      return -1;
+    }
+
+    return a.value - b.value;
+  };
+
+  getBaseOptions = (fieldName) => {
     const { lang } = this.props;
     const retentionLimits = this.getRetentionLimits();
     const retentionLimit = retentionLimits[fieldName];
@@ -264,21 +277,22 @@ export class GeneralTab extends Component {
     return options;
   };
 
-  createValueFormatter = (values) => (value) => {
-    const selectedOption = values.find((option) => option.value === value);
-    if (selectedOption) {
-      return selectedOption;
-    }
-    return { label: secondsToDays(value, this.props.lang), value };
-  };
+  getRetentionOptions = (fieldName, value) => {
+    const { intl, lang } = this.props;
+    const options = [...this.getBaseOptions(fieldName)];
 
-  formatRetention = (fieldName) => this.createValueFormatter(this.getRetentionOptions(fieldName));
+    if (Number.isFinite(value) && !options.some((elem) => elem.value === value)) {
+      const label =
+        value === 0 ? intl.formatMessage(settingsMessages.forever) : secondsToDays(value, lang);
+      options.push({ label, value });
+      options.sort(this.sortValues);
+    }
+
+    return options;
+  };
 
   formatInputValues = () => {
     const { formValues } = this.props;
-    if (!formValues) {
-      return {};
-    }
     const arrValues = Object.entries(formValues).map(([key, value]) => [
       key,
       value === 0 ? Infinity : value,
@@ -289,8 +303,9 @@ export class GeneralTab extends Component {
   };
 
   getLaunchesOptions = () => {
+    const { formValues } = this.props;
     const inputValues = this.formatInputValues();
-    const options = this.getRetentionOptions('keepLaunches');
+    const options = this.getRetentionOptions('keepLaunches', formValues.keepLaunches);
     const newOptions = options.map((elem) => {
       const disabled =
         elem.value !== 0 &&
@@ -307,8 +322,9 @@ export class GeneralTab extends Component {
   };
 
   getLogOptions = () => {
+    const { formValues } = this.props;
     const inputValues = this.formatInputValues();
-    const options = this.getRetentionOptions('keepLogs');
+    const options = this.getRetentionOptions('keepLogs', formValues.keepLogs);
     const newOptions = options.map((elem) => {
       const disabled =
         elem.value === 0
@@ -327,24 +343,19 @@ export class GeneralTab extends Component {
           : undefined,
       };
     });
-    if (newOptions.every((v) => v.hidden)) {
-      newOptions.push(this.formatRetention('keepLogs')(inputValues.keepLogs));
-    }
     return newOptions;
   };
 
   getScreenshotsOptions = () => {
+    const { formValues } = this.props;
     const inputValues = this.formatInputValues();
-    const options = this.getRetentionOptions('keepScreenshots');
+    const options = this.getRetentionOptions('keepScreenshots', formValues.keepScreenshots);
     const newOptions = options.map((elem) => {
       const isHidden =
         elem.value === 0 ? elem.value !== inputValues.keepLogs : elem.value > inputValues.keepLogs;
       const hidden = inputValues.keepLogs === Infinity ? false : isHidden;
       return { ...elem, hidden };
     });
-    if (newOptions.every((v) => v.hidden)) {
-      newOptions.push(this.formatRetention('keepScreenshots')(inputValues.keepScreenshots));
-    }
     return newOptions;
   };
 


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
Project Settings retention dropdowns rendered empty after raising org retention.

**Cause:** options were filtered by the org limit but never included the project's own value (`86400` [1 day] vs options `7d/14d`), so the `Dropdown` value appears empty.

**Fix** in `projectSettingsPageContainer/generalTab.jsx`, mirroring the `useRetentionUtils` hook (used in Org settings):

- `getBaseOptions(fieldName)` filters by org limit; `getRetentionOptions(fieldName, value)` appends the current value if missing and sorts
- Dropped `createValueFormatter` / `formatRetention` and both `every((v) => v.hidden)` workarounds
- Values now read from `formValues` (added `{}` default); 

The retention rules left untouched:
```pre
project.keepScreenshots  ≤  project.keepLogs  ≤  project.keepLaunches
         ≤                        ≤                      ≤
  org.attachments        ≤     org.logs       ≤    org.launches
         ≤                        ≤                      ≤
   billing.retention  (one value, the same for all 3 fields)
```

## Links
[EPMRPP-118684](https://jiraeu.epam.com/browse/EPMRPP-118684)

## Visuals
**_Before:_**

https://github.com/user-attachments/assets/1af1f69b-9fb1-4d70-81b5-1b0c404ee644


**_After:_**

https://github.com/user-attachments/assets/d3b44924-5fef-4a74-9c4e-ba6735e9600d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention settings so existing custom values remain available and are displayed with clear labels.
  * Retention options are now consistently filtered and sorted based on configured limits.
  * Removed unexpected hidden log and screenshot options from the settings interface.
  * Improved handling of retention settings when no initial form values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->