### PR TITLE
Add OAuth2 authorization option to the Email Server integration form

### DIFF
--- a/app/src/components/integrations/integrationProviders/emailIntegration/constants.js
+++ b/app/src/components/integrations/integrationProviders/emailIntegration/constants.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+/* Legacy boolean flag, kept only for reading integrations persisted before AUTH_MODE_KEY existed. */
 export const AUTH_ENABLED_KEY = 'authEnabled';
+export const AUTH_MODE_KEY = 'authMode';
 export const PROTOCOL_KEY = 'protocol';
 export const SSL_KEY = 'sslEnabled';
 export const TLS_KEY = 'starTlsEnabled';
@@ -24,6 +26,9 @@ export const HOST_KEY = 'host';
 export const PORT_KEY = 'port';
 export const USERNAME_KEY = 'username';
 export const PASSWORD_KEY = 'password';
+export const TENANT_ID_KEY = 'tenantId';
+export const CLIENT_ID_KEY = 'clientId';
+export const CLIENT_SECRET_KEY = 'clientSecret';
 const RP_HOST = 'rpHost';
 
 export const ENCRYPTION_MODE_NONE = 'none';
@@ -32,12 +37,19 @@ export const ENCRYPTION_MODE_SSL = 'ssl';
 
 export const PROTOCOL_SMTP = 'smtp';
 
+export const AUTH_MODE_OFF = 'OFF';
+export const AUTH_MODE_BASIC = 'BASIC';
+export const AUTH_MODE_OAUTH2 = 'OAUTH2';
+
 export const DEFAULT_FORM_CONFIG = {
-  [AUTH_ENABLED_KEY]: false,
+  [AUTH_MODE_KEY]: AUTH_MODE_OFF,
   [PROTOCOL_KEY]: PROTOCOL_SMTP,
   [SSL_KEY]: false,
   [TLS_KEY]: false,
   [USERNAME_KEY]: '',
   [PASSWORD_KEY]: '',
+  [TENANT_ID_KEY]: '',
+  [CLIENT_ID_KEY]: '',
+  [CLIENT_SECRET_KEY]: '',
   [RP_HOST]: window.location.origin,
 };

