### PR TITLE
EPMRPP-73997 || Fix EasyMDE code block toggle and clipboard link insertion

### DIFF
--- a/app/src/components/main/markdown/markdownEditor/markdownEditor.jsx
+++ b/app/src/components/main/markdown/markdownEditor/markdownEditor.jsx
@@ -24,6 +24,7 @@ import classNames from 'classnames/bind';
 import 'easymde/dist/easymde.min.css';
 import { MarkdownViewer } from '../markdownViewer/markdownViewer';
 import { MODE_DEFAULT, MODE_DARK } from '../constants';
+import { drawMarkdownLink, handleMarkdownUrlPaste } from './markdownLinkUtils';
 import styles from './markdownEditor.scss';
 
 const cx = classNames.bind(styles);
@@ -221,7 +222,7 @@ export class MarkdownEditor extends React.Component {
       },
       {
         name: 'link',
-        action: EasyMDE.drawLink,
+        action: drawMarkdownLink,
         className: 'icon-link',
         title: formatMessage(toolbarTitles.link),
       },
@@ -269,16 +270,25 @@ export class MarkdownEditor extends React.Component {
       blockStyles: {
         bold: '**',
         italic: '*',
-        code: '`',
+        code: '```',
+      },
+      shortcuts: {
+        drawLink: null,
       },
       previewRender: (plainText) =>
         ReactDOMServer.renderToStaticMarkup(<MarkdownViewer value={plainText} mode={mode} />),
     });
+    this.easyMDE.codemirror.addKeyMap({
+      'Cmd-K': () => drawMarkdownLink(this.easyMDE),
+      'Ctrl-K': () => drawMarkdownLink(this.easyMDE),
+    });
     this.easyMDE.codemirror.on('change', this.onChangeHandler);
