### PR TITLE
EPMRPP-118536 || Impossible to change test status for Manual Launches from the side menu

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/executionSidePanel/executionSidePanel.tsx
@@ -87,7 +87,7 @@ export const ExecutionSidePanel = ({ executionId, onClose }: ExecutionSidePanelP
     executionDetails?.manualScenario?.manualScenarioType === TestCaseManualScenario.TEXT;
   const [isStatusPopoverOpen, setIsStatusPopoverOpen] = useState(false);
 
-  useOnClickOutside(sidePanelRef, onClose);
+  useOnClickOutside(sidePanelRef, isStatusPopoverOpen ? undefined : onClose);
 
   const onFolderClick = (e?: React.MouseEvent, folderId?: number) => {
     e?.preventDefault();

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/constants.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/constants.ts
@@ -15,7 +15,6 @@
  */
 
 import { commonMessages } from 'pages/inside/common/common-messages';
-import { ExecutionStatus } from 'pages/inside/manualLaunchesPage/types';
 
 import type { StatusButtonConfig, StatusConfig, ExecutionStatusType } from './types';
 
@@ -23,13 +22,6 @@ export const EXECUTION_STATUS_TO_RUN = 'TO_RUN' as const;
 export const EXECUTION_STATUS_SKIPPED: ExecutionStatusType = 'skipped';
 export const EXECUTION_STATUS_FAILED: ExecutionStatusType = 'failed';
 export const EXECUTION_STATUS_PASSED: ExecutionStatusType = 'passed';
-
-
-export const RECORDED_RESULT_STATUSES: ExecutionStatus[] = [
-  ExecutionStatus.PASSED,
-  ExecutionStatus.FAILED,
-  ExecutionStatus.SKIPPED,
-];
 
 export const STATUS_BUTTONS: StatusButtonConfig[] = [
   { status: EXECUTION_STATUS_SKIPPED, message: commonMessages.skipped },

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/constants.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/constants.ts
@@ -15,6 +15,7 @@
  */
 
 import { commonMessages } from 'pages/inside/common/common-messages';
+import { ExecutionStatus } from 'pages/inside/manualLaunchesPage/types';
 
 import type { StatusButtonConfig, StatusConfig, ExecutionStatusType } from './types';
 
@@ -22,6 +23,13 @@ export const EXECUTION_STATUS_TO_RUN = 'TO_RUN' as const;
 export const EXECUTION_STATUS_SKIPPED: ExecutionStatusType = 'skipped';
 export const EXECUTION_STATUS_FAILED: ExecutionStatusType = 'failed';
 export const EXECUTION_STATUS_PASSED: ExecutionStatusType = 'passed';
+
+
+export const RECORDED_RESULT_STATUSES: ExecutionStatus[] = [
+  ExecutionStatus.PASSED,
+  ExecutionStatus.FAILED,
+  ExecutionStatus.SKIPPED,
+];
 
 export const STATUS_BUTTONS: StatusButtonConfig[] = [
   { status: EXECUTION_STATUS_SKIPPED, message: commonMessages.skipped },

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
@@ -49,16 +49,6 @@
       padding: 0 !important;
     }
   }
-
-  &--simple {
-    .checkbox-section {
-      padding-bottom: 0;
-    }
-
-    .confirmation-text:last-child {
-      margin-bottom: 0;
-    }
-  }
 }
 
 .modal-content {

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -62,7 +62,6 @@ import {
   EXECUTION_STATUS_CONFIRM_FORM_NAME,
   STATUS_CONFIG,
   EXECUTION_STATUS_FAILED,
-  RECORDED_RESULT_STATUSES,
 } from '../constants';
 import { messages } from './messages';
 import { messages as commonMessages } from '../messages';
@@ -96,6 +95,8 @@ const ExecutionStatusConfirmModalComponent: FC<
   const isClearStatus = status === ExecutionStatus.TO_RUN;
   const executionId = data?.executionId;
 
+  const hasLoadedExecution = !!executionId && activeExecution?.id === executionId;
+
   const {
     pendingFiles: attachedFiles,
     removedAttachmentIds: removedServerAttachmentIds,
@@ -106,56 +107,41 @@ const ExecutionStatusConfirmModalComponent: FC<
     handleExistingRemove: handleServerAttachmentRemove,
   } = useFileAttachments({
     resetKey: modalKey,
-    existingAttachments:
-      executionId && activeExecution?.id === executionId
-        ? (activeExecution.executionComment?.attachments ?? [])
-        : [],
+    existingAttachments: hasLoadedExecution
+      ? (activeExecution.executionComment?.attachments ?? [])
+      : [],
     messages: {
       duplicateFileNames: commonMessages.duplicateFileNames,
       emptyFiles: commonMessages.emptyFiles,
     },
   });
-  const currentStatus = data?.currentStatus;
   const statusLabel = isClearStatus ? '' : formatMessage(STATUS_CONFIG[status]?.label);
   const title = isClearStatus
     ? formatMessage(messages.clearStatus)
     : formatMessage(messages.markAsStatus, { status: statusLabel });
 
-  const hasRecordedResult = RECORDED_RESULT_STATUSES.includes(
-    String(currentStatus).toUpperCase() as ExecutionStatus,
-  );
-  const isStatusChange = hasRecordedResult && !isClearStatus;
   const showPostIssueToBts =
     canManageExecutions && status === EXECUTION_STATUS_FAILED && !isEmpty(availableBtsIntegrations);
   const okButtonLabel = isClearStatus
     ? formatMessage(messages.clearStatus)
     : formatMessage(messages.markAsStatus, { status: statusLabel });
 
-  const shouldSeedCommentForm = !isStatusChange && !isClearStatus;
+  const shouldSeedCommentForm = !isClearStatus;
+  const seededComment = hasLoadedExecution
+    ? String(activeExecution.executionComment?.comment ?? '')
+    : '';
 
   useEffect(() => {
     if (!executionId || dirty || !shouldSeedCommentForm) return;
 
-    const comment =
-      activeExecution?.id === executionId
-        ? String(activeExecution.executionComment?.comment ?? '')
-        : '';
-
     dispatch(
       initialize(EXECUTION_STATUS_CONFIRM_FORM_NAME, {
-        comment,
+        comment: seededComment,
         postIssueToBts: false,
         clearCommentAndLinksToBTS: false,
       }),
     );
-  }, [
-    executionId,
-    shouldSeedCommentForm,
-    dirty,
-    dispatch,
-    activeExecution?.id,
-    activeExecution?.executionComment?.comment,
-  ]);
+  }, [executionId, shouldSeedCommentForm, seededComment, dirty, dispatch]);
 
   const onSubmit = (values: ExecutionStatusConfirmFormValues) => {
     if (!executionId) return;
@@ -189,8 +175,8 @@ const ExecutionStatusConfirmModalComponent: FC<
         postIssueToBts: clearCommentCheckboxChecked ? false : values.postIssueToBts,
         attachments: clearCommentCheckboxChecked ? [] : attachedFiles,
         clearExecutionCommentAndBts: isClearStatus ? clearCommentCheckboxChecked : undefined,
-        preserveExistingCommentIfFormSkipped: isStatusChange,
-        ...(!isClearStatus && !isStatusChange
+        preserveExistingCommentIfFormSkipped: !hasLoadedExecution,
+        ...(!isClearStatus && hasLoadedExecution
           ? { removedServerAttachmentIds: Array.from(removedServerAttachmentIds) }
           : {}),
         onSuccess: () => {
@@ -227,38 +213,13 @@ const ExecutionStatusConfirmModalComponent: FC<
       cancelButton={cancelButton}
       allowCloseOutside={!dirty && !isSubmitting}
       scrollable
-      className={cx('execution-status-confirm-modal', {
-        'execution-status-confirm-modal--simple': isStatusChange,
-      })}
+      className={cx('execution-status-confirm-modal')}
     >
       <form
         className={cx('modal-content')}
         onSubmit={handleSubmit(onSubmit) as (event: FormEvent) => void}
       >
-        {isStatusChange && (
-          <>
-            <div className={cx('confirmation-text')}>
-              <div className={cx('confirmation-question')}>
-                {formatMessage(messages.confirmStatusChange, {
-                  status: <strong>{statusLabel}</strong>,
-                })}
-              </div>
-              <div className={cx('confirmation-hint')}>
-                {formatMessage(messages.updateCommentIfNeeded)}
-              </div>
-            </div>
-
-            {showPostIssueToBts && (
-              <div className={cx('checkbox-section')}>
-                <FieldProvider name="postIssueToBts">
-                  <InputCheckbox>{formatMessage(commonMessages.postIssueToBts)}</InputCheckbox>
-                </FieldProvider>
-              </div>
-            )}
-          </>
-        )}
-
-        {!isStatusChange && !isClearStatus && (
+        {!isClearStatus && (
           <>
             <div className={cx('comment-section')}>
               <FieldProvider name="comment">

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -62,6 +62,7 @@ import {
   EXECUTION_STATUS_CONFIRM_FORM_NAME,
   STATUS_CONFIG,
   EXECUTION_STATUS_FAILED,
+  RECORDED_RESULT_STATUSES,
 } from '../constants';
 import { messages } from './messages';
 import { messages as commonMessages } from '../messages';
@@ -119,7 +120,11 @@ const ExecutionStatusConfirmModalComponent: FC<
   const title = isClearStatus
     ? formatMessage(messages.clearStatus)
     : formatMessage(messages.markAsStatus, { status: statusLabel });
-  const isStatusChange = currentStatus && !isClearStatus;
+
+  const hasRecordedResult = RECORDED_RESULT_STATUSES.includes(
+    String(currentStatus).toUpperCase() as ExecutionStatus,
+  );
+  const isStatusChange = hasRecordedResult && !isClearStatus;
   const showPostIssueToBts =
     canManageExecutions && status === EXECUTION_STATUS_FAILED && !isEmpty(availableBtsIntegrations);
   const okButtonLabel = isClearStatus


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
before: 

https://github.com/user-attachments/assets/9ec477bb-f012-42c4-88af-619b850057f1


after: 
<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->

https://github.com/user-attachments/assets/8c5cd748-e297-448c-aaf2-32c4915c57ba



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the execution side panel from closing when the status popover is open.
  - Improved execution status-change confirmation behavior by correctly distinguishing recorded results from cleared or in-progress statuses.
  - Ensured status changes are handled consistently when clearing an execution result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->