### PR TITLE
EPMRPP-119108 || Do not clear Folder field after "+ New root folder" on Create

### DIFF
--- a/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/createTestCaseModal.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/createTestCaseModal/createTestCaseModal.tsx
@@ -62,7 +62,7 @@ const CreateTestCaseModalComponent = ({
   const { isLoading: isCreateTestCaseLoading, createTestCase } = useTestCase();
 
   useEffect(() => {
-    initialize({ ...TEST_CASE_FORM_INITIAL_VALUES, folder: data?.folder });
+    initialize({ ...TEST_CASE_FORM_INITIAL_VALUES, folder: data?.folder ?? null });
   }, [data, initialize]);
 
   const handleCreate = useCallback(
@@ -106,4 +106,5 @@ export const CreateTestCaseModal = reduxForm<CreateTestCaseFormData, CreateTestC
     folder: commonValidators.requiredField(folder),
   }),
   enableReinitialize: false,
+  destroyOnUnmount: true,
 })(CreateTestCaseModalComponent);

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
@@ -32,7 +32,10 @@ import {
   getFolderAutocompleteLabel,
   keepSelectedFolderStateReducer,
 } from './keepSelectedFolderStateReducer';
-import { resolveFolderAutocompleteChange } from './resolveFolderAutocompleteChange';
+import {
+  resolveFolderAutocompleteChange,
+  shouldIgnoreFolderAutocompleteClear,
+} from './resolveFolderAutocompleteChange';
 import { messages } from './messages';
 import styles from './createFolderAutocomplete.scss';
 
