### PR TITLE
EPMRPP-118942 || Increase max length for LDAP User and Group search filter fields

### DIFF
--- a/app/src/components/integrations/integrationProviders/ldapIntegration/ldapFormFields/ldapFormFields.jsx
+++ b/app/src/components/integrations/integrationProviders/ldapIntegration/ldapFormFields/ldapFormFields.jsx
@@ -130,6 +130,7 @@ const messages = defineMessages({
 });
 
 const urlValidator = bindMessageToValidator(validate.ldapUrl, 'requiredFieldHint');
+const SEARCH_FILTER_MAX_LENGTH = 1024;
 
 const LdapFormFieldsComponent = ({
   initialize,
@@ -222,6 +223,9 @@ const LdapFormFieldsComponent = ({
   const getFieldsConfig = () => {
     const defaultField = <FieldText maxLength="128" defaultWidth={false} />;
     const maxField = <FieldText maxLength="256" defaultWidth={false} />;
+    const searchFilterField = (
+      <FieldText maxLength={SEARCH_FILTER_MAX_LENGTH} defaultWidth={false} />
+    );
 
     const firstStepFields = [
       {
@@ -275,7 +279,7 @@ const LdapFormFieldsComponent = ({
           name: USER_SEARCH_FILTER_KEY,
         },
         label: messages.userSearchFilterLabel,
-        children: defaultField,
+        children: searchFilterField,
       },
       {
         fieldProps: {
@@ -289,7 +293,7 @@ const LdapFormFieldsComponent = ({
           name: GROUP_SEARCH_FILTER_KEY,
         },
         label: messages.groupSearchFilterLabel,
-        children: defaultField,
+        children: searchFilterField,
       },
       {
         fieldProps: {


### PR DESCRIPTION
## Description

Fixes [GitHub #2698](https://github.com/reportportal/reportportal/issues/2698): LDAP **User search filter** and **Group search filter** were limited to 128 characters, so realistic filters (for example with `memberOf=CN=...`) could not be typed or pasted.

## Solution

Raise `maxLength` for these two fields only to **1024**. Other LDAP form fields keep their existing limits (128 / 256).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LDAP user and group search-filter fields now support up to 1,024 characters, preventing valid longer filters from being rejected by the shorter default limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->