### PR TITLE
EPMRPP-118853 || Increase Import Test Cases CSV file size limit to 32 MB

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/importTestCaseModal/importTestCaseModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/importTestCaseModal/importTestCaseModal.tsx
@@ -47,7 +47,7 @@ export type ImportTestCaseModalData = {
 };
 
 const cx = createClassnames(styles);
-const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_MB = 32;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 const CSV_MIME_TYPES: MimeType[] = [MIME_TYPES.csv, MIME_TYPES.xls, MIME_TYPES.plain];
 const TEMPLATE_FILE_NAME = 'test-case-import-template.csv';
@@ -306,7 +306,9 @@ export const ImportTestCaseModal = ({
             <FileDropArea
               messages={{
                 incorrectFileFormat: formatMessage(messages.incorrectFileFormat),
-                incorrectFileSize: formatMessage(messages.incorrectFileSize),
+                incorrectFileSize: formatMessage(messages.incorrectFileSize, {
+                  size: MAX_FILE_SIZE_MB,
+                }),
               }}
               acceptFileMimeTypes={CSV_MIME_TYPES}
               maxFileSize={MAX_FILE_SIZE_BYTES}

--- a/app/src/pages/inside/testCaseLibraryPage/importTestCaseModal/messages.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/importTestCaseModal/messages.ts
@@ -29,7 +29,7 @@ export const messages = defineMessages({
   },
   incorrectFileSize: {
     id: 'ImportTestCaseModal.incorrectFileSize',
-    defaultMessage: 'File size exceeds the limit',
+    defaultMessage: 'File size exceeds the {size} MB limit.',
   },
   dropCsvOr: { id: 'ImportTestCaseModal.dropCsvOr', defaultMessage: 'Drop .CSV file or' },
   browse: { id: 'ImportTestCaseModal.browse', defaultMessage: 'Browse' },


### PR DESCRIPTION
## Description

Fixes EPMRPP-118853: Import Test Cases blocked CSV files above **10 MB**, while product guidelines require a **32 MB** client-side limit (exports from QA Space are often larger than 10 MB).

## Solution

Raise `MAX_FILE_SIZE_MB` to **32** in the Import Test Cases modal so the hint shows “File size should be up to 32 MB”, oversized files are rejected with “File size exceeds the 32 MB limit.”, and Import stays disabled until a valid file is attached. Backend limits already allow uploads above 32 MB, so no API change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the maximum test case import file size from 10 MB to 32 MB.
  - Updated the file-size error message to display the applicable limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->