+    this.easyMDE.codemirror.on('paste', handleMarkdownUrlPaste);
     manipulateEditorOutside(this.easyMDE.codemirror);
   }
   componentWillUnmount() {
     this.easyMDE.codemirror.off('change', this.onChangeHandler);
+    this.easyMDE.codemirror.off('paste', handleMarkdownUrlPaste);
   }
   onChangeHandler = () => {
     this.props.onChange(this.easyMDE.value());

--- a/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.js
+++ b/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const DEFAULT_LINK_URL = 'http://';
+
+export const isMarkdownLinkUrl = (text = '') => {
+  const trimmed = text.trim();
+  if (!trimmed || /\s/.test(trimmed)) {
+    return false;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return /^(https?:\/\/|www\.)/i.test(trimmed);
+  }
+};
+
+const insertMarkdownLink = (cm, selectedText, from, url) => {
+  const linkText = selectedText || 'link';
+  const prefix = `[${linkText}](`;
+  const insertion = `${prefix}${url})`;
+
+  cm.replaceSelection(insertion);
+
+  if (!selectedText.includes('\n')) {
+    const urlStart = from.ch + prefix.length;
+    cm.setSelection(
+      { line: from.line, ch: urlStart },
+      { line: from.line, ch: urlStart + url.length },
+    );
+  }
+
+  cm.focus();
+};
+
+export const drawMarkdownLink = (editor) => {
+  const cm = editor.codemirror;
+  if (!cm || editor.isPreviewActive()) {
+    return;
+  }
+
+  const selectedText = cm.getSelection();
+  const from = cm.getCursor('start');
+  const to = cm.getCursor('end');
+
+  const applyLink = (url) => {
+    cm.setSelection(from, to);
+    insertMarkdownLink(cm, selectedText, from, url || DEFAULT_LINK_URL);
+  };
+
+  if (!navigator.clipboard?.readText) {
+    applyLink(DEFAULT_LINK_URL);
+    return;
+  }
+
+  navigator.clipboard
+    .readText()
+    .then((text) => {
+      const trimmed = text.trim();
+      applyLink(isMarkdownLinkUrl(trimmed) ? trimmed : DEFAULT_LINK_URL);
+    })
+    .catch(() => {
+      applyLink(DEFAULT_LINK_URL);
+    });
+};
+
+export const handleMarkdownUrlPaste = (cm, event) => {
+  const selection = cm.getSelection();
+  const pastedText = event.clipboardData?.getData('text/plain')?.trim();
+
+  if (!selection || !isMarkdownLinkUrl(pastedText)) {
+    return;
+  }
+
+  event.preventDefault();
+  cm.replaceSelection(`[${selection}](${pastedText})`);
+};

--- a/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.js
+++ b/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.js
@@ -16,19 +16,29 @@
 
 const DEFAULT_LINK_URL = 'http://';
 
-export const isMarkdownLinkUrl = (text = '') => {
+export const normalizeMarkdownLinkUrl = (text = '') => {
   const trimmed = text.trim();
   if (!trimmed || /\s/.test(trimmed)) {
-    return false;
+    return null;
   }
 
+  const candidate = /^www\./i.test(trimmed) ? `http://${trimmed}` : trimmed;
+
   try {
-    const url = new URL(trimmed);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    if (!url.hostname || url.hostname === 'www.') {
+      return null;
+    }
+    return candidate;
   } catch {
-    return /^(https?:\/\/|www\.)/i.test(trimmed);
+    return null;
   }
 };
+
+export const isMarkdownLinkUrl = (text) => Boolean(normalizeMarkdownLinkUrl(text));
 
 const insertMarkdownLink = (cm, selectedText, from, url) => {
   const linkText = selectedText || 'link';
@@ -56,37 +66,47 @@ export const drawMarkdownLink = (editor) => {
 
   const selectedText = cm.getSelection();
   const from = cm.getCursor('start');
-  const to = cm.getCursor('end');
 
-  const applyLink = (url) => {
-    cm.setSelection(from, to);
-    insertMarkdownLink(cm, selectedText, from, url || DEFAULT_LINK_URL);
-  };
+  insertMarkdownLink(cm, selectedText, from, DEFAULT_LINK_URL);
 
-  if (!navigator.clipboard?.readText) {
-    applyLink(DEFAULT_LINK_URL);
+  if (!navigator.clipboard?.readText || selectedText.includes('\n')) {
     return;
   }
+
+  const urlFrom = cm.getCursor('start');
+  const urlTo = cm.getCursor('end');
+  const generation = cm.changeGeneration(true);
 
   navigator.clipboard
     .readText()
     .then((text) => {
-      const trimmed = text.trim();
-      applyLink(isMarkdownLinkUrl(trimmed) ? trimmed : DEFAULT_LINK_URL);
+      if (!cm.isClean(generation)) {
+        return;
+      }
+
+      const normalized = normalizeMarkdownLinkUrl(text);
+      if (!normalized) {
+        return;
+      }
+
+      cm.replaceRange(normalized, urlFrom, urlTo);
+      cm.setSelection(urlFrom, {
+        line: urlFrom.line,
+        ch: urlFrom.ch + normalized.length,
+      });
+      cm.focus();
     })
-    .catch(() => {
-      applyLink(DEFAULT_LINK_URL);
-    });
+    .catch(() => {});
 };
 
 export const handleMarkdownUrlPaste = (cm, event) => {
   const selection = cm.getSelection();
-  const pastedText = event.clipboardData?.getData('text/plain')?.trim();
+  const normalized = normalizeMarkdownLinkUrl(event.clipboardData?.getData('text/plain'));
 
-  if (!selection || !isMarkdownLinkUrl(pastedText)) {
+  if (!selection || !normalized) {
     return;
   }
 
   event.preventDefault();
-  cm.replaceSelection(`[${selection}](${pastedText})`);
+  cm.replaceSelection(`[${selection}](${normalized})`);
 };

--- a/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.test.js
+++ b/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.test.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  drawMarkdownLink,
+  handleMarkdownUrlPaste,
+  isMarkdownLinkUrl,
+} from './markdownLinkUtils';
+
+describe('markdownLinkUtils', () => {
+  describe('isMarkdownLinkUrl', () => {
+    test('accepts http and https urls', () => {
+      expect(isMarkdownLinkUrl('https://reportportal.io')).toBe(true);
+      expect(isMarkdownLinkUrl('http://example.com/path')).toBe(true);
+      expect(isMarkdownLinkUrl('www.example.com')).toBe(true);
+    });
+
+    test('rejects non-url text', () => {
+      expect(isMarkdownLinkUrl('not a url')).toBe(false);
+      expect(isMarkdownLinkUrl('')).toBe(false);
+      expect(isMarkdownLinkUrl('ftp://example.com')).toBe(false);
+    });
+  });
+
+  describe('handleMarkdownUrlPaste', () => {
+    test('wraps selection with pasted url', () => {
+      const replaceSelection = jest.fn();
+      const preventDefault = jest.fn();
+      const cm = {
+        getSelection: () => 'docs',
+        replaceSelection,
+      };
+      const event = {
+        preventDefault,
+        clipboardData: {
+          getData: () => 'https://reportportal.io',
+        },
+      };
+
+      handleMarkdownUrlPaste(cm, event);
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(replaceSelection).toHaveBeenCalledWith('[docs](https://reportportal.io)');
+    });
+
+    test('does not handle paste without selection', () => {
+      const replaceSelection = jest.fn();
+      const preventDefault = jest.fn();
+      const cm = {
+        getSelection: () => '',
+        replaceSelection,
+      };
+      const event = {
+        preventDefault,
+        clipboardData: {
+          getData: () => 'https://reportportal.io',
+        },
+      };
+
+      handleMarkdownUrlPaste(cm, event);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(replaceSelection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drawMarkdownLink', () => {
+    test('inserts link and selects url placeholder', () => {
+      const replaceSelection = jest.fn();
+      const setSelection = jest.fn();
+      const focus = jest.fn();
+      const cm = {
+        getSelection: () => 'docs',
+        getCursor: (type) => (type === 'start' ? { line: 0, ch: 0 } : { line: 0, ch: 4 }),
+        setSelection,
+        replaceSelection,
+        focus,
+      };
+      const editor = {
+        codemirror: cm,
+        isPreviewActive: () => false,
+      };
+
+      const originalClipboard = navigator.clipboard;
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: undefined,
+      });
+
+      drawMarkdownLink(editor);
+
+      expect(replaceSelection).toHaveBeenCalledWith('[docs](http://)');
+      expect(setSelection).toHaveBeenCalledWith({ line: 0, ch: 7 }, { line: 0, ch: 14 });
+      expect(focus).toHaveBeenCalled();
+
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    });
+  });
+});

--- a/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.test.js
+++ b/app/src/components/main/markdown/markdownEditor/markdownLinkUtils.test.js
@@ -18,9 +18,26 @@ import {
   drawMarkdownLink,
   handleMarkdownUrlPaste,
   isMarkdownLinkUrl,
+  normalizeMarkdownLinkUrl,
 } from './markdownLinkUtils';
 
 describe('markdownLinkUtils', () => {
+  describe('normalizeMarkdownLinkUrl', () => {
+    test('normalizes valid http(s) and www urls', () => {
+      expect(normalizeMarkdownLinkUrl('https://reportportal.io')).toBe('https://reportportal.io');
+      expect(normalizeMarkdownLinkUrl('http://example.com/path')).toBe('http://example.com/path');
+      expect(normalizeMarkdownLinkUrl('www.example.com')).toBe('http://www.example.com');
+    });
+
+    test('rejects incomplete and invalid values', () => {
+      expect(normalizeMarkdownLinkUrl('https://')).toBeNull();
+      expect(normalizeMarkdownLinkUrl('www.')).toBeNull();
+      expect(normalizeMarkdownLinkUrl('not a url')).toBeNull();
+      expect(normalizeMarkdownLinkUrl('')).toBeNull();
+      expect(normalizeMarkdownLinkUrl('ftp://example.com')).toBeNull();
+    });
+  });
+
   describe('isMarkdownLinkUrl', () => {
     test('accepts http and https urls', () => {
       expect(isMarkdownLinkUrl('https://reportportal.io')).toBe(true);
@@ -32,6 +49,8 @@ describe('markdownLinkUtils', () => {
       expect(isMarkdownLinkUrl('not a url')).toBe(false);
       expect(isMarkdownLinkUrl('')).toBe(false);
       expect(isMarkdownLinkUrl('ftp://example.com')).toBe(false);
+      expect(isMarkdownLinkUrl('https://')).toBe(false);
+      expect(isMarkdownLinkUrl('www.')).toBe(false);
     });
   });
 
@@ -54,6 +73,45 @@ describe('markdownLinkUtils', () => {
 
       expect(preventDefault).toHaveBeenCalled();
       expect(replaceSelection).toHaveBeenCalledWith('[docs](https://reportportal.io)');
+    });
+
+    test('prefixes www urls on paste', () => {
+      const replaceSelection = jest.fn();
+      const preventDefault = jest.fn();
+      const cm = {
+        getSelection: () => 'docs',
+        replaceSelection,
+      };
+      const event = {
+        preventDefault,
+        clipboardData: {
+          getData: () => 'www.example.com',
+        },
+      };
+
+      handleMarkdownUrlPaste(cm, event);
+
+      expect(replaceSelection).toHaveBeenCalledWith('[docs](http://www.example.com)');
+    });
+
+    test('does not handle incomplete urls', () => {
+      const replaceSelection = jest.fn();
+      const preventDefault = jest.fn();
+      const cm = {
+        getSelection: () => 'docs',
+        replaceSelection,
+      };
+      const event = {
+        preventDefault,
+        clipboardData: {
+          getData: () => 'https://',
+        },
+      };
+
+      handleMarkdownUrlPaste(cm, event);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(replaceSelection).not.toHaveBeenCalled();
     });
 
     test('does not handle paste without selection', () => {
@@ -110,6 +168,87 @@ describe('markdownLinkUtils', () => {
         configurable: true,
         value: originalClipboard,
       });
+    });
+
+    test('replaces placeholder with clipboard url when document is unchanged', async () => {
+      const replaceSelection = jest.fn();
+      const replaceRange = jest.fn();
+      const setSelection = jest.fn();
+      const focus = jest.fn();
+      let cursorStart = { line: 0, ch: 0 };
+      let cursorEnd = { line: 0, ch: 4 };
+      const cm = {
+        getSelection: () => 'docs',
+        getCursor: (type) => (type === 'start' ? cursorStart : cursorEnd),
+        setSelection: (from, to) => {
+          setSelection(from, to);
+          cursorStart = from;
+          cursorEnd = to;
+        },
+        replaceSelection,
+        replaceRange,
+        changeGeneration: () => 1,
+        isClean: () => true,
+        focus,
+      };
+      const editor = {
+        codemirror: cm,
+        isPreviewActive: () => false,
+      };
+
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          readText: () => Promise.resolve('www.example.com'),
+        },
+      });
+
+      drawMarkdownLink(editor);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(replaceSelection).toHaveBeenCalledWith('[docs](http://)');
+      expect(replaceRange).toHaveBeenCalledWith(
+        'http://www.example.com',
+        { line: 0, ch: 7 },
+        { line: 0, ch: 14 },
+      );
+    });
+
+    test('skips clipboard url when document changed after placeholder insert', async () => {
+      const replaceRange = jest.fn();
+      let cursorStart = { line: 0, ch: 0 };
+      let cursorEnd = { line: 0, ch: 4 };
+      const cm = {
+        getSelection: () => 'docs',
+        getCursor: (type) => (type === 'start' ? cursorStart : cursorEnd),
+        setSelection: (from, to) => {
+          cursorStart = from;
+          cursorEnd = to;
+        },
+        replaceSelection: jest.fn(),
+        replaceRange,
+        changeGeneration: () => 1,
+        isClean: () => false,
+        focus: jest.fn(),
+      };
+      const editor = {
+        codemirror: cm,
+        isPreviewActive: () => false,
+      };
+
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          readText: () => Promise.resolve('https://reportportal.io'),
+        },
+      });
+
+      drawMarkdownLink(editor);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(replaceRange).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/src/components/main/markdown/singletonMarkdownObject.js
+++ b/app/src/components/main/markdown/singletonMarkdownObject.js
@@ -28,7 +28,7 @@ const getInstance = () => {
       blockStyles: {
         bold: '**',
         italic: '*',
-        code: '`',
+        code: '```',
       },
     });
   }


### PR DESCRIPTION
## Summary

Follow-up to EPMRPP-73997 / EasyMDE migration: fixes QA findings for the markdown editor code toggle and clipboard-based link insertion.

### Changes
- Set `blockStyles.code` to fenced markers (` ``` `) so code mode can be toggled off correctly (single backtick broke reverse toggle in EasyMDE)
- Custom link action: if clipboard holds an http(s)/www URL, insert it into `[text](url)`; otherwise fall back to `http://`
- Paste URL over a text selection wraps the selection as a markdown link
- Align Ctrl/Cmd+K with the custom link action (disable default EasyMDE `drawLink` shortcut)
- Shared helpers in `markdownLinkUtils` with unit coverage

## Benefits
- Code toolbar action works as a true on/off toggle for fenced blocks
- Link creation matches expected clipboard and paste-over-selection behavior after the SimpleMDE → EasyMDE move


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved Markdown link insertion with custom keyboard shortcuts.
  * Pasting a valid HTTP(S) or `www.` URL over selected text now formats it as a Markdown link.
  * Link insertion can use selected text or clipboard content and highlights the URL placeholder for editing.
  * Code blocks now use standard triple-backtick Markdown formatting.

* **Bug Fixes**
  * Improved handling of link creation and URL pasting in the Markdown editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->