### PR TITLE
EPMRPP-118758 || Hide folder drag and drop for Viewer in Test Case Library

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/testCaseFolders.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/testCaseFolders.tsx
@@ -307,10 +307,10 @@ export const TestCaseFolders = () => {
       setAllTestCases={navigateToAllTestCases}
       onFolderClick={handleFolderClick}
       renderCreateFolderButton={renderCreateFolderButton}
-      onMoveFolder={handleMoveFolder}
-      onDuplicateFolder={handleDuplicateFolder}
-      onMoveTestCase={handleMoveTestCase}
-      onDuplicateTestCase={handleDuplicateTestCase}
+      onMoveFolder={canManageTestCases ? handleMoveFolder : undefined}
+      onDuplicateFolder={canManageTestCases ? handleDuplicateFolder : undefined}
+      onMoveTestCase={canManageTestCases ? handleMoveTestCase : undefined}
+      onDuplicateTestCase={canManageTestCases ? handleDuplicateTestCase : undefined}
       onFolderTreeViewControl={handleFolderTreeViewControl}
     >
       <AllTestCasesPage


### PR DESCRIPTION
## Description

Fixes EPMRPP-118758: a user with the **Viewer** project role could drag and drop folders in Test Case Library and complete Move from the context menu, even though write operations must not be available for this role.

## Solution

Pass folder and test case drag-and-drop handlers into `ExpandedOptions` only when `canManageTestCases` is true. Without handlers, `isDragAndDropEnabled` stays false, so the drag handle and Move/Duplicate drop menu are not shown for Viewer. Editor behavior is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted test-case folder move and duplicate actions to users with permission to manage test cases.
  * Unauthorized users no longer receive active controls for these actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->