### PR TITLE
EPMRPP-118867 || Apply table left offset only when checkboxes are shown

### DIFF
--- a/app/src/pages/inside/common/testCaseList/testCaseList.scss
+++ b/app/src/pages/inside/common/testCaseList/testCaseList.scss
@@ -27,8 +27,11 @@
 
 .test-case-table {
   margin-bottom: 32px;
-  margin-left: -32px;
-  width: calc(100% + 32px);
+
+  &_selectable {
+    margin-left: -32px;
+    width: calc(100% + 32px);
+  }
 
   > div:first-child > div:first-child {
     padding: 4px 0 4px;

--- a/app/src/pages/inside/common/testCaseList/testCaseList.tsx
+++ b/app/src/pages/inside/common/testCaseList/testCaseList.tsx
@@ -73,6 +73,7 @@ export const TestCaseList = memo(
     const location = useSelector(locationSelector);
     const [selectedTestCaseId, setSelectedTestCaseId] = useState<number | null>(null);
     const { canManageTestCases } = useUserPermissions();
+    const isSelectable = selectable && canManageTestCases;
 
     const searchQuery = location?.query?.testCasesSearchParams || '';
 
@@ -234,7 +235,7 @@ export const TestCaseList = memo(
                   }}
                 />
                 <Table
-                  selectable={selectable && canManageTestCases}
+                  selectable={isSelectable}
                   onToggleRowSelection={handleRowSelect}
                   selectedRowIds={selectedRowIds}
                   data={tableData}
@@ -242,7 +243,9 @@ export const TestCaseList = memo(
                   primaryColumn={primaryColumn}
                   sortableColumns={[]}
                   onToggleAllRowsSelection={handleSelectAll}
-                  className={cx('test-case-table')}
+                  className={cx('test-case-table', {
+                    'test-case-table_selectable': isSelectable,
+                  })}
                   rowClassName={`${cx('test-case-table-row')} test-case-table-row-global`}
                   isSelectAllCheckboxAlwaysVisible
                 />

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.scss
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.scss
@@ -95,8 +95,12 @@ $sidebar-width: calc(100vw - 408px);
 }
 
 .executions-table {
-  margin-left: -32px;
-  width: calc(100% + 32px);
+  width: 100%;
+
+  &_selectable {
+    margin-left: -32px;
+    width: calc(100% + 32px);
+  }
 
   :global([class*='_header-cell_']) {
     font-family: var(--rp-ui-base-font-family);

--- a/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.tsx
+++ b/app/src/pages/inside/manualLaunchesPage/manualLaunchDetailsPage/manualLaunchExecutions/manualLaunchExecutions.tsx
@@ -359,7 +359,9 @@ export const ManualLaunchExecutions = ({
               fixedColumns={fixedColumns}
               primaryColumn={primaryColumn}
               sortableColumns={[]}
-              className={cx('executions-table')}
+              className={cx('executions-table', {
+                'executions-table_selectable': canManageTestCases,
+              })}
               headerClassName={cx('executions-table-header')}
               bodyClassName={cx('executions-table-body')}
               rowClassName={cx('execution-chip')}


### PR DESCRIPTION
Fixes EPMRPP-118867: for users without edit permissions, test cases in Test Case Library and Manual Launches had no left padding after the folder tree. Expected: left padding equals right padding (32px).

## Problem

Tables always used `margin-left: -32px` / `width: calc(100% + 32px)` to compensate for the checkbox column. Viewers do not see checkboxes, so the negative margin pulled content flush to the folder panel while the right side kept 32px.

## Solution

- Apply the left bleed only when the table is selectable (`canManageTestCases`): `test-case-table_selectable` and `executions-table_selectable`.
- Keep the previous layout for Editors/Admins; Viewers get symmetric 32px padding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table layouts for test case lists and manual launch executions.
  * Selectable table styling is now applied only when the user has permission to manage test cases.
  * Non-selectable tables now maintain consistent full-width layouts without unintended spacing or sizing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->