### PR TITLE
EPMRPP-118314 || No limits for the "Execution time, min" field for the Test case leads to unexpected errors

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/commonMessages.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/commonMessages.ts
@@ -110,6 +110,10 @@ export const commonMessages: Record<string, MessageDescriptor> = defineMessages(
     id: 'CreateTestCaseModal.executionTime',
     defaultMessage: 'Execution time, min',
   },
+  executionTimeMaxValueHint: {
+    id: 'CreateTestCaseModal.executionTimeMaxValueHint',
+    defaultMessage: 'Value cannot exceed {maxValue}',
+  },
   duplicateTestCase: {
     id: 'TestCaseLibraryPage.duplicateTestCase',
     defaultMessage: 'Duplicate Test Case',

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseDetails/template/template.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseDetails/template/template.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useCallback } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { noop } from 'es-toolkit';
 import { FieldNumber } from '@reportportal/ui-kit';
@@ -22,6 +23,10 @@ import { createClassnames } from 'common/utils';
 import { FieldProvider } from 'components/fields';
 import { ManualScenarioType } from 'pages/inside/testCaseLibraryPage/types';
 import { commonMessages } from 'pages/inside/testCaseLibraryPage/commonMessages';
+import {
+  EXECUTION_ESTIMATION_TIME_MAX_VALUE,
+  createExecutionEstimationTimeMaxValidator,
+} from 'pages/inside/testCaseLibraryPage/utils/executionEstimationTimeFieldUtils';
 
 import { DropdownWithDescription } from '../../dropdownWithDescription';
 
@@ -59,6 +64,16 @@ interface TemplateProps {
 export const Template = ({ isTemplateFieldDisabled = false }: TemplateProps) => {
   const { formatMessage } = useIntl();
 
+  const validateExecutionTime = useCallback(
+    (value: unknown) =>
+      createExecutionEstimationTimeMaxValidator(
+        formatMessage(commonMessages.executionTimeMaxValueHint, {
+          maxValue: EXECUTION_ESTIMATION_TIME_MAX_VALUE,
+        }),
+      )(value),
+    [formatMessage],
+  );
+
   const templateOptions = [
     {
       value: ManualScenarioType.STEPS,
@@ -83,9 +98,10 @@ export const Template = ({ isTemplateFieldDisabled = false }: TemplateProps) => 
         />
       </FieldProvider>
       <div className={cx('template__execution-time')}>
-        <FieldProvider name="executionEstimationTime">
+        <FieldProvider name="executionEstimationTime" validate={validateExecutionTime}>
           <FieldNumber
             min={1}
+            max={EXECUTION_ESTIMATION_TIME_MAX_VALUE}
             label={formatMessage(commonMessages.executionTime)}
             onChange={noop}
           />

--- a/app/src/pages/inside/testCaseLibraryPage/editScenarioModal/scenarioFields.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/editScenarioModal/scenarioFields.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { MIME_TYPES } from '@reportportal/ui-kit/fileDropArea';
 import { FieldNumber } from '@reportportal/ui-kit';
@@ -22,7 +23,11 @@ import { noop } from 'es-toolkit';
 
 import { createClassnames } from 'common/utils';
 import { FieldProvider } from 'components/fields';
-import { normalizeExecutionEstimationTime } from '../utils/executionEstimationTimeFieldUtils';
+import {
+  normalizeExecutionEstimationTime,
+  EXECUTION_ESTIMATION_TIME_MAX_VALUE,
+  createExecutionEstimationTimeMaxValidator,
+} from '../utils/executionEstimationTimeFieldUtils';
 
 import { AttachmentArea } from '../createTestCaseModal/attachmentArea';
 import { Precondition } from '../createTestCaseModal/testCaseDetails/precondition';
@@ -45,6 +50,16 @@ export const ScenarioFields = ({ formName }: ScenarioFieldsProps) => {
   const manualScenarioType = useSelector(manualScenarioTypeSelector(formName));
   const stepsData = useSelector(stepsDataSelector(formName));
 
+  const validateExecutionTime = useCallback(
+    (value: unknown) =>
+      createExecutionEstimationTimeMaxValidator(
+        formatMessage(commonMessages.executionTimeMaxValueHint, {
+          maxValue: EXECUTION_ESTIMATION_TIME_MAX_VALUE,
+        }),
+      )(value),
+    [formatMessage],
+  );
+
   const { steps, isEditMode, handleAddStep, handleRemoveStep, handleMoveStep, handleReorderSteps } =
     useStepsManagement({
       formName,
@@ -60,9 +75,11 @@ export const ScenarioFields = ({ formName }: ScenarioFieldsProps) => {
         <FieldProvider
           name="executionEstimationTime"
           parse={normalizeExecutionEstimationTime}
+          validate={validateExecutionTime}
         >
           <FieldNumber
             min={1}
+            max={EXECUTION_ESTIMATION_TIME_MAX_VALUE}
             label={formatMessage(commonMessages.executionTime)}
             onChange={noop}
           />

--- a/app/src/pages/inside/testCaseLibraryPage/utils/executionEstimationTimeFieldUtils.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/utils/executionEstimationTimeFieldUtils.ts
@@ -23,3 +23,15 @@ export const normalizeExecutionEstimationTime = (value: unknown): string | numbe
 
   return Number.isNaN(time) ? (value as string | number) : time;
 };
+
+export const EXECUTION_ESTIMATION_TIME_MAX_VALUE = 2147483647;
+
+export const createExecutionEstimationTimeMaxValidator =
+  (errorMessage: string) =>
+  (value: unknown): string | undefined => {
+    const time = Number(value);
+
+    return !Number.isNaN(time) && time > EXECUTION_ESTIMATION_TIME_MAX_VALUE
+      ? errorMessage
+      : undefined;
+  };


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals

Before: 

https://github.com/user-attachments/assets/8df7d96b-c678-4694-bbbf-8a2836f4d99b


After: 

https://github.com/user-attachments/assets/9d00b3ad-3bc9-472d-99de-d98c22b2a493


<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added maximum-value validation for execution-time fields when creating test cases and editing scenarios.
  - Displays a clear localized message when the execution time exceeds the allowed limit.
  - Prevents values above the supported maximum from being submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->