### PR TITLE
EPMRPP-117763 || Multiple 'You have been logged out' toasters when the user is logged out from another tab

### DIFF
--- a/app/src/controllers/auth/sagas.js
+++ b/app/src/controllers/auth/sagas.js
@@ -96,6 +96,11 @@ function* logoutOnServer(redirectedPage) {
 
 // TODO: clear cookie on logout
 function* handleLogout({ payload }) {
+  const token = yield select(tokenSelector);
+  if (!token) {
+    return;
+  }
+
   yield call(logoutOnServer, payload);
   yield put(resetTokenAction());
   yield put(fetchPublicPluginsAction());
@@ -115,7 +120,10 @@ function* handleLogout({ payload }) {
 }
 
 function* watchLogout() {
-  yield takeEvery(LOGOUT, handleLogout);
+  while (true) {
+    const action = yield take(LOGOUT);
+    yield call(handleLogout, action);
+  }
 }
 
 function* loginSuccessHandler({ payload }) {


### PR DESCRIPTION
## PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, other if mentioned in the task)
* [x] Have you verified that your branch is consistent with the target branch and has no conflicts? (if not, make a rebase under the target branch)
* [x] Have you checked that everything works within the branch according to the task description and tested it locally?
* [x] Have you run the linter (`npm run lint`) prior to submission? Enable the git hook on commit in your IDE to run it and format the code automatically.
* [x] Have you run the tests locally and added/updated them if needed?
* [x] Have you checked that app can be built (`npm run build`)?
* [x] Have you checked that no new circular dependencies appreared with your changes? (the webpack plugin reports circular dependencies within the `dev` npm script)
* [x] Have you made sure that all the necessary pipelines has been successfully completed?
* [x] If the task requires translations to be updated, have you done this by running the `manage:translations` script?
* [x] Have you added the link to the PR in the Jira ticket comments?
* [x] Have you checked and implemented role-based permissions? (if the feature requires different behavior or visibility for different user roles)

## Changes
**Root cause.**  
When the user logs out in one tab, `handleLogout` removes `ACTIVITY_TIMESTAMP` from local storage. 
In the other tab the session-activity listeners in `layouts/common/layout/layout.jsx` are still attached, and they read that key on every `mousemove`, `keydown`, `scroll`, `click` and `resize`. With the key gone `logoutAction` is dispatched on every single event — dozens of times per mouse movement. Since `watchLogout` used `takeEvery`, each of those actions forked its own `handleLogout` instance, and every instance reached `showNotification`.

**Fix.** 
- `handleLogout` now reads the token first and returns immediately if it is already cleared.
- `watchLogout` replaced `takeEvery` with a blocking `take` + `call` loop (the manual equivalent of [takeLeading](https://redux-saga.js.org/docs/api/#takeleadingpattern-saga-args), which does not exist in redux-saga 0.16). While a logout is in flight incoming `LOGOUT` actions are simply not consumed, so no concurrent handlers can start.

## Links
[EPMRPP-117763](https://jiraeu.epam.com/browse/EPMRPP-117763)


## Visuals
**_Before:_**

https://github.com/user-attachments/assets/72876ad2-9128-4339-aedf-1a4258d23d58


**_After:_**

https://github.com/user-attachments/assets/a99f9fb0-c71d-42cd-a788-6c3b338194c7


https://github.com/user-attachments/assets/dfd164b0-c96e-4a55-b82d-073dc721b28a





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Logout now exits immediately when no authentication token is present.
  - Prevents unnecessary logout processing and redirects for unauthenticated users.
  - Logout requests are handled sequentially for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->