### PR TITLE
EPMRPP-118886 || Restore launch name in Test Case Search group header

### DIFF
--- a/app/src/pages/inside/stepPage/stepGrid/groupHeader/groupHeader.jsx
+++ b/app/src/pages/inside/stepPage/stepGrid/groupHeader/groupHeader.jsx
@@ -25,7 +25,7 @@ import {
   filterIdSelector,
   urlOrganizationAndProjectSelector,
 } from 'controllers/pages';
-import { isTestItemsListSelector } from 'controllers/testItem';
+import { isTestItemsListSelector, isSearchWidgetItemsExistSelector } from 'controllers/testItem';
 import styles from './groupHeader.scss';
 
 const cx = classNames.bind(styles);
@@ -40,12 +40,15 @@ const createLink = (projectSlug, filterId, launchId, testItemIds, organizationSl
   },
 });
 
-export const GroupHeader = connect((state) => ({
+export const mapStateToProps = (state) => ({
   launchId: launchIdSelector(state),
   filterId: filterIdSelector(state),
   isTestItemsList: isTestItemsListSelector(state),
+  isSearchedItems: isSearchWidgetItemsExistSelector(state),
   slugs: urlOrganizationAndProjectSelector(state),
-}))(({
+});
+
+export const GroupHeader = connect(mapStateToProps)(({
   data,
   launchId,
   filterId,

--- a/app/src/pages/inside/stepPage/stepGrid/groupHeader/groupHeader.test.js
+++ b/app/src/pages/inside/stepPage/stepGrid/groupHeader/groupHeader.test.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mapStateToProps } from './groupHeader';
+
+const createState = ({ searchedItems = {}, testItemIds } = {}) => ({
+  location: {
+    payload: {
+      filterId: 'all',
+      organizationSlug: 'org',
+      projectSlug: 'proj',
+      testItemIds,
+    },
+  },
+  testItem: {
+    searchedItems,
+  },
+  user: {
+    activeProject: {},
+  },
+});
+
+describe('GroupHeader mapStateToProps', () => {
+  test('sets isSearchedItems when Test Case Search widget has results', () => {
+    const state = createState({
+      searchedItems: {
+        'widget-1': { content: [{ id: 1 }] },
+      },
+    });
+
+    expect(mapStateToProps(state).isSearchedItems).toBe(true);
+  });
+
+  test('sets isSearchedItems to false when search widget has no results', () => {
+    expect(mapStateToProps(createState()).isSearchedItems).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes EPMRPP-118886: in the Test Case Search widget, with **Display Launches** turned on, the group path showed only suite and test names. Expected: launch, suite, and test (`LaunchName #N / Suite / Test`).

## Problem

`GroupHeader` prepends the launch name when `isTestItemsList || isSearchedItems`. After the develop → organizations merge ([#4326](https://github.com/reportportal/service-ui/pull/4326)), `isSearchedItems` stayed in the component but was no longer mapped from Redux (`isSearchWidgetItemsExistSelector`), so it was always `undefined` on the dashboard. The launch segment from `pathNames.launchPathName` was never added.

## Solution

- Map `isSearchedItems` from `isSearchWidgetItemsExistSelector` again in `GroupHeader` `mapStateToProps` (same approach as [EPMRPP-101005](https://github.com/reportportal/service-ui/pull/4279)).
- Export `mapStateToProps` and cover it with unit tests.

## Visuals

<img width="1915" height="961" alt="image" src="https://github.com/user-attachments/assets/b361b0e3-663e-417b-a380-aef219e6649d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group headers now correctly reflect whether Test Case Search has matching results.

* **Tests**
  * Added coverage verifying group header behavior when search results are present or absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->