--- a/app/src/components/integrations/integrationProviders/emailIntegration/emailFormFields/emailFormFields.jsx
+++ b/app/src/components/integrations/integrationProviders/emailIntegration/emailFormFields/emailFormFields.jsx
@@ -35,6 +35,10 @@ import { separateFromIntoNameAndEmail } from 'common/utils';
 import {
   DEFAULT_FORM_CONFIG,
   AUTH_ENABLED_KEY,
+  AUTH_MODE_KEY,
+  AUTH_MODE_OFF,
+  AUTH_MODE_BASIC,
+  AUTH_MODE_OAUTH2,
   PROTOCOL_KEY,
   SSL_KEY,
   TLS_KEY,
@@ -43,6 +47,9 @@ import {
   PORT_KEY,
   USERNAME_KEY,
   PASSWORD_KEY,
+  TENANT_ID_KEY,
+  CLIENT_ID_KEY,
+  CLIENT_SECRET_KEY,
   FROM_EMAIL_KEY,
   ENCRYPTION_MODE_NONE,
   ENCRYPTION_MODE_TLS,
@@ -98,13 +105,17 @@ const messages = defineMessages({
     id: 'EmailFormFields.authLabel',
     defaultMessage: 'Authorization',
   },
-  authOn: {
-    id: 'EmailFormFields.authOn',
-    defaultMessage: 'On',
+  tenantIdLabel: {
+    id: 'EmailFormFields.tenantIdLabel',
+    defaultMessage: 'Tenant Id',
   },
-  authOff: {
-    id: 'EmailFormFields.authOff',
-    defaultMessage: 'Off',
+  clientIdLabel: {
+    id: 'EmailFormFields.clientIdLabel',
+    defaultMessage: 'Client Id',
+  },
+  clientSecretLabel: {
+    id: 'EmailFormFields.clientSecretLabel',
+    defaultMessage: 'Client Secret',
   },
   usernameLabel: {
     id: 'EmailFormFields.usernameLabel',
@@ -152,42 +163,24 @@ const getEncryptionMode = (tlsEnabled, sslEnabled) => {
   return ENCRYPTION_MODE_NONE;
 };
 
-const AuthRadios = ({ value, onChange, disabled, formatMessage }) => {
-  const opts = [
-    { bool: true, label: formatMessage(messages.authOn) },
-    { bool: false, label: formatMessage(messages.authOff) },
-  ];
-  const current = value === true || value === 'true';
-  return (
-    <div className={cx('radio-row')}>
-      {opts.map(({ bool, label }) => (
-        <Radio
-          key={String(bool)}
-          disabled={disabled}
-          option={{
-            value: bool ? 'true' : 'false',
-            label,
-            disabled: !!disabled,
-          }}
-          value={current ? 'true' : 'false'}
-          onChange={() => onChange(bool ? 'true' : 'false')}
-        />
-      ))}
-    </div>
-  );
-};
-
-AuthRadios.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  onChange: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
-  formatMessage: PropTypes.func.isRequired,
+/*
+ * Integrations persisted before AUTH_MODE_KEY existed only carry the legacy boolean
+ * authEnabled flag: true meant Basic auth (the only mode that existed back then), anything
+ * else meant Off. Mirrors EmailAuthMode#resolve on the backend.
+ */
+const resolveAuthMode = (data) => {
+  if (data[AUTH_MODE_KEY]) {
+    return data[AUTH_MODE_KEY];
+  }
+  return data[AUTH_ENABLED_KEY] === true || data[AUTH_ENABLED_KEY] === 'true'
+    ? AUTH_MODE_BASIC
+    : AUTH_MODE_OFF;
 };
 
 @connect((state) => ({
-  authEnabled: formValueSelector(INTEGRATION_FORM)(state, AUTH_ENABLED_KEY),
   tlsEnabled: formValueSelector(INTEGRATION_FORM)(state, TLS_KEY),
   sslEnabled: formValueSelector(INTEGRATION_FORM)(state, SSL_KEY),
+  authMode: formValueSelector(INTEGRATION_FORM)(state, AUTH_MODE_KEY),
 }))
 @injectIntl
 export class EmailFormFields extends Component {
@@ -196,9 +189,9 @@ export class EmailFormFields extends Component {
     initialize: PropTypes.func.isRequired,
     change: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
-    authEnabled: PropTypes.bool,
     tlsEnabled: PropTypes.bool,
     sslEnabled: PropTypes.bool,
+    authMode: PropTypes.string,
     initialData: PropTypes.object,
     editAuthMode: PropTypes.bool,
     updateMetaData: PropTypes.func,
@@ -206,9 +199,9 @@ export class EmailFormFields extends Component {
 
   static defaultProps = {
     disabled: false,
-    authEnabled: false,
     tlsEnabled: false,
     sslEnabled: false,
+    authMode: AUTH_MODE_OFF,
     initialData: DEFAULT_FORM_CONFIG,
     editAuthMode: false,
     updateMetaData: () => {},
@@ -217,6 +210,11 @@ export class EmailFormFields extends Component {
   constructor(props) {
     super(props);
     this.protocolOptions = [{ value: PROTOCOL_SMTP, label: 'SMTP' }];
+    this.authOptions = [
+      { value: AUTH_MODE_OFF, label: 'Off' },
+      { value: AUTH_MODE_BASIC, label: 'Basic' },
+      { value: AUTH_MODE_OAUTH2, label: 'OAuth 2.0' },
+    ];
   }
 
   componentDidMount() {
@@ -225,6 +223,7 @@ export class EmailFormFields extends Component {
     if (editAuthMode) {
       preparedData[PASSWORD_KEY] = '';
     }
+    preparedData[AUTH_MODE_KEY] = resolveAuthMode(preparedData);
     this.props.initialize(preparedData);
     if (preparedData[TLS_KEY] && preparedData[SSL_KEY]) {
       this.props.change(SSL_KEY, false);
@@ -234,12 +233,17 @@ export class EmailFormFields extends Component {
     });
   }
 
-  onChangeAuthAvailability = (...args) => {
-    const raw = args.length > 1 ? args[1] : args[0];
-    const enabled = raw === true || raw === 'true';
-    if (!enabled) {
+  onChangeAuthMode = (event, value) => {
+    if (value === AUTH_MODE_OFF) {
       this.props.change(USERNAME_KEY, '');
+    }
+    if (value !== AUTH_MODE_BASIC) {
       this.props.change(PASSWORD_KEY, '');
+    }
+    if (value !== AUTH_MODE_OAUTH2) {
+      this.props.change(TENANT_ID_KEY, '');
+      this.props.change(CLIENT_ID_KEY, '');
+      this.props.change(CLIENT_SECRET_KEY, '');
     }
   };
 
@@ -269,9 +273,9 @@ export class EmailFormFields extends Component {
   render() {
     const {
       intl: { formatMessage },
-      authEnabled,
       tlsEnabled,
       sslEnabled,
+      authMode,
       disabled,
     } = this.props;
 
@@ -359,23 +363,48 @@ export class EmailFormFields extends Component {
           </FieldErrorHint>
         </FieldElement>
         <FieldElement
-          name={AUTH_ENABLED_KEY}
+          name={AUTH_MODE_KEY}
           label={formatMessage(messages.authLabel)}
           disabled={disabled}
           className={cx('fields')}
-          format={(v) => (v ? 'true' : 'false')}
-          parse={(v) => v === 'true'}
-          onChange={this.onChangeAuthAvailability}
+          onChange={this.onChangeAuthMode}
         >
           <FieldErrorHint provideHint={false}>
-            <AuthRadios disabled={disabled} formatMessage={formatMessage} />
+            <Dropdown options={this.authOptions} />
           </FieldErrorHint>
         </FieldElement>
-        {authEnabled && (
+        {(authMode === AUTH_MODE_BASIC || authMode === AUTH_MODE_OAUTH2) && (
+          <FieldElement
+            name={USERNAME_KEY}
+            label={formatMessage(messages.usernameLabel)}
+            disabled={disabled}
+            className={cx('fields')}
+            validate={commonValidators.requiredField}
+            isRequired
+          >
+            <FieldErrorHint provideHint={false}>
+              <FieldText defaultWidth={false} />
+            </FieldErrorHint>
+          </FieldElement>
+        )}
+        {authMode === AUTH_MODE_BASIC && (
+          <FieldElement
+            name={PASSWORD_KEY}
+            label={formatMessage(messages.passwordLabel)}
+            disabled={disabled}
+            className={cx('fields')}
+            isRequired
+          >
+            <FieldErrorHint provideHint={false}>
+              <FieldText defaultWidth={false} type="password" />
+            </FieldErrorHint>
+          </FieldElement>
+        )}
+        {authMode === AUTH_MODE_OAUTH2 && (
           <>
             <FieldElement
-              name={USERNAME_KEY}
-              label={formatMessage(messages.usernameLabel)}
+              name={TENANT_ID_KEY}
+              label={formatMessage(messages.tenantIdLabel)}
               disabled={disabled}
               className={cx('fields')}
               validate={commonValidators.requiredField}
@@ -387,8 +416,20 @@ export class EmailFormFields extends Component {
               </FieldErrorHint>
             </FieldElement>
             <FieldElement
-              name={PASSWORD_KEY}
-              label={formatMessage(messages.passwordLabel)}
+              name={CLIENT_ID_KEY}
+              label={formatMessage(messages.clientIdLabel)}
+              disabled={disabled}
+              className={cx('fields')}
+              validate={commonValidators.requiredField}
+              isRequired
+            >
+              <FieldErrorHint provideHint={false}>
+                <FieldText defaultWidth={false} />
+              </FieldErrorHint>
+            </FieldElement>
+            <FieldElement
+              name={CLIENT_SECRET_KEY}
+              label={formatMessage(messages.clientSecretLabel)}
               disabled={disabled}
               className={cx('fields')}
               validate={commonValidators.requiredField}


### PR DESCRIPTION
 Add OAuth2 authorization option to the Email Server integration form

## Summary

Companion to the `service-api` PR adding OAuth2 (client-credentials) authorization support to the Email Server integration. This PR updates the Email Server form to expose it.

## What's new

- The Authorization dropdown goes from two options (On/Off) to three (**Off / Basic / OAuth 2.0**).
- Selecting **Basic** shows the existing Username/Password fields, unchanged.
- Selecting **OAuth 2.0** shows **Tenant Id**, **Client Id**, and **Client Secret** (masked like Password) - plus **Username**, which Basic and OAuth 2.0 now share, since OAuth2 mode also needs a mailbox identity for the SMTP AUTH exchange.
- Selecting **Off** clears all auth-related fields, same as today.
- Existing integrations saved with the old boolean auth flag (no `authMode` key) are read correctly on load - resolved to Basic/Off exactly as before, matching the same fallback logic on the `service-api` side.

## Testing

- Manually verified the full flow against a real backend running the paired `service-api` change: created a new OAuth2-mode integration, submitted, got a live `CONNECTED` status from a real Microsoft 365 tenant.
- Verified switching between Off/Basic/OAuth 2.0 correctly shows/hides and clears the right fields each time.
- Verified an integration saved by unmodified `service-ui`/`service-api` (Basic mode, no `authMode` field) still loads and displays correctly with this change applied.

## Notes for reviewers

- No new dependencies, no changes outside the Email Server integration's own component folder (`components/integrations/integrationProviders/emailIntegration/`).
- Pairs with the [service-api PR](https://github.com/reportportal/service-api/pull/2810) - see that PR for the backend design (field names, validation, why `Username` is required for OAuth2 mode too).
- <img width="493" height="206" alt="image" src="https://github.com/user-attachments/assets/d9762c32-32cc-4d54-9d1c-a61ba11ab506" />
- <img width="1530" height="1270" alt="image" src="https://github.com/user-attachments/assets/c6e71142-988c-41c4-b3e1-cd5b2001505c" />
- <img width="1946" height="821" alt="image" src="https://github.com/user-attachments/assets/4a874a2e-7b30-44c8-87b5-d315b0b3d096" />