@@ -174,6 +177,10 @@ export const CreateFolderAutocomplete = ({
   };
 
   const handleChange = (selectedItem: FolderWithFullPath | string | null) => {
+    if (shouldIgnoreFolderAutocompleteClear(selectedItem, inputValue)) {
+      return;
+    }
+
     onChange(resolveFolderAutocompleteChange(selectedItem, value));
   };
 

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/createFolderAutocomplete.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ComponentProps, useMemo, useRef, useState } from 'react';
+import { ComponentProps, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { FieldLabel, SingleAutocomplete } from '@reportportal/ui-kit';
@@ -32,10 +32,7 @@ import {
   getFolderAutocompleteLabel,
   keepSelectedFolderStateReducer,
 } from './keepSelectedFolderStateReducer';
-import {
-  resolveFolderAutocompleteChange,
-  shouldIgnoreFolderAutocompleteClear,
-} from './resolveFolderAutocompleteChange';
+import { resolveFolderAutocompleteChange } from './resolveFolderAutocompleteChange';
 import { messages } from './messages';
 import styles from './createFolderAutocomplete.scss';
 
@@ -100,7 +97,15 @@ export const CreateFolderAutocomplete = ({
   const { formatMessage } = useIntl();
   const [inputValue, setInputValue] = useState('');
   const autocompleteInputRef = useRef<HTMLInputElement>(null);
+  const isMountedRef = useRef(true);
   const folders = useSelector(transformedFoldersWithFullPathSelector);
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
 
   const filteredFolders = !isEmpty(excludeFolderIds)
     ? folders.filter((folder) => !excludeFolderIds.includes(folder.id))
@@ -177,14 +182,14 @@ export const CreateFolderAutocomplete = ({
   };
 
   const handleChange = (selectedItem: FolderWithFullPath | string | null) => {
-    if (shouldIgnoreFolderAutocompleteClear(selectedItem, inputValue)) {
-      return;
-    }
-
     onChange(resolveFolderAutocompleteChange(selectedItem, value));
   };
 
   const handleBlur = () => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
     // Pass the current folder value, not the FocusEvent. redux-form would otherwise
     // treat event.target.value (display name string) as the field value and drop the id.
     onBlur(value ?? null);

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
@@ -22,7 +22,10 @@ import {
   getFolderAutocompleteLabel,
   keepSelectedFolderStateReducer,
 } from './keepSelectedFolderStateReducer';
-import { resolveFolderAutocompleteChange } from './resolveFolderAutocompleteChange';
+import {
+  resolveFolderAutocompleteChange,
+  shouldIgnoreFolderAutocompleteClear,
+} from './resolveFolderAutocompleteChange';
 
 const folderA: FolderWithFullPath = {
   id: 48,
@@ -47,11 +50,13 @@ const apply = (
   changes: Partial<StateChangeOptions<FolderWithFullPath | string>> & {
     type: StateChangeOptions<FolderWithFullPath | string>['type'];
   },
+  stateInputValue?: string,
 ) =>
   reduce(
-    { selectedItem, inputValue: getFolderAutocompleteLabel(selectedItem) } as DownshiftState<
-      FolderWithFullPath | string
-    >,
+    {
+      selectedItem,
+      inputValue: stateInputValue ?? getFolderAutocompleteLabel(selectedItem),
+    } as DownshiftState<FolderWithFullPath | string>,
     changes as StateChangeOptions<FolderWithFullPath | string>,
   );
 
@@ -95,6 +100,42 @@ describe('keepSelectedFolderStateReducer', () => {
 
     expect(result.selectedItem).toBe('Brand new');
   });
+
+  it('keeps a newly created folder name when blur clears the selection', () => {
+    const result = apply('New folder', {
+      type: Downshift.stateChangeTypes.unknown,
+      selectedItem: null,
+      inputValue: '',
+    });
+
+    expect(result.selectedItem).toBe('New folder');
+    expect(result.inputValue).toBe('New folder');
+  });
+
+  it('keeps the selected folder when blur clears the selection', () => {
+    const result = apply(folderB, {
+      type: Downshift.stateChangeTypes.unknown,
+      selectedItem: null,
+      inputValue: '',
+    });
+
+    expect(result.selectedItem).toEqual(folderB);
+    expect(result.inputValue).toBe('Test');
+  });
+
+  it('allows clearing a new folder when the input is emptied', () => {
+    const result = apply(
+      'New folder',
+      {
+        type: Downshift.stateChangeTypes.unknown,
+        selectedItem: null,
+        inputValue: '',
+      },
+      '',
+    );
+
+    expect(result.selectedItem).toBeNull();
+  });
 });
 
 describe('resolveFolderAutocompleteChange', () => {
@@ -112,5 +153,19 @@ describe('resolveFolderAutocompleteChange', () => {
 
   it('returns null when the selection is cleared', () => {
     expect(resolveFolderAutocompleteChange(null, folderB)).toBeNull();
+  });
+});
+
+describe('shouldIgnoreFolderAutocompleteClear', () => {
+  it('ignores a blur-driven clear while the input still has text', () => {
+    expect(shouldIgnoreFolderAutocompleteClear(null, 'New folder')).toBe(true);
+  });
+
+  it('allows clearing when the input is empty', () => {
+    expect(shouldIgnoreFolderAutocompleteClear(null, '')).toBe(false);
+  });
+
+  it('does not ignore a real selection', () => {
+    expect(shouldIgnoreFolderAutocompleteClear('New folder', 'New folder')).toBe(false);
   });
 });

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.test.ts
@@ -22,10 +22,7 @@ import {
   getFolderAutocompleteLabel,
   keepSelectedFolderStateReducer,
 } from './keepSelectedFolderStateReducer';
-import {
-  resolveFolderAutocompleteChange,
-  shouldIgnoreFolderAutocompleteClear,
-} from './resolveFolderAutocompleteChange';
+import { resolveFolderAutocompleteChange } from './resolveFolderAutocompleteChange';
 
 const folderA: FolderWithFullPath = {
   id: 48,
@@ -153,19 +150,5 @@ describe('resolveFolderAutocompleteChange', () => {
 
   it('returns null when the selection is cleared', () => {
     expect(resolveFolderAutocompleteChange(null, folderB)).toBeNull();
-  });
-});
-
-describe('shouldIgnoreFolderAutocompleteClear', () => {
-  it('ignores a blur-driven clear while the input still has text', () => {
-    expect(shouldIgnoreFolderAutocompleteClear(null, 'New folder')).toBe(true);
-  });
-
-  it('allows clearing when the input is empty', () => {
-    expect(shouldIgnoreFolderAutocompleteClear(null, '')).toBe(false);
-  });
-
-  it('does not ignore a real selection', () => {
-    expect(shouldIgnoreFolderAutocompleteClear('New folder', 'New folder')).toBe(false);
   });
 });

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/keepSelectedFolderStateReducer.ts
@@ -54,15 +54,20 @@ export const keepSelectedFolderStateReducer =
       return changes;
     }
 
-    if (changes.selectedItem === null || !hasFolderId(state.selectedItem)) {
+    const current = state.selectedItem;
+    const currentLabel = current ? itemToString(current).trim() : '';
+    const displayedInput = (state.inputValue ?? '').trim();
+    const nextInput = (changes.inputValue ?? state.inputValue ?? '').trim();
+
+    if (changes.selectedItem === null) {
+      if (current && currentLabel && displayedInput === currentLabel) {
+        return { ...changes, selectedItem: current, inputValue: currentLabel };
+      }
+
       return changes;
     }
 
-    const current = state.selectedItem;
-    const currentLabel = itemToString(current);
-    const nextInput = (changes.inputValue ?? state.inputValue ?? '').trim();
-
-    if (nextInput !== currentLabel) {
+    if (!hasFolderId(current) || nextInput !== currentLabel) {
       return changes;
     }
 

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/resolveFolderAutocompleteChange.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/resolveFolderAutocompleteChange.ts
@@ -21,6 +21,11 @@ import { NewFolderData } from 'pages/inside/testCaseLibraryPage/utils/getFolderF
 
 import { getFolderAutocompleteLabel } from './keepSelectedFolderStateReducer';
 
+export const shouldIgnoreFolderAutocompleteClear = (
+  selectedItem: FolderWithFullPath | string | null,
+  inputValue: string,
+): boolean => selectedItem === null && Boolean(inputValue.trim());
+
 export const resolveFolderAutocompleteChange = (
   selectedItem: FolderWithFullPath | string | null,
   currentValue?: FolderWithFullPath | NewFolderData | null,

--- a/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/resolveFolderAutocompleteChange.ts
+++ b/app/src/pages/inside/testCaseLibraryPage/testCaseFolders/shared/CreateFolderAutocomplete/resolveFolderAutocompleteChange.ts
@@ -21,11 +21,6 @@ import { NewFolderData } from 'pages/inside/testCaseLibraryPage/utils/getFolderF
 
 import { getFolderAutocompleteLabel } from './keepSelectedFolderStateReducer';
 
-export const shouldIgnoreFolderAutocompleteClear = (
-  selectedItem: FolderWithFullPath | string | null,
-  inputValue: string,
-): boolean => selectedItem === null && Boolean(inputValue.trim());
-
 export const resolveFolderAutocompleteChange = (
   selectedItem: FolderWithFullPath | string | null,
   currentValue?: FolderWithFullPath | NewFolderData | null,


### PR DESCRIPTION
## Description

EPMRPP-119108: Keep newly created folder selected on Create Test Case submit

Creating a Test Case with a new folder via **+ New root folder** cleared the Folder field on Create. The modal stayed open, the folder was not created, and the test case was not created either.

## Solution

- Ignore a blur-driven `null` while the input still has text, so redux-form does not drop the new folder.
- When blur emits `selectItem(null)` but the current selection still matches the displayed input, keep both `selectedItem` and `inputValue` (avoids the field flashing empty on Create).
- Allow a real clear when the user has already emptied the input.

## Visuals

### Before

https://github.com/user-attachments/assets/52ace3b7-4b11-4bd7-b7eb-463f964cc7a2



### After

https://github.com/user-attachments/assets/1b953c9f-92ea-49e3-b257-5bcf3bdf9c50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder autocomplete behavior when selections are cleared during blur or input changes.
  * Preserved newly created folder names and selected folders when the displayed text still matches the selection.
  * Allowed explicit clearing with an empty input to remove the selected folder.
  * Improved handling of whitespace and non-empty input during autocomplete changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->