### PR TITLE
EPMRPP-118951 || The page is empty and blocked after clicking on .har attachment

### DIFF
--- a/app/src/controllers/log/attachments/sagas.js
+++ b/app/src/controllers/log/attachments/sagas.js
@@ -123,10 +123,10 @@ function* openImageModalsWorker(data) {
 /* BINARY */
 function* openBinaryModalWorker(data) {
   const binaryData = yield call(fetchFileData, data);
-  const content =
-    data.extension === JSON_TYPE && !isTextWithJson(data.contentType)
-      ? JSON.stringify(binaryData, null, 4)
-      : binaryData;
+  const shouldStringify =
+    typeof binaryData !== 'string' ||
+    (data.extension === JSON_TYPE && !isTextWithJson(data.contentType));
+  const content = shouldStringify ? JSON.stringify(binaryData, null, 4) : binaryData;
   yield put(
     showModalAction({
       id: ATTACHMENT_CODE_MODAL_ID,

--- a/app/src/pages/inside/logsPage/modals/attachments/attachmentCodeModal.jsx
+++ b/app/src/pages/inside/logsPage/modals/attachments/attachmentCodeModal.jsx
@@ -83,7 +83,8 @@ export class AttachmentCodeModal extends Component {
       intl,
       data: { extension, content, fileName },
     } = this.props;
-    const safeContent = typeof content === 'string' ? content : JSON.stringify(content, null, 4);
+    const safeContent =
+      typeof content === 'string' ? content : (JSON.stringify(content, null, 4) ?? '');
     const cancelButton = {
       text: intl.formatMessage(COMMON_LOCALE_KEYS.CLOSE),
     };

--- a/app/src/pages/inside/logsPage/modals/attachments/attachmentCodeModal.jsx
+++ b/app/src/pages/inside/logsPage/modals/attachments/attachmentCodeModal.jsx
@@ -33,6 +33,17 @@ import {
 import { ActionsItem } from '../../attachmentActions/actionsItem';
 import { messages } from './messages';
 
+// highlight.js tokenizes synchronously, so large files are rendered without highlighting
+const MAX_HIGHLIGHTED_LENGTH = 100000;
+const CONTENT_STYLE = {
+  ...DEFAULT_HIGHLIGHT_STYLE,
+  margin: 0,
+  overflow: 'auto',
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+};
+const CODE_TAG_PROPS = { style: { whiteSpace: 'inherit', overflowWrap: 'inherit' } };
+
 @withModal(ATTACHMENT_CODE_MODAL_ID)
 @connect(null, { openAttachmentInBrowserAction })
 @injectIntl
@@ -72,6 +83,7 @@ export class AttachmentCodeModal extends Component {
       intl,
       data: { extension, content, fileName },
     } = this.props;
+    const safeContent = typeof content === 'string' ? content : JSON.stringify(content, null, 4);
     const cancelButton = {
       text: intl.formatMessage(COMMON_LOCALE_KEYS.CLOSE),
     };
@@ -84,13 +96,18 @@ export class AttachmentCodeModal extends Component {
         renderFooterElements={this.renderCustomButton}
       >
         <form>
-          <SyntaxHighlighter
-            language={extension}
-            style={atomOneLight}
-            customStyle={DEFAULT_HIGHLIGHT_STYLE}
-          >
-            {content}
-          </SyntaxHighlighter>
+          {safeContent.length > MAX_HIGHLIGHTED_LENGTH ? (
+            <pre style={CONTENT_STYLE}>{safeContent}</pre>
+          ) : (
+            <SyntaxHighlighter
+              language={extension}
+              style={atomOneLight}
+              customStyle={CONTENT_STYLE}
+              codeTagProps={CODE_TAG_PROPS}
+            >
+              {safeContent}
+            </SyntaxHighlighter>
+          )}
         </form>
       </ModalLayout>
     );

--- a/app/src/pages/inside/logsPage/modals/attachments/attachmentCodeModal.jsx
+++ b/app/src/pages/inside/logsPage/modals/attachments/attachmentCodeModal.jsx
@@ -52,8 +52,8 @@ export class AttachmentCodeModal extends Component {
   static propTypes = {
     data: PropTypes.shape({
       extension: PropTypes.string.isRequired,
-      content: PropTypes.string.isRequired,
-      id: PropTypes.number.isRequired,
+      content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
       fileName: PropTypes.string,
     }).isRequired,
     intl: PropTypes.object.isRequired,

--- a/app/src/pages/inside/logsPage/modals/attachments/har/PerfCascade.jsx
+++ b/app/src/pages/inside/logsPage/modals/attachments/har/PerfCascade.jsx
@@ -21,6 +21,23 @@ import 'perf-cascade/dist/perf-cascade.css';
 import { NoItemMessage } from 'components/main/noItemMessage';
 import DOMPurify from 'dompurify';
 
+// perf-cascade injects HAR string values into the DOM via innerHTML, including lazily on row click,
+// so the data has to be sanitized before it reaches the renderer
+const sanitizeHarData = (value) => {
+  if (typeof value === 'string') {
+    return DOMPurify.sanitize(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeHarData);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, sanitizeHarData(item)]),
+    );
+  }
+  return value;
+};
+
 export class PerfCascade extends Component {
   static propTypes = {
     harData: PropTypes.object.isRequired,
@@ -38,7 +55,7 @@ export class PerfCascade extends Component {
   componentDidMount() {
     let perfCascadeSvg;
     try {
-      perfCascadeSvg = fromHar(DOMPurify.sanitize(this.props.harData));
+      perfCascadeSvg = fromHar(sanitizeHarData(this.props.harData));
       this.myRef.current.appendChild(perfCascadeSvg);
     } catch (e) {
       this.showErrorMessage();


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Issue 1. App crash on a `.har` file reported as `text/plain`.**  
Such a file routes to the code modal, but the backend response was parsed as JSON, so `content` was an object. `react-syntax-highlighter` threw `Expected string for value, got [object Object]` during render, taking down the whole app. Now `openBinaryModalWorker` stringifies any non-string response, and `AttachmentCodeModal` keeps a defensive fallback for the same case.

**1.1. Rendering of large files.**  
Content above `MAX_HIGHLIGHTED_LENGTH` (100 000 characters, ~100 KB) is rendered in a plain `<pre>` instead of running _highlight.js_, which tokenizes synchronously and made multi-megabyte HAR files take seconds to open.  
The limit is a pragmatic round number: below it highlighting is imperceptible, above it attachments are usually machine-generated traces where highlighting adds little. 
Both branches also wrap long lines (`pre-wrap` plus `overflowWrap: 'anywhere'`, with `codeTagProps` so the inner `<code>` inherits it), fixing text overflowing the modal on long URLs.

**Issue 2. HAR viewer was completely broken.**  
In `PerfCascade.jsx`, the parsed HAR **object** was passed to `DOMPurify.sanitize()`, which only accepts a string or a DOM node. DOMPurify coerced the object to the string `"[object Object]"`, so `fromHar()` always threw and the `catch` block showed the generic "Bad file structure" message — which looked like a problem with the user's file rather than a bug.

This regression came from the vulnerability fix [EPMRPP-67803](https://jiraeu.epam.com/browse/EPMRPP-67803), which changed `fromHar(this.props.harData)` into `fromHar(DOMPurify.sanitize(this.props.harData))`. 

**Fix:** sanitize the HAR data recursively — every string value inside the object goes through DOMPurify while the object structure is preserved. This was chosen over sanitizing the rendered SVG because `perf-cascade` injects request details via `innerHTML` lazily on row click, after `componentDidMount`, and because DOMPurify strips `foreignObject` by default, which `perf-cascade` relies on for labels and overlays.

## Visuals
### Issue 1
**Before:** 

https://github.com/user-attachments/assets/22190580-ce96-42fb-a5ef-082efa24000a

**After:**

https://github.com/user-attachments/assets/89deba0c-6557-4f02-b4de-bade273bc3e8


### Issue 2
**Before:** 

https://github.com/user-attachments/assets/d08bb9ce-01d9-4480-a541-dba4bdee9580

**After:** 

https://github.com/user-attachments/assets/c300dcd5-bda3-4b52-8fdf-c0104a50cd2e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Attachment content is now consistently converted and formatted for easier reading, including structured data nested within attachments.
  - Very large attachments display as plain text for improved responsiveness, while smaller files retain syntax highlighting.
  - HAR data is sanitized throughout nested arrays and objects before being displayed.
  - Attachment identifiers and content formats are handled more flexibly when rendering attachment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->