### PR TITLE
EPMRPP-118921 || Incorrect project is opened when different organizations contain projects with the same Project Name

### DIFF
--- a/app/src/store/organizationProjectRouteMiddleware.js
+++ b/app/src/store/organizationProjectRouteMiddleware.js
@@ -74,7 +74,8 @@ export const organizationProjectRouteMiddleware = (store) => (next) => (action) 
   if (!authorized || !isOrganizationPage) return next(action);
 
   const { slug: organizationSlug } = activeOrganizationSelector(getState());
-  const { projectSlug } = activeProjectSelector(getState());
+  const { organizationSlug: activeProjectOrganizationSlug, projectSlug } =
+    activeProjectSelector(getState());
   const user = userInfoSelector(getState());
   const {
     hasPermission,
@@ -103,7 +104,10 @@ export const organizationProjectRouteMiddleware = (store) => (next) => (action) 
   }
 
   const isChangedOrganization = !stringEqual(organizationSlug, hashOrganizationSlug);
-  const isChangedProject = isChangedOrganization || !stringEqual(projectSlug, hashProjectSlug);
+  const isChangedProject =
+    isChangedOrganization ||
+    !stringEqual(activeProjectOrganizationSlug, hashOrganizationSlug) ||
+    !stringEqual(projectSlug, hashProjectSlug);
   const projectKey = assignedProjectKey || (assignmentNotRequired && hashProjectKey);
 
   // Organization changed — fetch its data (runs independently of project change)


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Problem:** Incorrect project loaded when two organizations have projects with the same slug.

**Cause:** `isChangedProject` in `organizationProjectRouteMiddleware` compared only `activeOrganization.slug` and `projectSlug`. Since `activeOrganization` and `activeProject` are updated independently, switching between same-slug projects across orgs left both checks `false`, so no project refetch happened and stale `projectInfo` was rendered.

**Fix:** Also compare the URL org slug against `activeProject.organizationSlug`, so a project reload is triggered whenever the URL points to a project from a different organization.

## Links
[EPMRPP-118921](https://jiraeu.epam.com/browse/EPMRPP-118921)

## Visuals
**_Before:_**

https://github.com/user-attachments/assets/e52b1796-46d8-4397-aa7f-f39517fce1e4

**_After:_**

https://github.com/user-attachments/assets/ac8672fe-3d74-4f06-a52f-03b3162faa2b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project navigation detection when the active project belongs to a different organization.
  * Ensured organization and project URLs stay synchronized when switching projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->