### PR TITLE
EPMRPP-118939 || Show folder tree scroll fades only when content overflows

### DIFF
--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.scss
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.scss
@@ -241,6 +241,22 @@
     position: relative;
     overflow: hidden;
 
+    &--fade-top::before {
+      content: '';
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      right: var(--folder-tree-scrollbar-gutter, 0px);
+      height: 48px;
+      pointer-events: none;
+      background: linear-gradient(
+        180deg,
+        var(--rp-ui-base-bg-000) 0%,
+        color-mix(in srgb, var(--rp-ui-base-bg-000) 0%, transparent) 100%
+      );
+    }
+
     &:has(.expanded-options__drop-placeholder) {
       .folders-tree {
         opacity: 0.5;

--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CSSProperties, useCallback, useMemo, useState } from 'react';
+import { CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDrop } from 'react-dnd';
 import { isEmpty } from 'es-toolkit/compat';
@@ -190,6 +190,12 @@ export const ExpandedOptions = ({
   const hideSidebar =
     hideFolderSidebar ||
     (hasFolderSidebarFilters && (isSidebarResolving || !hasSearchFilteredFolders));
+
+  useEffect(() => {
+    if (hideSidebar) {
+      setScrollEdges(NO_SCROLL_OVERFLOW_EDGES);
+    }
+  }, [hideSidebar]);
 
   const handleMoveFolder = useCallback(
     (draggedItem: TreeDragItem, targetId: string | number, position: TreeDropPosition) => {

--- a/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
+++ b/app/src/pages/inside/common/expandedOptions/expandedOptions.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useMemo } from 'react';
+import { CSSProperties, useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useDrop } from 'react-dnd';
 import { isEmpty } from 'es-toolkit/compat';
@@ -47,6 +47,10 @@ import { EmptyPageState } from 'pages/common/emptyPageState';
 import { messages } from './messages';
 import { VirtualFolderTree } from './folderTree/virtualFolderTree';
 import { FolderTreeFooter } from './folderTree/folderTreeFooter';
+import {
+  NO_SCROLL_OVERFLOW_EDGES,
+  type ScrollOverflowEdges,
+} from './folderTree/useScrollOverflowEdges';
 import type { ExpandedOptionsProps } from './types';
 import { useFolderSearch } from './useFolderSearch';
 import { useSearchFilteredFolders } from './useSearchFilteredFolders';
@@ -85,6 +89,17 @@ export const ExpandedOptions = ({
     flatViewScopeId,
   });
   const allFolders = useSelector(foldersSelector);
+  const [scrollEdges, setScrollEdges] = useState<ScrollOverflowEdges>(NO_SCROLL_OVERFLOW_EDGES);
+
+  const handleScrollEdgesChange = useCallback((edges: ScrollOverflowEdges) => {
+    setScrollEdges((previous) =>
+      previous.canScrollUp === edges.canScrollUp &&
+      previous.canScrollDown === edges.canScrollDown &&
+      previous.scrollbarGutter === edges.scrollbarGutter
+        ? previous
+        : edges,
+    );
+  }, []);
 
   const internalSearchData = useSearchFilteredFolders({
     searchQuery: searchFilteredData ? undefined : pageSearchQuery,
@@ -276,7 +291,14 @@ export const ExpandedOptions = ({
       )}
       <div className={cx('expanded-options', { 'expanded-options--no-sidebar': hideSidebar })}>
         {hideSidebar || (
-          <div className={cx('expanded-options__sidebar')}>
+          <div
+            className={cx('expanded-options__sidebar')}
+            style={
+              {
+                '--folder-tree-scrollbar-gutter': `${scrollEdges.scrollbarGutter}px`,
+              } as CSSProperties
+            }
+          >
             <div className={cx('sidebar-header')}>
               <button
                 type="button"
@@ -321,7 +343,12 @@ export const ExpandedOptions = ({
                 />
               </div>
             )}
-            <div ref={dropZoneRef} className={cx('expanded-options__sidebar-folders-wrapper')}>
+            <div
+              ref={dropZoneRef}
+              className={cx('expanded-options__sidebar-folders-wrapper', {
+                'expanded-options__sidebar-folders-wrapper--fade-top': scrollEdges.canScrollUp,
+              })}
+            >
               {isDraggingAny && !isOverFoldersZone && (
                 <div className={cx('expanded-options__drop-placeholder')}>
                   <div className={cx('expanded-options__drop-placeholder-content')}>
@@ -354,6 +381,7 @@ export const ExpandedOptions = ({
                 setAllTestCases={setAllTestCases}
                 onToggleFolder={handleToggleFolder}
                 onFolderClick={onFolderClick}
+                onScrollEdgesChange={handleScrollEdgesChange}
               />
             </div>
             {!isEmpty(filteredFolders) && (
@@ -361,6 +389,7 @@ export const ExpandedOptions = ({
                 isFlatView={isFlatView}
                 isExpandAllDisabled={isExpandAllDisabled}
                 isCollapseAllDisabled={isCollapseAllDisabled}
+                showBottomFade={scrollEdges.canScrollDown}
                 onFlatViewChange={setIsFlatView}
                 onExpandAll={handleExpandAll}
                 onCollapseAll={handleCollapseAll}

--- a/app/src/pages/inside/common/expandedOptions/folderTree/folderTreeFooter.scss
+++ b/app/src/pages/inside/common/expandedOptions/folderTree/folderTreeFooter.scss
@@ -26,18 +26,18 @@
   background-color: var(--rp-ui-base-bg-000);
   box-sizing: border-box;
 
-  &::before {
+  &--fade-bottom::before {
     content: '';
     position: absolute;
     bottom: 102%;
     left: 0;
-    right: 0;
-    height: 36px;
+    right: var(--folder-tree-scrollbar-gutter, 0px);
+    height: 48px;
     pointer-events: none;
     background: linear-gradient(
       360deg,
       var(--rp-ui-base-bg-000) 0%,
-      color-mix(in srgb, var(--rp-ui-base-bg-000), transparent) 100%
+      color-mix(in srgb, var(--rp-ui-base-bg-000) 0%, transparent) 100%
     );
   }
 

--- a/app/src/pages/inside/common/expandedOptions/folderTree/folderTreeFooter.tsx
+++ b/app/src/pages/inside/common/expandedOptions/folderTree/folderTreeFooter.tsx
@@ -33,6 +33,7 @@ interface FolderTreeFooterProps {
   isFlatView: boolean;
   isExpandAllDisabled: boolean;
   isCollapseAllDisabled: boolean;
+  showBottomFade?: boolean;
   onFlatViewChange: (value: boolean) => void;
   onExpandAll: VoidFn;
   onCollapseAll: VoidFn;
@@ -43,6 +44,7 @@ export const FolderTreeFooter = ({
   isFlatView,
   isExpandAllDisabled,
   isCollapseAllDisabled,
+  showBottomFade = false,
   onFlatViewChange,
   onExpandAll,
   onCollapseAll,
@@ -69,7 +71,11 @@ export const FolderTreeFooter = ({
   };
 
   return (
-    <div className={cx('folder-tree-footer')}>
+    <div
+      className={cx('folder-tree-footer', {
+        'folder-tree-footer--fade-bottom': showBottomFade,
+      })}
+    >
       <Toggle
         value={isFlatView}
         className={cx('folder-tree-footer__toggle')}

--- a/app/src/pages/inside/common/expandedOptions/folderTree/useScrollOverflowEdges.test.ts
+++ b/app/src/pages/inside/common/expandedOptions/folderTree/useScrollOverflowEdges.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getScrollOverflowEdges } from './useScrollOverflowEdges';
+
+const createScrollElement = ({
+  scrollTop,
+  clientHeight,
+  scrollHeight,
+  offsetWidth = 200,
+  clientWidth = 200,
+}: {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+  offsetWidth?: number;
+  clientWidth?: number;
+}): HTMLElement =>
+  ({
+    scrollTop,
+    clientHeight,
+    scrollHeight,
+    offsetWidth,
+    clientWidth,
+  }) as HTMLElement;
+
+describe('getScrollOverflowEdges', () => {
+  it('reports no overflow when content fits the viewport', () => {
+    expect(
+      getScrollOverflowEdges(
+        createScrollElement({ scrollTop: 0, clientHeight: 200, scrollHeight: 200 }),
+      ),
+    ).toEqual({ canScrollUp: false, canScrollDown: false, scrollbarGutter: 0 });
+  });
+
+  it('reports bottom overflow at the top of a tall list', () => {
+    expect(
+      getScrollOverflowEdges(
+        createScrollElement({ scrollTop: 0, clientHeight: 200, scrollHeight: 500 }),
+      ),
+    ).toEqual({ canScrollUp: false, canScrollDown: true, scrollbarGutter: 0 });
+  });
+
+  it('reports top overflow at the bottom of a tall list', () => {
+    expect(
+      getScrollOverflowEdges(
+        createScrollElement({ scrollTop: 300, clientHeight: 200, scrollHeight: 500 }),
+      ),
+    ).toEqual({ canScrollUp: true, canScrollDown: false, scrollbarGutter: 0 });
+  });
+
+  it('reports both edges when scrolled in the middle', () => {
+    expect(
+      getScrollOverflowEdges(
+        createScrollElement({ scrollTop: 100, clientHeight: 200, scrollHeight: 500 }),
+      ),
+    ).toEqual({ canScrollUp: true, canScrollDown: true, scrollbarGutter: 0 });
+  });
+
+  it('reports scrollbar gutter width', () => {
+    expect(
+      getScrollOverflowEdges(
+        createScrollElement({
+          scrollTop: 0,
+          clientHeight: 200,
+          scrollHeight: 500,
+          offsetWidth: 220,
+          clientWidth: 205,
+        }),
+      ),
+    ).toEqual({ canScrollUp: false, canScrollDown: true, scrollbarGutter: 15 });
+  });
+});

--- a/app/src/pages/inside/common/expandedOptions/folderTree/useScrollOverflowEdges.ts
+++ b/app/src/pages/inside/common/expandedOptions/folderTree/useScrollOverflowEdges.ts
@@ -55,6 +55,7 @@ export const useScrollOverflowEdges = (
 ) => {
   const onChangeRef = useRef(onChange);
   const previousEdgesRef = useRef<ScrollOverflowEdges>(NO_SCROLL_OVERFLOW_EDGES);
+  const hasOnChange = Boolean(onChange);
 
   onChangeRef.current = onChange;
 
@@ -95,5 +96,5 @@ export const useScrollOverflowEdges = (
       element.removeEventListener('scroll', update);
       resizeObserver.disconnect();
     };
-  }, [scrollRef, contentSizeKey]);
+  }, [scrollRef, contentSizeKey, hasOnChange]);
 };

--- a/app/src/pages/inside/common/expandedOptions/folderTree/useScrollOverflowEdges.ts
+++ b/app/src/pages/inside/common/expandedOptions/folderTree/useScrollOverflowEdges.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RefObject, useEffect, useRef } from 'react';
+
+const SCROLL_EDGE_EPSILON_PX = 1;
+
+export interface ScrollOverflowEdges {
+  canScrollUp: boolean;
+  canScrollDown: boolean;
+  scrollbarGutter: number;
+}
+
+export const NO_SCROLL_OVERFLOW_EDGES: ScrollOverflowEdges = {
+  canScrollUp: false,
+  canScrollDown: false,
+  scrollbarGutter: 0,
+};
+
+export const getScrollOverflowEdges = (element: HTMLElement): ScrollOverflowEdges => {
+  const { scrollTop, clientHeight, scrollHeight, offsetWidth, clientWidth } = element;
+
+  return {
+    canScrollUp: scrollTop > SCROLL_EDGE_EPSILON_PX,
+    canScrollDown: scrollTop + clientHeight < scrollHeight - SCROLL_EDGE_EPSILON_PX,
+    scrollbarGutter: Math.max(0, offsetWidth - clientWidth),
+  };
+};
+
+const areScrollOverflowEdgesEqual = (
+  left: ScrollOverflowEdges,
+  right: ScrollOverflowEdges,
+): boolean =>
+  left.canScrollUp === right.canScrollUp &&
+  left.canScrollDown === right.canScrollDown &&
+  left.scrollbarGutter === right.scrollbarGutter;
+
+export const useScrollOverflowEdges = (
+  scrollRef: RefObject<HTMLElement | null>,
+  onChange: ((edges: ScrollOverflowEdges) => void) | undefined,
+  contentSizeKey: number | string,
+) => {
+  const onChangeRef = useRef(onChange);
+  const previousEdgesRef = useRef<ScrollOverflowEdges>(NO_SCROLL_OVERFLOW_EDGES);
+
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    const emit = (edges: ScrollOverflowEdges) => {
+      if (areScrollOverflowEdgesEqual(previousEdgesRef.current, edges)) {
+        return;
+      }
+
+      previousEdgesRef.current = edges;
+      onChangeRef.current?.(edges);
+    };
+
+    const element = scrollRef.current;
+
+    if (!element || !onChangeRef.current) {
+      emit(NO_SCROLL_OVERFLOW_EDGES);
+      return;
+    }
+
+    const update = () => {
+      emit(getScrollOverflowEdges(element));
+    };
+
+    update();
+
+    element.addEventListener('scroll', update, { passive: true });
+
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(element);
+
+    const content = element.firstElementChild;
+    if (content) {
+      resizeObserver.observe(content);
+    }
+
+    return () => {
+      element.removeEventListener('scroll', update);
+      resizeObserver.disconnect();
+    };
+  }, [scrollRef, contentSizeKey]);
+};

--- a/app/src/pages/inside/common/expandedOptions/folderTree/virtualFolderTree.tsx
+++ b/app/src/pages/inside/common/expandedOptions/folderTree/virtualFolderTree.tsx
@@ -31,6 +31,11 @@ import { ROW_HEIGHT_PX } from '../folder/connectorLines';
 import { useFlattenedTree, type FlatFolderNode } from '../useFlattenedTree';
 
 import { FOLDER_DRAG_TYPE, EXTERNAL_TREE_DROP_TYPE } from '../constants';
+import {
+  NO_SCROLL_OVERFLOW_EDGES,
+  useScrollOverflowEdges,
+  type ScrollOverflowEdges,
+} from './useScrollOverflowEdges';
 
 import styles from './virtualFolderTree.scss';
 
@@ -53,6 +58,7 @@ export interface VirtualFolderTreeProps {
   onFolderClick: (id: number) => void;
   setAllTestCases: VoidFn;
   onToggleFolder: (folder: TransformedFolder) => void;
+  onScrollEdgesChange?: (edges: ScrollOverflowEdges) => void;
 }
 
 export const VirtualFolderTree = ({
@@ -72,10 +78,15 @@ export const VirtualFolderTree = ({
   onFolderClick,
   setAllTestCases,
   onToggleFolder,
+  onScrollEdgesChange,
 }: VirtualFolderTreeProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const flatFolders = useFlattenedTree(folders, expandedIds, searchQuery, isFlatView);
   const flatFoldersRef = useRef(flatFolders);
+  const isTreeContentHidden =
+    Boolean(pageSearchQuery && isSearchFilteredLoading) ||
+    Boolean(pageSearchQuery && !hasSearchFilteredFolders) ||
+    Boolean(searchQuery && !hasAnyMatch);
 
   const virtualizer = useVirtualizer({
     count: size(flatFolders),
@@ -85,6 +96,22 @@ export const VirtualFolderTree = ({
   });
 
   flatFoldersRef.current = flatFolders;
+
+  const contentSizeKey = isTreeContentHidden
+    ? 'hidden'
+    : `${size(flatFolders)}:${virtualizer.getTotalSize()}`;
+
+  useScrollOverflowEdges(
+    scrollRef,
+    isTreeContentHidden ? undefined : onScrollEdgesChange,
+    contentSizeKey,
+  );
+
+  useEffect(() => {
+    if (isTreeContentHidden) {
+      onScrollEdgesChange?.(NO_SCROLL_OVERFLOW_EDGES);
+    }
+  }, [isTreeContentHidden, onScrollEdgesChange]);
 
   const scrollToActiveFolder = useCallback(
     (folderId: number) => {


### PR DESCRIPTION
## Description

Fixes EPMRPP-118939: the last folder in Test Case Library was always partially blurred. The bottom fade on the folder tree footer stayed visible even when the list was scrolled to the end.

## Problem

`FolderTreeFooter` rendered a permanent gradient overlay above the footer. It did not depend on scroll position, so the last visible folder stayed faded when there was nothing left to scroll to. Expected behavior (and Figma): edge fades appear only while more items are hidden above or below.

## Solution

- Track folder tree scroll overflow edges (`canScrollUp` / `canScrollDown`) and show top/bottom fades only when needed.
- Match Figma fade style: 48px gradient from solid background color to full transparency.
- Keep fades clear of the scrollbar by offsetting them with the measured scrollbar gutter width.

## Visuals

https://github.com/user-attachments/assets/b181a8ea-14b6-4c33-92dc-bd8b30eff132




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added subtle fade indicators to the folder tree when additional folders are available above or below the visible area.
  - Fade overlays automatically adjust to the scrollbar area and appear only when scrolling is possible.

- **Bug Fixes**
  - Improved folder tree scrolling visuals across different content sizes and scrollbar states.

- **Tests**
  - Added coverage for detecting scrollable content and scrollbar spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->