### PR TITLE
EPMRPP-118938 || Long values in the Test Case body are not moved to the new line and are overlapping the container borders

### DIFF
--- a/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.scss
+++ b/app/src/pages/inside/common/testCaseList/testCaseSidePanel/scenario/scenario.scss
@@ -38,6 +38,7 @@
     font-weight: 400;
     line-height: 20px;
     white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 
   &.full-view {

--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseDetails/steps/step/step.scss
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/testCaseDetails/steps/step/step.scss
@@ -43,6 +43,7 @@
       line-height: 20px;
       min-height: 20px;
       white-space: pre-wrap;
+      overflow-wrap: anywhere;
     }
 
     .section-border {


### PR DESCRIPTION
## PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [ ] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [ ] Have you checked that everything works within the branch according to the task description and tested it locally?
* [ ] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [ ] Have you run the tests locally and added/updated them if needed?
* [ ] Have you checked that app can be built (`npm run build`)?
* [ ] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [ ] Have you made sure that all the necessary pipelines has been successfully completed?
* [ ] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [ ] Have you added the link to the PR in the Jira ticket comments?
* [ ] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Visuals
before : 
<img width="1910" height="1020" alt="image" src="https://github.com/user-attachments/assets/b3578d62-9bb5-48f9-91a7-bfbe7cb09591" />

after : 
<img width="1913" height="1018" alt="image" src="https://github.com/user-attachments/assets/692c98b9-e576-4b63-a144-336bd715ff8e" />

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long, unbroken text in scenario preconditions and test case step details now wraps within its designated area instead of overflowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->