### PR TITLE
EPMRPP-118572 || Incorrect modal window layout on status change when no BTS integrations are configured

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.scss
@@ -148,7 +148,7 @@ $sidebar-width: calc(100vw - 408px);
 }
 
 .test-name-link {
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.scss
@@ -84,6 +84,10 @@
   }
 }
 
+.post-issue-tooltip-wrapper {
+  width: fit-content !important;
+}
+
 .divider {
   border-top: 1px solid var(--rp-ui-base-e-100);
 }

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -25,6 +25,7 @@ import {
   FieldTextFlex,
   PlusIcon,
   DragAndDropIcon,
+  Tooltip,
 } from '@reportportal/ui-kit';
 import { MIME_TYPES } from '@reportportal/ui-kit/fileDropArea';
 import { VoidFn } from '@reportportal/ui-kit/common';
@@ -61,7 +62,6 @@ import {
   EXECUTION_STATUS_CONFIRM_MODAL,
   EXECUTION_STATUS_CONFIRM_FORM_NAME,
   STATUS_CONFIG,
-  EXECUTION_STATUS_FAILED,
 } from '../constants';
 import { messages } from './messages';
 import { messages as commonMessages } from '../messages';
@@ -120,8 +120,8 @@ const ExecutionStatusConfirmModalComponent: FC<
     ? formatMessage(messages.clearStatus)
     : formatMessage(messages.markAsStatus, { status: statusLabel });
 
-  const showPostIssueToBts =
-    canManageExecutions && status === EXECUTION_STATUS_FAILED && !isEmpty(availableBtsIntegrations);
+  const canPostIssueToBts = canManageExecutions;
+  const hasBtsIntegration = !isEmpty(availableBtsIntegrations);
   const okButtonLabel = isClearStatus
     ? formatMessage(messages.clearStatus)
     : formatMessage(messages.markAsStatus, { status: statusLabel });
@@ -235,15 +235,29 @@ const ExecutionStatusConfirmModalComponent: FC<
               </FieldProvider>
             </div>
 
-            {showPostIssueToBts && (
+            {canPostIssueToBts && (
               <div className={cx('checkbox-section')}>
-                <FieldProvider name="postIssueToBts">
-                  <InputCheckbox>{formatMessage(commonMessages.postIssueToBts)}</InputCheckbox>
-                </FieldProvider>
+                {hasBtsIntegration  ? (
+                  <FieldProvider name="postIssueToBts">
+                    <InputCheckbox>{formatMessage(commonMessages.postIssueToBts)}</InputCheckbox>
+                  </FieldProvider>
+                ) : (
+                  <Tooltip
+                    content={formatMessage(commonMessages.postIssueToBtsDisabledTooltip)}
+                    placement="top"
+                    wrapperClassName={cx('post-issue-tooltip-wrapper')}
+                  >
+                    <FieldProvider name="postIssueToBts">
+                      <InputCheckbox disabled>
+                        {formatMessage(commonMessages.postIssueToBts)}
+                      </InputCheckbox>
+                    </FieldProvider>
+                  </Tooltip>
+                )}
               </div>
             )}
 
-            {showPostIssueToBts && <div className={cx('divider')} />}
+            {canPostIssueToBts && <div className={cx('divider')} />}
 
             <div className={cx('attachments-section')}>
               <div className={cx('attachments-file-drop')}>

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -162,7 +162,8 @@ const ExecutionStatusConfirmModalComponent: FC<
       );
     }
 
-    const shouldOpenBtsModal = values.postIssueToBts && !clearCommentCheckboxChecked;
+    const shouldOpenBtsModal =
+      values.postIssueToBts && hasBtsIntegration && !clearCommentCheckboxChecked;
 
     setIsSubmitting(true);
     dispatch(

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/messages.ts
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/messages.ts
@@ -89,4 +89,8 @@ export const messages = defineMessages({
     id: 'ExecutionStatusConfirmModal.postIssueToBts',
     defaultMessage: 'Post or link issue to BTS',
   },
+  postIssueToBtsDisabledTooltip: {
+    id: 'ExecutionStatusConfirmModal.postIssueToBtsDisabledTooltip',
+    defaultMessage: 'No integration with BTS configured yet.\nContact Admin for assistance',
+  },
 });


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
## Description
showing the checkbox correct state by checking BTS integrations list + some style fixes

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to post or link a BTS issue when changing execution statuses, where permitted.
  - Added guidance explaining when issue posting is unavailable because no integration is configured.

- **Bug Fixes**
  - Improved the display and alignment of test-name links.
  - Added clearer disabled-state behavior and tooltip messaging for unavailable issue actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->