### PR TITLE
EPMRPP-118572 || Incorrect modal window layout on status change when no BTS integrations are configured

### DIFF
--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchExecutionPage/executionStatusConfirmModal/executionStatusConfirmModal.tsx
@@ -83,7 +83,7 @@ const ExecutionStatusConfirmModalComponent: FC<
   const launchId = useManualLaunchId();
   const activeExecution = useSelector(activeManualLaunchExecutionSelector);
   const availableBtsIntegrations = useSelector(availableBtsIntegrationsSelector);
-
+  const tooltipRoot = document.getElementById('tooltip-root');
   const modalKey = `${data?.executionId}-${data?.status}-${data?.currentStatus}`;
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -247,6 +247,7 @@ const ExecutionStatusConfirmModalComponent: FC<
                     content={formatMessage(commonMessages.postIssueToBtsDisabledTooltip)}
                     placement="top"
                     wrapperClassName={cx('post-issue-tooltip-wrapper')}
+                    portalRoot={tooltipRoot}
                   >
                     <FieldProvider name="postIssueToBts">
                       <InputCheckbox disabled>


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
before fix : 
<img width="789" height="661" alt="image" src="https://github.com/user-attachments/assets/5c0db540-e258-426d-a976-596fc1dd47a0" />

after fix : 
<img width="696" height="580" alt="image" src="https://github.com/user-attachments/assets/34eaa48f-d5b1-4d06-9ec1-ee5f49d73d52" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip rendering in the execution status confirmation dialog when BTS integration is unavailable.
  * Tooltips now appear within the designated tooltip area for more consistent positioning and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->