### PR TITLE
EPMRPP-118575 || Fix empty testCaseIds when adding Test Case to Launch from details/side panel

### DIFF
--- a/app/src/pages/inside/common/launchFormFields/baseLaunchModal.tsx
+++ b/app/src/pages/inside/common/launchFormFields/baseLaunchModal.tsx
@@ -38,6 +38,7 @@ export const BaseLaunchModal = ({
   handleSubmit,
   change,
   testCases,
+  selectedTestCaseIds,
   folderId,
   testPlanId,
   modalTitle,
@@ -62,6 +63,7 @@ export const BaseLaunchModal = ({
     folderId,
     onClearSelection,
     onSubmitSuccess,
+    selectedTestCaseIds,
   );
 
   const areAllTestCasesCovered = useMemo(

--- a/app/src/pages/inside/common/launchFormFields/types.ts
+++ b/app/src/pages/inside/common/launchFormFields/types.ts
@@ -114,6 +114,7 @@ export interface NewLaunchFieldsProps {
 
 export interface BaseLaunchModalProps {
   testCases: ExtendedTestCase[];
+  selectedTestCaseIds?: number[];
   folderId?: number;
   testPlanId?: number;
   modalTitle: string;

--- a/app/src/pages/inside/common/launchFormFields/useCreateManualLaunch.ts
+++ b/app/src/pages/inside/common/launchFormFields/useCreateManualLaunch.ts
@@ -18,7 +18,7 @@ import { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { isString } from 'es-toolkit';
-import { isNumber } from 'es-toolkit/compat';
+import { isEmpty, isNumber } from 'es-toolkit/compat';
 
 import { URLS } from 'common/urls';
 import { fetch } from 'common/utils';
@@ -36,6 +36,36 @@ import { generateUUID } from './utils';
 import { messages } from './messages';
 import { fetchAllTestCases } from '../testLibrarySidePanel/utils';
 
+const resolveTestCaseIds = ({
+  folderId,
+  selectedTestCaseIds,
+  submitTestCases,
+  uncoveredTestsOnly,
+}: {
+  folderId?: number;
+  selectedTestCaseIds?: number[];
+  submitTestCases: ExtendedTestCase[];
+  uncoveredTestsOnly?: boolean;
+}): number[] => {
+  if (!folderId && selectedTestCaseIds?.length) {
+    if (!uncoveredTestsOnly) {
+      return selectedTestCaseIds;
+    }
+
+    return selectedTestCaseIds.filter((id) => {
+      const testCase = submitTestCases.find((item) => item.id === id);
+
+      return testCase ? !getIsManualCovered(testCase.lastExecution?.status) : true;
+    });
+  }
+
+  const addedTestCases = uncoveredTestsOnly
+    ? submitTestCases.filter((testCase) => !getIsManualCovered(testCase.lastExecution?.status))
+    : submitTestCases;
+
+  return addedTestCases.map((testCase) => testCase.id);
+};
+
 export const useCreateManualLaunch = (
   testCases: ExtendedTestCase[],
   activeMode: LaunchMode,
@@ -44,6 +74,7 @@ export const useCreateManualLaunch = (
   folderId?: number,
   onClearSelection?: () => void,
   onSubmitSuccess?: (mode: LaunchMode) => void,
+  selectedTestCaseIds?: number[],
 ) => {
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
@@ -86,13 +117,27 @@ export const useCreateManualLaunch = (
         return;
       }
 
-      const addedTestCases = formValues.uncoveredTestsOnly
-        ? submitTestCases.filter(
-            (testCase) => !getIsManualCovered(testCase.lastExecution?.status),
-          )
-        : submitTestCases;
+      const testCaseIds = resolveTestCaseIds({
+        folderId,
+        selectedTestCaseIds,
+        submitTestCases,
+        uncoveredTestsOnly: formValues.uncoveredTestsOnly,
+      });
 
-      const testCaseIds = addedTestCases.map((testCase) => testCase.id);
+      if (isEmpty(testCaseIds)) {
+        dispatch(
+          showErrorNotification({
+            message: formatMessage(messages.launchCreationFailed),
+          }),
+        );
+        setIsLoading(false);
+
+        return;
+      }
+
+      const primaryTestCaseName = submitTestCases.find(
+        (testCase) => testCase.id === testCaseIds[0],
+      )?.name;
 
       try {
         const launchId = isLaunchObject(formValues.name) ? formValues.name.id : selectedLaunchId;
@@ -118,10 +163,10 @@ export const useCreateManualLaunch = (
           dispatch(
             showSuccessNotification({
               message:
-                addedTestCases.length > 1
+                testCaseIds.length > 1
                   ? formatMessage(messages.testCasesAddedSuccess)
                   : formatMessage(messages.testCaseAddedSuccess, {
-                      testCaseName: addedTestCases[0]?.name,
+                      testCaseName: primaryTestCaseName,
                     }),
             }),
           );
@@ -173,6 +218,8 @@ export const useCreateManualLaunch = (
     [
       testPlanId,
       getTestCasesForSubmit,
+      folderId,
+      selectedTestCaseIds,
       selectedLaunchId,
       activeMode,
       onClearSelection,

--- a/app/src/pages/inside/testCaseLibraryPage/addToLaunchModal/addToLaunchModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/addToLaunchModal/addToLaunchModal.tsx
@@ -33,7 +33,8 @@ import {
   LaunchMode,
   INITIAL_LAUNCH_FORM_VALUES,
 } from 'pages/inside/common/launchFormFields';
-import { testCasesSelector } from 'controllers/testCase';
+import { testCaseDetailsSelector, testCasesSelector } from 'controllers/testCase';
+import { ExtendedTestCase } from 'types/testCase';
 
 import { AddToLaunchModalProps } from './types';
 import { messages } from './messages';
@@ -45,6 +46,26 @@ const cx = createClassnames(styles);
 const BoldTestCasesCount = (parts: ReactNode[]) => (
   <b className={cx('selected-test-cases')}>{parts}</b>
 );
+
+const resolveSelectedTestCases = ({
+  selectedTestCaseIds,
+  allTestCases,
+  testCaseDetails,
+}: {
+  selectedTestCaseIds: number[];
+  allTestCases: ExtendedTestCase[];
+  testCaseDetails?: ExtendedTestCase | null;
+}): ExtendedTestCase[] => {
+  const testCasesById = new Map(allTestCases.map((testCase) => [testCase.id, testCase]));
+
+  if (testCaseDetails?.id) {
+    testCasesById.set(testCaseDetails.id, testCaseDetails);
+  }
+
+  return selectedTestCaseIds.map(
+    (id) => testCasesById.get(id) ?? ({ id } as ExtendedTestCase),
+  );
+};
 
 const AddToLaunchModalComponent = ({
   folderId,
@@ -58,6 +79,7 @@ const AddToLaunchModalComponent = ({
   const { formatMessage } = useIntl();
   const { trackEvent } = useTracking();
   const allTestCases = useSelector(testCasesSelector);
+  const testCaseDetails = useSelector(testCaseDetailsSelector);
 
   const isFromFolder = folderId !== undefined;
 
@@ -65,8 +87,12 @@ const AddToLaunchModalComponent = ({
     () =>
       isFromFolder
         ? []
-        : allTestCases.filter((testCase) => (selectedTestCaseIds || []).includes(testCase.id)),
-    [allTestCases, isFromFolder, selectedTestCaseIds],
+        : resolveSelectedTestCases({
+            selectedTestCaseIds: selectedTestCaseIds || [],
+            allTestCases,
+            testCaseDetails,
+          }),
+    [allTestCases, isFromFolder, selectedTestCaseIds, testCaseDetails],
   );
 
   const count = isFromFolder ? (itemCount ?? 0) : selectedTestCaseIds.length;
@@ -111,6 +137,7 @@ const AddToLaunchModalComponent = ({
     <BaseLaunchModal
       {...reduxFormProps}
       testCases={testCases}
+      selectedTestCaseIds={isFromFolder ? undefined : selectedTestCaseIds}
       folderId={folderId}
       modalTitle={formatMessage(messages.addToLaunch)}
       okButtonText={COMMON_LOCALE_KEYS.ADD}

--- a/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/addTestCasesToLaunchModal/addTestCasesToLaunchModal.tsx
+++ b/app/src/pages/inside/testPlansPage/testPlanDetailsPage/testPlanFolders/allTestCasesPage/addTestCasesToLaunchModal/addTestCasesToLaunchModal.tsx
@@ -96,6 +96,7 @@ const AddTestCasesToLaunchModalComponent = ({
     <BaseLaunchModal
       {...reduxFormProps}
       testCases={testCases}
+      selectedTestCaseIds={selectedRowsIds}
       testPlanId={Number(testPlanId)}
       modalTitle={formatMessage(messages.addToLaunch)}
       okButtonText={COMMON_LOCALE_KEYS.ADD}


### PR DESCRIPTION
## Description

Fixes EPMRPP-118575: adding a Test Case to an existing Manual Launch from the details page or side panel could return **400** (`Field 'testCaseIds' should not be empty`) when the launch was linked to a Test Plan.

## Problem

`AddToLaunchModal` resolved Test Cases only by filtering the current list page in Redux (`testCasesSelector`). From details/side panel the selected case is often absent from that list, so submit sent `testCaseIds: []`.

Launch batch accepts an empty list (noop), but the follow-up sync to the linked Test Plan (`test-plan/.../test-case/batch`) validates `@NotEmpty` and fails — which made the bug look flaky and “wrong Test Plan request”.

## Solution

- Pass `selectedTestCaseIds` through `BaseLaunchModal` into `useCreateManualLaunch` and use them as the source of truth for the API payload (same approach as Add to Test Plan).
- Resolve Test Case entities from list + details for UI (description / success name), with id stubs as fallback.
- Guard empty `testCaseIds` before any request.
- Keep linked Test Plan sync when the launch has a linked plan (US-TMS-TEP-007 / EPMRPP-107270).

## Visuals

### Before


https://github.com/user-attachments/assets/5023e01f-550a-4b95-8420-c7c3cc4e283a



### After


https://github.com/user-attachments/assets/21d8b699-6cc0-4c20-b8b4-c54920327fa1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adding selected test cases to launches, including cases not currently visible in the loaded list.
  * Manual launches now consistently use the selected test cases and avoid submitting covered cases when filtering is enabled.
  * Added an error notification when no valid test cases are available for submission.
  * Updated launch success notifications to reflect the test cases actually submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->