### PR TITLE
EPMRPP-118676 || Keep selected folder by id when duplicating or creating a test case

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.test.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { processFolder } from './testCaseUtils';
+
+describe('processFolder', () => {
+  it('sends testFolderId when the selected folder has an id', () => {
+    const result = processFolder({
+      id: 52,
+      name: 'Test',
+      description: 'Test',
+      fullPath: 'Test',
+    });
+
+    expect(result.payload).toEqual({ testFolderId: 52 });
+    expect(result.existingFolderId).toBe(52);
+    expect(result.newFolderDetails).toBeUndefined();
+  });
+
+  it('sends testFolderId for an existing folder even when fullPath is missing', () => {
+    const result = processFolder({
+      id: 52,
+      name: 'Test',
+    } as Parameters<typeof processFolder>[0]);
+
+    expect(result.payload).toEqual({ testFolderId: 52 });
+    expect(result.existingFolderId).toBe(52);
+    expect(result.newFolderDetails).toBeUndefined();
+  });
+
+  it('creates a new folder only when the value is a name without an id', () => {
+    const result = processFolder('Test');
+
+    expect(result.payload).toEqual({ testFolder: { name: 'Test' } });
+    expect(result.existingFolderId).toBeUndefined();
+    expect(result.newFolderDetails).toEqual({ name: 'Test', parentTestFolderId: undefined });
+  });
+
+  it('creates a nested new folder from NewFolderData', () => {
+    const result = processFolder({ name: 'New folder', parentTestFolderId: 10 });
+
+    expect(result.payload).toEqual({
+      testFolder: { name: 'New folder', parentTestFolderId: 10 },
+    });
+    expect(result.existingFolderId).toBeUndefined();
+  });
+});

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.test.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.test.ts
@@ -57,4 +57,12 @@ describe('processFolder', () => {
     });
     expect(result.existingFolderId).toBeUndefined();
   });
+
+  it('keeps parentTestFolderId when it is 0', () => {
+    const result = processFolder({ name: 'New folder', parentTestFolderId: 0 });
+
+    expect(result.payload).toEqual({
+      testFolder: { name: 'New folder', parentTestFolderId: 0 },
+    });
+  });
 });

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
@@ -25,7 +25,7 @@ import {
   ManualScenarioType,
   CreateTestCaseFormData,
 } from '../types';
-import { NewFolderData } from '../utils/getFolderFromFormValues';
+import { NewFolderData, isNewFolderData } from '../utils/getFolderFromFormValues';
 import { getMeaningfulRequirements } from '../utils/requirementsUtils';
 import { hasStepContent } from '../../common/scenarioUtils';
 
@@ -92,17 +92,25 @@ export const processFolder = (
     };
   }
 
-  const parentId = folder.parentTestFolderId;
+  if (isNewFolderData(folder)) {
+    const parentId = folder.parentTestFolderId;
+
+    return {
+      payload: {
+        testFolder: {
+          name: folder.name,
+          ...(parentId != null && { parentTestFolderId: parentId }),
+        },
+      },
+      newFolderDetails: folder,
+      existingFolderId: undefined,
+    };
+  }
 
   return {
-    payload: {
-      testFolder: {
-        name: folder.name,
-        ...(parentId && { parentTestFolderId: parentId }),
-      },
-    },
-    newFolderDetails: folder,
-    existingFolderId: undefined,
+    payload: { testFolderId: folder.id },
+    newFolderDetails: undefined,
+    existingFolderId: folder.id,
   };
 };
 

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseUtils.ts
@@ -25,7 +25,7 @@ import {
   ManualScenarioType,
   CreateTestCaseFormData,
 } from '../types';
-import { NewFolderData, isNewFolderData } from '../utils/getFolderFromFormValues';
+import { NewFolderData } from '../utils/getFolderFromFormValues';
 import { getMeaningfulRequirements } from '../utils/requirementsUtils';
 import { hasStepContent } from '../../common/scenarioUtils';
 
