### PR TITLE
EPMRPP-118899 || Support remote plugins in the admin sidebar

### DIFF
--- a/app/src/common/urls.js
+++ b/app/src/common/urls.js
@@ -300,6 +300,8 @@ export const URLS = {
 
   appInfo: () => `${compositeBase}info`,
 
+  grafanaSession: () => `${urlBase}integration/grafana/session`,
+
   plugin: () => `${urlBase}plugin`,
   pluginById: (pluginId) => `${urlBase}plugin/${pluginId}`,
   pluginPublic: () => `${urlBase}plugin/public`,

--- a/app/src/components/buttons/sidebarButton/sidebarButton.scss
+++ b/app/src/components/buttons/sidebarButton/sidebarButton.scss
@@ -20,6 +20,13 @@
   height: 20px;
   margin: 0 10px;
   vertical-align: middle;
+
+  > svg,
+  > img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 }
 
 .btn-title-mobile {

--- a/app/src/controllers/auth/constants.js
+++ b/app/src/controllers/auth/constants.js
@@ -32,3 +32,5 @@ export const GRANT_TYPES = {
 };
 
 export const ANONYMOUS_REDIRECT_PATH_STORAGE_KEY = 'anonymousRedirectPath';
+
+export const GRAFANA_SESSION_REVOKE_TIMEOUT = 2000;

--- a/app/src/controllers/auth/sagas.js
+++ b/app/src/controllers/auth/sagas.js
@@ -79,6 +79,12 @@ import { tokenSelector } from './selectors';
 
 // TODO: clear cookie on logout
 function* handleLogout({ payload }) {
+  try {
+    yield call(fetch, URLS.grafanaSession(), { method: 'DELETE' });
+  } catch {
+    // Grafana session revocation must not block ReportPortal logout.
+  }
+
   yield put(resetTokenAction());
   yield put(fetchPublicPluginsAction());
   yield put(fetchAppInfoAction());

--- a/app/src/controllers/auth/sagas.js
+++ b/app/src/controllers/auth/sagas.js
@@ -74,15 +74,19 @@ import {
   SET_TOKEN,
   LOGIN_SUCCESS,
   ANONYMOUS_REDIRECT_PATH_STORAGE_KEY,
+  GRAFANA_SESSION_REVOKE_TIMEOUT,
 } from './constants';
 import { tokenSelector } from './selectors';
 
 // TODO: clear cookie on logout
 function* handleLogout({ payload }) {
   try {
-    yield call(fetch, URLS.grafanaSession(), { method: 'DELETE' });
-  } catch {
-    // Grafana session revocation must not block ReportPortal logout.
+    yield call(fetch, URLS.grafanaSession(), {
+      method: 'DELETE',
+      timeout: GRAFANA_SESSION_REVOKE_TIMEOUT,
+    });
+  } catch (error) {
+    console.error('Failed to revoke Grafana session on logout', error);
   }
 
   yield put(resetTokenAction());

--- a/app/src/controllers/plugins/uiExtensions/constants.js
+++ b/app/src/controllers/plugins/uiExtensions/constants.js
@@ -39,6 +39,7 @@ export const EXTENSION_TYPE_TEST_ITEM_DETAILS_ADDON = 'uiExtension:testItemDetai
 export const EXTENSION_TYPE_PROJECT_PAGE = 'uiExtension:projectPage';
 
 export const REMOTE_EXTENSION_POINT_PROJECT_PAGE = 'projectPages';
+export const REMOTE_EXTENSION_POINT_ADMIN_PAGE = 'adminPages';
 // plugin commands
 export const COMMAND_GET_ISSUE_TYPES = 'getIssueTypes';
 export const COMMAND_GET_ISSUE_FIELDS = 'getIssueFields';

--- a/app/src/controllers/plugins/uiExtensions/selectors.js
+++ b/app/src/controllers/plugins/uiExtensions/selectors.js
@@ -41,6 +41,7 @@ import {
   PLUGIN_TYPE_REMOTE,
   PLUGIN_TYPE_EXTENSION,
   REMOTE_EXTENSION_POINT_PROJECT_PAGE,
+  REMOTE_EXTENSION_POINT_ADMIN_PAGE,
   MANIFEST_OVERRIDES_KEY,
   MANIFEST_OVERRIDE_DISABLE_POPUP_CONTENT_KEY,
 } from './constants';
@@ -95,6 +96,7 @@ export const uiExtensionSettingsTabsSelector = createExtensionSelectorByExtensio
 ]);
 export const uiExtensionAdminPagesSelector = createExtensionSelectorByExtensionPoints([
   EXTENSION_TYPE_ADMIN_PAGE,
+  REMOTE_EXTENSION_POINT_ADMIN_PAGE,
 ]);
 export const uiExtensionSidebarComponentsSelector = createExtensionSelectorByExtensionPoints([
   EXTENSION_TYPE_SIDEBAR_COMPONENT,

--- a/app/src/layouts/adminLayout/adminSidebar/adminSidebar.jsx
+++ b/app/src/layouts/adminLayout/adminSidebar/adminSidebar.jsx
@@ -37,6 +37,8 @@ import {
   uiExtensionAdminPagesSelector,
   uiExtensionAdminSidebarComponentsSelector,
 } from 'controllers/plugins/uiExtensions';
+import { PLUGIN_TYPE_REMOTE } from 'controllers/plugins/uiExtensions/constants';
+import { RemotePluginIcon } from 'components/integrations/elements/pluginIcon/remotePluginIcon';
 import { ADMIN_SIDEBAR_EVENTS } from 'components/main/analytics/events';
 import { withTooltip } from 'components/main/tooltips/tooltip';
 import { TextTooltip } from 'components/main/tooltips/textTooltip';
@@ -99,18 +101,22 @@ function AdminSidebarComponent({
   };
 
   const createTopSidebarItems = () => {
+    let menuCounter = 0;
+    const menuStep = 10;
     const items = [
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_PROJECTS_BTN),
         link: { type: PROJECTS_PAGE },
         icon: ProjectsIcon,
         message: <FormattedMessage id={'AdminSidebar.allProjects'} defaultMessage={'Projects'} />,
+        menuOrder: (menuCounter += menuStep),
       },
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_ALL_USERS_BTN),
         link: { type: ALL_USERS_PAGE },
         icon: UsersIcon,
         message: <FormattedMessage id={'AdminSidebar.allUsers'} defaultMessage={'All Users'} />,
+        menuOrder: (menuCounter += menuStep),
       },
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_SERVER_SETTINGS_BTN),
@@ -119,12 +125,14 @@ function AdminSidebarComponent({
         message: (
           <FormattedMessage id={'AdminSidebar.settings'} defaultMessage={'Server settings'} />
         ),
+        menuOrder: (menuCounter += menuStep),
       },
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_PLUGINS_BTN),
         link: { type: PLUGINS_PAGE },
         icon: PluginsIcon,
         message: <FormattedMessage id={'AdminSidebar.plugins'} defaultMessage={'Plugins'} />,
+        menuOrder: (menuCounter += menuStep),
       },
     ];
 
