### PR TITLE
EPMRPP-118926 || Duplicate Folder submit button stays enabled when Name is empty

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/createFolderModal/createFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/createFolderModal/createFolderModal.tsx
@@ -52,7 +52,7 @@ const CreateFolderModal = reduxForm<FolderFormValues>({
       parentFolder: isToggled ? commonValidators.requiredField(parentFolder) : undefined,
     };
   },
-})(({ dirty, handleSubmit, change }: InjectedFormProps<FolderFormValues>) => {
+})(({ dirty, invalid, handleSubmit, change }: InjectedFormProps<FolderFormValues>) => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
   const { trackEvent } = useTracking();
@@ -85,6 +85,7 @@ const CreateFolderModal = reduxForm<FolderFormValues>({
       formName={CREATE_FORM_NAME}
       title={formatMessage(commonMessages.createFolder)}
       dirty={dirty}
+      invalid={invalid}
       isLoading={isCreatingFolder}
       isToggled={isSubfolderToggled}
       toggleLabel={formatMessage(commonFolderMessages.createAsSubfolder)}

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/duplicateFolderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/duplicateFolderModal/duplicateFolderModal.tsx
@@ -63,6 +63,7 @@ const DuplicateFolderModal = reduxForm<DuplicateFolderFormValues, DuplicateFolde
   }),
 })(({
   dirty,
+  invalid,
   data: {
     folder: { id: folderId, name: folderName, parentFolderId },
   },
@@ -124,6 +125,7 @@ const DuplicateFolderModal = reduxForm<DuplicateFolderFormValues, DuplicateFolde
       formName={DUPLICATE_FORM_NAME}
       title={formatMessage(commonMessages.duplicateFolder)}
       dirty={dirty}
+      invalid={invalid}
       isLoading={isDuplicating}
       isToggled={shouldMoveToRoot}
       toggleLabel={formatMessage(messages.moveToRootDirectory)}

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/folderModal/folderModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/modals/folderModal/folderModal.tsx
@@ -50,11 +50,12 @@ interface FolderModalConfig {
 }
 
 type FolderModalProps = FolderModalConfig &
-  Pick<InjectedFormProps<unknown>, 'dirty' | 'handleSubmit' | 'change'>;
+  Pick<InjectedFormProps<unknown>, 'dirty' | 'invalid' | 'handleSubmit' | 'change'>;
 
 export const FolderModal = ({
   title,
   dirty,
+  invalid,
   isLoading,
   isToggled,
   toggleLabel,
@@ -79,9 +80,11 @@ export const FolderModal = ({
     children: formatMessage(COMMON_LOCALE_KEYS.CREATE),
     onClick: handleSubmit(onSubmit) as () => void,
     disabled:
-      isLoading || parentFolderFieldName === PARENT_FOLDER_FIELD
+      isLoading ||
+      invalid ||
+      (parentFolderFieldName === PARENT_FOLDER_FIELD
         ? isToggled && !formValues?.[parentFolderFieldName as keyof FolderFormValues]
-        : false,
+        : false),
     'data-automation-id': 'submitButton',
   };
 


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Description
added correct submit button validation check for the duplicate folder and create folder modals



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder creation and duplication actions are now unavailable while form entries are invalid.
  * Modal action buttons correctly reflect validation status alongside existing loading and folder-selection conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->