@@ -76,6 +76,14 @@ interface ProcessFolderResult {
 export const processFolder = (
   folder: FolderWithFullPath | NewFolderData | string,
 ): ProcessFolderResult => {
+  if (!isString(folder) && 'id' in folder && typeof folder.id === 'number') {
+    return {
+      payload: { testFolderId: folder.id },
+      newFolderDetails: undefined,
+      existingFolderId: folder.id,
+    };
+  }
+
   if (isString(folder)) {
     return {
       payload: { testFolder: { name: folder } },
@@ -84,25 +92,17 @@ export const processFolder = (
     };
   }
 
-  if (isNewFolderData(folder)) {
-    const parentId = folder.parentTestFolderId;
-
-    return {
-      payload: {
-        testFolder: {
-          name: folder.name,
-          ...(parentId && { parentTestFolderId: parentId }),
-        },
-      },
-      newFolderDetails: folder,
-      existingFolderId: undefined,
-    };
-  }
+  const parentId = folder.parentTestFolderId;
 
   return {
-    payload: { testFolderId: folder.id },
-    newFolderDetails: undefined,
-    existingFolderId: folder.id,
+    payload: {
+      testFolder: {
+        name: folder.name,
+        ...(parentId && { parentTestFolderId: parentId }),
+      },
+    },
+    newFolderDetails: folder,
+    existingFolderId: undefined,
   };
 };
 

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
@@ -28,6 +28,11 @@ import { commonMessages } from 'pages/inside/testCaseLibraryPage/commonMessages'
 import { findFolderById } from 'pages/inside/testCaseLibraryPage/utils';
 import { NewFolderData } from 'pages/inside/testCaseLibraryPage/utils/getFolderFromFormValues';
 
+import {
+  getFolderAutocompleteLabel,
+  keepSelectedFolderStateReducer,
+} from './keepSelectedFolderStateReducer';
+import { resolveFolderAutocompleteChange } from './resolveFolderAutocompleteChange';
 import { messages } from './messages';
 import styles from './createFolderAutocomplete.scss';
 
@@ -83,7 +88,6 @@ export const CreateFolderAutocomplete = ({
   menuClassName,
   onStateChange = noop,
   onChange = noop,
-  onBlur = noop,
   onFocus = noop,
   maxLength,
 }: CreateFolderAutocompleteProps) => {
@@ -167,27 +171,11 @@ export const CreateFolderAutocomplete = ({
   };
 
   const handleChange = (selectedItem: FolderWithFullPath | string | null) => {
-    if (selectedItem) {
-      onChange(isString(selectedItem) ? { name: selectedItem } : selectedItem);
+    const nextValue = resolveFolderAutocompleteChange(selectedItem, value);
+
+    if (nextValue) {
+      onChange(nextValue);
     }
-
-    autocompleteInputRef.current?.blur();
-  };
-
-  const parseValueToString = (option: FolderWithFullPath | NewFolderData | string) => {
-    if (!option) {
-      return '';
-    }
-
-    if (isString(option)) {
-      return option;
-    }
-
-    if ('fullPath' in option) {
-      return option.description || option.name || '';
-    }
-
-    return option.name || '';
   };
 
   const handleStateChange: SingleAutocompleteOnStateChange = (changes, stateAndHelpers) => {
@@ -197,6 +185,10 @@ export const CreateFolderAutocomplete = ({
 
     onStateChange(changes, stateAndHelpers);
   };
+
+  const stateReducer = keepSelectedFolderStateReducer<FolderWithFullPath | string>(
+    getFolderAutocompleteLabel,
+  );
 
   return (
     <div className={cx('create-folder-autocomplete', className)}>
@@ -220,10 +212,12 @@ export const CreateFolderAutocomplete = ({
         maxLength={maxLength}
         customEmptyListMessage={customEmptyListMessage || formatMessage(messages.noFoldersFound)}
         renderOption={renderOption}
-        parseValueToString={parseValueToString}
+        parseValueToString={getFolderAutocompleteLabel}
+        getUniqKey={(item) => (isString(item) ? item : String(item.id))}
+        stateReducer={stateReducer}
         onStateChange={handleStateChange}
         onChange={handleChange}
-        onBlur={onBlur}
+        onBlur={noop}
         onFocus={onFocus}
       />
     </div>

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
@@ -64,8 +64,8 @@ interface CreateFolderAutocompleteProps {
   placement?: ComponentProps<typeof SingleAutocomplete>['placement'];
   menuClassName?: string;
   onStateChange?: SingleAutocompleteOnStateChange;
-  onChange?: (value: FolderWithFullPath | NewFolderData) => void;
-  onBlur?: () => void;
+  onChange?: (value: FolderWithFullPath | NewFolderData | null) => void;
+  onBlur?: (value?: FolderWithFullPath | NewFolderData | null) => void;
   onFocus?: () => void;
   maxLength?: number;
 }
@@ -88,6 +88,7 @@ export const CreateFolderAutocomplete = ({
   menuClassName,
   onStateChange = noop,
   onChange = noop,
+  onBlur = noop,
   onFocus = noop,
   maxLength,
 }: CreateFolderAutocompleteProps) => {
@@ -171,11 +172,13 @@ export const CreateFolderAutocomplete = ({
   };
 
   const handleChange = (selectedItem: FolderWithFullPath | string | null) => {
-    const nextValue = resolveFolderAutocompleteChange(selectedItem, value);
+    onChange(resolveFolderAutocompleteChange(selectedItem, value));
+  };
 
-    if (nextValue) {
-      onChange(nextValue);
-    }
+  const handleBlur = () => {
+    // Pass the current folder value, not the FocusEvent. redux-form would otherwise
+    // treat event.target.value (display name string) as the field value and drop the id.
+    onBlur(value ?? null);
   };
 
   const handleStateChange: SingleAutocompleteOnStateChange = (changes, stateAndHelpers) => {
@@ -217,7 +220,7 @@ export const CreateFolderAutocomplete = ({
         stateReducer={stateReducer}
         onStateChange={handleStateChange}
         onChange={handleChange}
-        onBlur={noop}
+        onBlur={handleBlur}
         onFocus={onFocus}
       />
     </div>

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
@@ -46,6 +46,8 @@ type SingleAutocompleteRenderOption = ComponentProps<
   typeof SingleAutocomplete<FolderWithFullPath>
 >['renderOption'];
 
+type FolderAutocompleteValue = FolderWithFullPath | NewFolderData | null;
+
 interface CreateFolderAutocompleteProps {
   name?: string;
   label?: string;
@@ -53,7 +55,7 @@ interface CreateFolderAutocompleteProps {
   isRequired?: boolean;
   className?: string;
   customEmptyListMessage?: string;
-  value?: FolderWithFullPath | NewFolderData | null;
+  value?: FolderAutocompleteValue;
   error?: string;
   touched?: boolean;
   shouldDisplayNewFolderButton?: boolean;
@@ -64,8 +66,8 @@ interface CreateFolderAutocompleteProps {
   placement?: ComponentProps<typeof SingleAutocomplete>['placement'];
   menuClassName?: string;
   onStateChange?: SingleAutocompleteOnStateChange;
-  onChange?: (value: FolderWithFullPath | NewFolderData | null) => void;
-  onBlur?: (value?: FolderWithFullPath | NewFolderData | null) => void;
+  onChange?: (value: FolderAutocompleteValue) => void;
+  onBlur?: (value?: FolderAutocompleteValue) => void;
   onFocus?: () => void;
   maxLength?: number;
 }

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
+
+import { FolderWithFullPath } from 'controllers/testCase';
+
+import {
+  getFolderAutocompleteLabel,
+  keepSelectedFolderStateReducer,
+} from './keepSelectedFolderStateReducer';
+import { resolveFolderAutocompleteChange } from './resolveFolderAutocompleteChange';
+
+const folderA: FolderWithFullPath = {
+  id: 48,
+  name: 'Test',
+  description: 'Test',
+  fullPath: 'Root / Test',
+};
+
+const folderB: FolderWithFullPath = {
+  id: 52,
+  name: 'Test',
+  description: 'Test',
+  fullPath: 'Other / Test',
+};
+
+const reduce = keepSelectedFolderStateReducer<FolderWithFullPath | string>(
+  getFolderAutocompleteLabel,
+);
+
+const apply = (
+  selectedItem: FolderWithFullPath | string | null,
+  changes: Partial<StateChangeOptions<FolderWithFullPath | string>> & {
+    type: StateChangeOptions<FolderWithFullPath | string>['type'];
+  },
+) =>
+  reduce(
+    { selectedItem, inputValue: getFolderAutocompleteLabel(selectedItem) } as DownshiftState<
+      FolderWithFullPath | string
+    >,
+    changes as StateChangeOptions<FolderWithFullPath | string>,
+  );
+
+describe('keepSelectedFolderStateReducer', () => {
+  it('keeps the clicked folder when blur rematches another folder with the same name', () => {
+    const result = apply(folderB, {
+      type: Downshift.stateChangeTypes.unknown,
+      selectedItem: folderA,
+      inputValue: 'Test',
+    });
+
+    expect(result.selectedItem).toEqual(folderB);
+  });
+
+  it('does not collapse the selected folder to a display-name string', () => {
+    const result = apply(folderB, {
+      type: Downshift.stateChangeTypes.unknown,
+      selectedItem: 'Test',
+      inputValue: 'Test',
+    });
+
+    expect(result.selectedItem).toEqual(folderB);
+  });
+
+  it('allows selecting a different same-named folder via click', () => {
+    const result = apply(folderA, {
+      type: Downshift.stateChangeTypes.clickItem,
+      selectedItem: folderB,
+      inputValue: 'Test',
+    });
+
+    expect(result.selectedItem).toEqual(folderB);
+  });
+
+  it('allows creating a new folder when the typed name does not match the selection', () => {
+    const result = apply(folderB, {
+      type: Downshift.stateChangeTypes.unknown,
+      selectedItem: 'Brand new',
+      inputValue: 'Brand new',
+    });
+
+    expect(result.selectedItem).toBe('Brand new');
+  });
+});
+
+describe('resolveFolderAutocompleteChange', () => {
+  it('keeps the folder object when the autocomplete emits the display name of the selected folder', () => {
+    expect(resolveFolderAutocompleteChange('Test', folderB)).toEqual(folderB);
+  });
+
+  it('keeps a clicked folder object with id', () => {
+    expect(resolveFolderAutocompleteChange(folderB, folderA)).toEqual(folderB);
+  });
+
+  it('treats an unmatched typed string as a new folder name', () => {
+    expect(resolveFolderAutocompleteChange('Brand new', folderB)).toEqual({ name: 'Brand new' });
+  });
+});

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
@@ -109,4 +109,8 @@ describe('resolveFolderAutocompleteChange', () => {
   it('treats an unmatched typed string as a new folder name', () => {
     expect(resolveFolderAutocompleteChange('Brand new', folderB)).toEqual({ name: 'Brand new' });
   });
+
+  it('returns null when the selection is cleared', () => {
+    expect(resolveFolderAutocompleteChange(null, folderB)).toBeNull();
+  });
 });

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
+import { isString } from 'es-toolkit/compat';
+
+import { FolderWithFullPath } from 'controllers/testCase';
+import { NewFolderData } from 'pages/inside/testCaseLibraryPage/utils/getFolderFromFormValues';
+
+export const getFolderAutocompleteLabel = (
+  option: FolderWithFullPath | NewFolderData | string | null,
+): string => {
+  if (!option) {
+    return '';
+  }
+
+  if (isString(option)) {
+    return option;
+  }
+
+  if ('fullPath' in option) {
+    return option.description || option.name || '';
+  }
+
+  return option.name || '';
+};
+
+const isUserFolderSelection = (type: StateChangeOptions<unknown>['type']) =>
+  type === Downshift.stateChangeTypes.clickItem || type === Downshift.stateChangeTypes.keyDownEnter;
+
+const hasFolderId = (item: unknown): item is { id: number } =>
+  Boolean(item) &&
+  typeof item === 'object' &&
+  'id' in item &&
+  typeof (item as { id: unknown }).id === 'number';
+
+export const keepSelectedFolderStateReducer =
+  <T>(itemToString: (item: T | null) => string) =>
+  (state: DownshiftState<T>, changes: StateChangeOptions<T>): Partial<StateChangeOptions<T>> => {
+    if (isUserFolderSelection(changes.type) || changes.selectedItem === undefined) {
+      return changes;
+    }
+
+    if (changes.selectedItem === null || !hasFolderId(state.selectedItem)) {
+      return changes;
+    }
+
+    const current = state.selectedItem;
+    const currentLabel = itemToString(current);
+    const nextInput = (changes.inputValue ?? state.inputValue ?? '').trim();
+
+    if (nextInput !== currentLabel) {
+      return changes;
+    }
+
+    return { ...changes, selectedItem: current };
+  };

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/resolveFolderAutocompleteChange.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/resolveFolderAutocompleteChange.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isNumber, isString } from 'es-toolkit/compat';
+
+import { FolderWithFullPath } from 'controllers/testCase';
+import { NewFolderData } from 'pages/inside/testCaseLibraryPage/utils/getFolderFromFormValues';
+
+import { getFolderAutocompleteLabel } from './keepSelectedFolderStateReducer';
+
+export const resolveFolderAutocompleteChange = (
+  selectedItem: FolderWithFullPath | string | null,
+  currentValue?: FolderWithFullPath | NewFolderData | null,
+): FolderWithFullPath | NewFolderData | null => {
+  if (!selectedItem) {
+    return null;
+  }
+
+  if (!isString(selectedItem)) {
+    return selectedItem;
+  }
+
+  if (
+    currentValue &&
+    typeof currentValue === 'object' &&
+    'id' in currentValue &&
+    isNumber(currentValue.id) &&
+    getFolderAutocompleteLabel(currentValue) === selectedItem
+  ) {
+    return currentValue;
+  }
+
+  return { name: selectedItem };
+};


### PR DESCRIPTION
## Description
Fixes [EPMRPP-118676](https://jiraeu.epam.com/browse/EPMRPP-118676): Duplicate / Create Test Case placed the case into a newly created folder instead of the folder selected in the Folder field when another folder with the same name already existed.

## Problem

TMS allows several folders with the same name. The Folder autocomplete identified the selection by display name, not by id. After picking a folder (for example id=52 named "Test"), the value collapsed to the string `"Test"`. Submit then sent `testFolder: { name: "Test" }` instead of `testFolderId: 52`. The API treated that as "create a new folder" and put the test case there.

The same Folder field is used for Create Test Case, so the same failure appeared there.

**Expected:** the case is created in the selected folder by id. No extra folder is created. Same-name folders at the same level stay allowed.

## Solution

Keep the selected folder object with `id` through submit.

- Do not pass the input blur event into redux-form (it replaced the folder object with the display-name string).
- On blur rematch, keep the already selected folder instead of the first option with the same name.
- If the submitted value has a numeric `id`, send `testFolderId`. A name-only payload is used only when creating a new folder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder autocomplete behavior when multiple folders share the same name.
  * Preserved selected folders while typing, while still allowing explicit selection or creation of a new folder.
  * Improved handling of existing, new, and nested folders during test case creation.

* **Tests**
  * Added coverage for folder processing and autocomplete selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->