@@ -138,6 +146,22 @@ function AdminSidebarComponent({
           link: { type: PLUGIN_UI_EXTENSION_ADMIN_PAGE, payload: { pluginPage: extension.name } },
           icon: extension.buttonIcon,
           message: extension.buttonLabel || extension.name,
+          menuOrder: (menuCounter += menuStep),
+        }),
+      );
+
+    adminPageExtensions
+      .filter(({ pluginType, payload }) => pluginType === PLUGIN_TYPE_REMOTE && payload.icon)
+      .forEach(({ payload }) =>
+        items.push({
+          onClick: handleClickButton(),
+          link: {
+            type: PLUGIN_UI_EXTENSION_ADMIN_PAGE,
+            payload: { pluginPage: payload.slug },
+          },
+          icon: <RemotePluginIcon icon={payload.icon} />,
+          message: payload.title || payload.name,
+          menuOrder: payload.menuOrder ?? (menuCounter += menuStep),
         }),
       );
 
@@ -149,7 +173,7 @@ function AdminSidebarComponent({
       }),
     );
 
-    return items;
+    return items.sort((a, b) => a.menuOrder - b.menuOrder);
   };
 
   const createBottomSidebarItems = () => [

--- a/app/src/layouts/adminLayout/adminSidebar/adminSidebar.jsx
+++ b/app/src/layouts/adminLayout/adminSidebar/adminSidebar.jsx
@@ -103,20 +103,24 @@ function AdminSidebarComponent({
   const createTopSidebarItems = () => {
     let menuCounter = 0;
     const menuStep = 10;
+    const nextMenuOrder = () => {
+      menuCounter += menuStep;
+      return menuCounter;
+    };
     const items = [
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_PROJECTS_BTN),
         link: { type: PROJECTS_PAGE },
         icon: ProjectsIcon,
         message: <FormattedMessage id={'AdminSidebar.allProjects'} defaultMessage={'Projects'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_ALL_USERS_BTN),
         link: { type: ALL_USERS_PAGE },
         icon: UsersIcon,
         message: <FormattedMessage id={'AdminSidebar.allUsers'} defaultMessage={'All Users'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_SERVER_SETTINGS_BTN),
@@ -125,14 +129,14 @@ function AdminSidebarComponent({
         message: (
           <FormattedMessage id={'AdminSidebar.settings'} defaultMessage={'Server settings'} />
         ),
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
       {
         onClick: handleClickButton(ADMIN_SIDEBAR_EVENTS.CLICK_PLUGINS_BTN),
         link: { type: PLUGINS_PAGE },
         icon: PluginsIcon,
         message: <FormattedMessage id={'AdminSidebar.plugins'} defaultMessage={'Plugins'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
     ];
 
@@ -146,7 +150,7 @@ function AdminSidebarComponent({
           link: { type: PLUGIN_UI_EXTENSION_ADMIN_PAGE, payload: { pluginPage: extension.name } },
           icon: extension.buttonIcon,
           message: extension.buttonLabel || extension.name,
-          menuOrder: (menuCounter += menuStep),
+          menuOrder: nextMenuOrder(),
         }),
       );
 
@@ -161,7 +165,7 @@ function AdminSidebarComponent({
           },
           icon: <RemotePluginIcon icon={payload.icon} />,
           message: payload.title || payload.name,
-          menuOrder: payload.menuOrder ?? (menuCounter += menuStep),
+          menuOrder: payload.menuOrder ?? nextMenuOrder(),
         }),
       );
 

--- a/app/src/layouts/adminLayout/adminUiExtensionPageLayout/adminUiExtensionPageLayout.jsx
+++ b/app/src/layouts/adminLayout/adminUiExtensionPageLayout/adminUiExtensionPageLayout.jsx
@@ -15,14 +15,22 @@
  */
 
 import PropTypes from 'prop-types';
+import { PLUGIN_TYPE_REMOTE } from 'controllers/plugins/uiExtensions/constants';
+import { uiExtensionAdminPagesSelector } from 'controllers/plugins/uiExtensions';
+import { useActivePluginPageExtension } from 'controllers/plugins/uiExtensions/hooks';
 import { Layout } from 'layouts/common/layout';
 import { AdminSidebar } from '../adminSidebar';
 
-export const AdminUiExtensionPageLayout = ({ children }) => (
-  <Layout isExtensionPage Sidebar={AdminSidebar}>
-    {children}
-  </Layout>
-);
+export const AdminUiExtensionPageLayout = ({ children }) => {
+  const extension = useActivePluginPageExtension(uiExtensionAdminPagesSelector);
+  const isRemotePluginPage = extension?.pluginType === PLUGIN_TYPE_REMOTE;
+
+  return (
+    <Layout isExtensionPage Sidebar={AdminSidebar} rawContent={isRemotePluginPage}>
+      {children}
+    </Layout>
+  );
+};
 AdminUiExtensionPageLayout.propTypes = {
   children: PropTypes.node,
 };

--- a/app/src/layouts/appLayout/appSidebar/appSidebar.jsx
+++ b/app/src/layouts/appLayout/appSidebar/appSidebar.jsx
@@ -177,8 +177,8 @@ export class AppSidebar extends Component {
             payload: { projectId: activeProject, pluginPage: payload.slug },
           },
           icon: <RemotePluginIcon icon={payload.icon} />,
-          message: payload.title,
-          menuOrder: payload.menuOrder || (menuCounter += menuStep),
+          message: payload.title || payload.name,
+          menuOrder: payload.menuOrder ?? (menuCounter += menuStep),
         });
       }
     });

--- a/app/src/layouts/appLayout/appSidebar/appSidebar.jsx
+++ b/app/src/layouts/appLayout/appSidebar/appSidebar.jsx
@@ -105,13 +105,17 @@ export class AppSidebar extends Component {
 
     let menuCounter = 0;
     const menuStep = 10;
+    const nextMenuOrder = () => {
+      menuCounter += menuStep;
+      return menuCounter;
+    };
     const topItems = [
       {
         onClick: () => this.onClickButton(SIDEBAR_EVENTS.CLICK_DASHBOARD_BTN),
         link: { type: PROJECT_DASHBOARD_PAGE, payload: { projectId: activeProject } },
         icon: DashboardIcon,
         message: <FormattedMessage id={'Sidebar.dashboardsBtn'} defaultMessage={'Dashboards'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
       {
         onClick: () => this.onClickButton(SIDEBAR_EVENTS.clickSidebarIcon('launches')),
@@ -121,14 +125,14 @@ export class AppSidebar extends Component {
         },
         icon: LaunchesIcon,
         message: <FormattedMessage id={'Sidebar.launchesBtn'} defaultMessage={'Launches'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
       {
         onClick: () => this.onClickButton(SIDEBAR_EVENTS.CLICK_FILTERS_BTN),
         link: { type: PROJECT_FILTERS_PAGE, payload: { projectId: activeProject } },
         icon: FiltersIcon,
         message: <FormattedMessage id={'Sidebar.filtersBtn'} defaultMessage={'Filters'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
       {
         onClick: () => this.onClickButton(SIDEBAR_EVENTS.CLICK_DEBUG_BTN),
@@ -138,7 +142,7 @@ export class AppSidebar extends Component {
         },
         icon: DebugIcon,
         message: <FormattedMessage id={'Sidebar.debugBtn'} defaultMessage={'Debug'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       },
     ];
 
@@ -151,7 +155,7 @@ export class AppSidebar extends Component {
         },
         icon: MembersIcon,
         message: <FormattedMessage id={'Sidebar.membersBnt'} defaultMessage={'Project members'} />,
-        menuOrder: (menuCounter += menuStep),
+        menuOrder: nextMenuOrder(),
       });
     }
 
@@ -163,7 +167,7 @@ export class AppSidebar extends Component {
       },
       icon: SettingsIcon,
       message: <FormattedMessage id={'Sidebar.settingsBnt'} defaultMessage={'Project settings'} />,
-      menuOrder: (menuCounter += menuStep),
+      menuOrder: nextMenuOrder(),
     });
     projectPageExtensions.forEach(({ payload }) => {
       if (payload.icon) {
@@ -178,7 +182,7 @@ export class AppSidebar extends Component {
           },
           icon: <RemotePluginIcon icon={payload.icon} />,
           message: payload.title || payload.name,
-          menuOrder: payload.menuOrder ?? (menuCounter += menuStep),
+          menuOrder: payload.menuOrder ?? nextMenuOrder(),
         });
       }
     });

--- a/app/src/pages/admin/adminUiExtensionPage/adminUiExtensionPage.jsx
+++ b/app/src/pages/admin/adminUiExtensionPage/adminUiExtensionPage.jsx
@@ -16,6 +16,7 @@
 
 import React, { useState } from 'react';
 import classNames from 'classnames/bind';
+import { PLUGIN_TYPE_REMOTE } from 'controllers/plugins/uiExtensions/constants';
 import { uiExtensionAdminPagesSelector } from 'controllers/plugins/uiExtensions';
 import { useActivePluginPageExtension } from 'controllers/plugins/uiExtensions/hooks';
 import { Header } from 'pages/inside/projectSettingsPageContainer/header';
@@ -28,6 +29,10 @@ const cx = classNames.bind(styles);
 export const AdminUiExtensionPage = () => {
   const extension = useActivePluginPageExtension(uiExtensionAdminPagesSelector);
   const [headerNodes, setHeaderNodes] = useState({});
+
+  if (extension?.pluginType === PLUGIN_TYPE_REMOTE) {
+    return <ExtensionLoader extension={extension} silentOnError={false} withPreloader />;
+  }
 
   let pageLayout = null;
 

--- a/docs/13-plugins.md
+++ b/docs/13-plugins.md
@@ -101,7 +101,12 @@ Remote plugins are uploaded as `.json` manifests on **Instance → Plugins**. Th
 }
 ```
 
-`baseUrl` must be an absolute HTTP(S) URL without a trailing slash. The page `url` is relative to `baseUrl` and becomes the iframe source. Same-origin iframe pages are covered by the default `frame-src 'self'` CSP rule. A remote domain must be explicitly allowed in `frame-src`.
+`baseUrl` must be an absolute HTTP(S) URL without a trailing slash. The page `url` is relative to `baseUrl` and becomes the iframe source.
+
+Embedding is controlled by CSP on **both** sides:
+
+- **ReportPortal** (`frame-src`): same-origin pages are allowed by default (`'self'`). A remote domain must be explicitly allowed.
+- **Remote page** (`frame-ancestors`): if the plugin response sets this header, it must allow the ReportPortal origin; otherwise the browser blocks the iframe even when `frame-src` permits the URL.
 
 Disabling or uninstalling a remote plugin removes its sidebar entries. The page `slug` forms the plugin route, while `title` overrides the navigation label.
 

--- a/docs/13-plugins.md
+++ b/docs/13-plugins.md
@@ -62,6 +62,49 @@ All loaded extensions can be used in application core via [selectors](https://gi
 | sidebarComponent      | Adds a component to the application sidebar.                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | launchItemComponent   | Adds a component to the every launch entity on launches page (component will be displayed under the launch name).                                                                                                                                                                                                                                                                                                                                                        |
 
+## Remote UI plugins
+
+Remote plugins are uploaded as `.json` manifests on **Instance → Plugins**. Their pages are loaded in a sandboxed iframe instead of registering React components:
+
+- `modules.projectPages` adds pages to the project sidebar.
+- `modules.adminPages` adds pages to the instance administration sidebar and is available only to instance administrators.
+
+```json
+{
+  "$schema": "https://schema.reportportal.io/manifest.schema.json",
+  "manifestVersion": "1.0",
+  "id": "my-remote-app",
+  "name": "My Remote App",
+  "version": "1.0.0",
+  "description": "A description of the app",
+  "developer": { "name": "Publisher Name" },
+  "baseUrl": "https://example.com",
+  "icon": {
+    "type": "svg",
+    "content": "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"
+  },
+  "permissions": { "scopes": [] },
+  "modules": {
+    "adminPages": [
+      {
+        "slug": "my-admin-page",
+        "name": "My Admin Page",
+        "title": "My Admin Page",
+        "url": "/admin",
+        "icon": {
+          "type": "svg",
+          "content": "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"
+        }
+      }
+    ]
+  }
+}
+```
+
+`baseUrl` must be an absolute HTTP(S) URL without a trailing slash. The page `url` is relative to `baseUrl` and becomes the iframe source. Same-origin iframe pages are covered by the default `frame-src 'self'` CSP rule. A remote domain must be explicitly allowed in `frame-src`.
+
+Disabling or uninstalling a remote plugin removes its sidebar entries. The page `slug` forms the plugin route, while `title` overrides the navigation label.
+
 #### Permissions
 
 For `integrations` page permissions are applied according to permission map (PM and Admin can edit settings on this page, other users have readonly access).<br/>


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
1. Now instance admins can open remote plugins (e.g. Grafana) from the admin sidebar. 
The page loads in a full-size iframe (no page title / footer). Existing plugins like Billing stay as they were.
2. Added support for admin sidebar order.
3. Grafana session is cleared on logout.

<details>
<summary>Example</summary>

After upload, an enabled remote plugin **My Plugin** appears under **Plugins → Other**. Instance admins get a sidebar item **My Admin Page** (order `15`, between Projects and All Users) that opens `https://example.com/my-plugin/` in a full-page iframe. Project sidebar is unchanged; non-admins do not see the item.

```json
{
  "$schema": "https://schema.reportportal.io/manifest.schema.json",
  "manifestVersion": "1.0",
  "id": "myPlugin",
  "name": "My Plugin",
  "version": "1.0.0",
  "description": "Reinforce your ReportPortal instance with My Plugin integration.",
  "group": "other",
  "developer": {
    "name": "ReportPortal",
    "website": "https://reportportal.io"
  },
  "documentation": "https://reportportal.io/docs",
  "license": "Apache-2.0",
  "icon": {
    "type": "svg",
    "content": "<svg>...</svg>"
  },
  "baseUrl": "https://example.com",
  "permissions": {
    "scopes": []
  },
  "modules": {
    "adminPages": [
      {
        "slug": "my-admin-page",
        "name": "My Admin Page",
        "title": "My Admin Page",
        "url": "/my-plugin/",
        "icon": {
          "type": "svg",
          "content": "<svg>...</svg>"
        },
        "menuOrder": 15
      }
    ]
  }
}
```

</details>

## Links
[EPMRPP-118899](https://jiraeu.epam.com/browse/EPMRPP-118899)

## Visuals

https://github.com/user-attachments/assets/27e00144-133b-49fe-8730-f7e06892be96

---

**Note:** Requires schema-registry changes https://github.com/reportportal/schema-registry/pull/1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for remote plugins to provide administration pages through JSON manifests.
  - Remote plugin administration pages now appear in the admin sidebar with custom icons and configurable ordering.
  - Improved plugin navigation labels by using a fallback name when a title is unavailable.
- **Bug Fixes**
  - Grafana sessions are now revoked during logout without preventing logout if revocation fails.
  - Plugin icons now scale correctly while preserving their aspect ratio.
- **Documentation**
  - Added guidance for configuring remote UI plugins, including manifests, permissions, URLs, navigation, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->